### PR TITLE
Fix the build

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -76,7 +76,7 @@ fn open_socket(params: &ConnectParams)
     let port = params.port.unwrap_or(DEFAULT_PORT);
     let socket = match params.target {
         ConnectTarget::Tcp(ref host) =>
-            tcp::TcpStream::connect(host[], port).map(TcpStream),
+            tcp::TcpStream::connect((host[], port)).map(TcpStream),
         ConnectTarget::Unix(ref path) => {
             let mut path = path.clone();
             path.push(format!(".s.PGSQL.{}", port));


### PR DESCRIPTION
```
src/io.rs:79:13: 79:50 error: this function takes 1 parameter but 2 parameters were supplied [E0061]
src/io.rs:79             tcp::TcpStream::connect(host[], port).map(TcpStream),
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This is now fixed.
