### PR TITLE
cond.signal() those in lock().cond.wait()

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -123,7 +123,9 @@ pub struct PooledPostgresConnection {
 impl Drop for PooledPostgresConnection {
     fn drop(&mut self) {
         let conn = unsafe { cast::transmute(self.conn.take_unwrap()) };
-        self.pool.pool.lock().pool.push(conn);
+        let mut pool = self.pool.pool.lock();
+        pool.pool.push(conn);
+        pool.cond.signal();
     }
 }
 


### PR DESCRIPTION
This attempts to fix #32 but, for me at least, it just leads to

```
RefCell<T> already borrowed
```

errors.  I don't know if these are separate issues or related.
