### PR TITLE
Show trait for SQLSTATEs:

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,7 @@ use types::PostgresType;
 macro_rules! make_errors(
     ($($code:expr => $error:ident),+) => (
         /// SQLSTATE error codes
-        #[deriving(PartialEq, Eq, Clone)]
+        #[deriving(PartialEq, Eq, Clone, Show)]
         #[allow(missing_doc)]
         pub enum PostgresSqlState {
             $($error,)+


### PR DESCRIPTION
 Useful for, if nothing else, debugging to determine which
 SQLSTATE occurred w/o comparing against a hundred or so possible
 states, nor loosely interpreting the message.
