### PR TITLE
Remove locked revisions from the Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,9 @@ path = "tests/test.rs"
 
 [dependencies.openssl]
 git = "https://github.com/sfackler/rust-openssl"
-rev = "cd40d25cb5721064c5c2002c41a616d2dba7399a"
 
 [dependencies.phf]
 git = "https://github.com/sfackler/rust-phf"
-rev = "af0a11c92bd531c9677bef31f6a6d8c4b59ad29b"
 
 [dependencies.phf_mac]
 git = "https://github.com/sfackler/rust-phf"
-rev = "af0a11c92bd531c9677bef31f6a6d8c4b59ad29b"


### PR DESCRIPTION
Locked revisions inside of a manifest generally indicate that a library is only
compatible with exactly one revision of the dependent library. In general these
locked revisions belong in a Cargo.lock instead of a Cargo.toml.

By including a locked revision, the dependency graph is forked such that
postgres will have its own copy of all of its dependencies, while all other
users of, for example, rust-openssl will get a different copy (the sources are
different).

This package is in general compatible with the current master branch of its
dependencies, and applications will have locked versions of all these
dependencies regardless.
