### PR TITLE
Depend on rust-lang/time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ git = "https://github.com/sfackler/rust-phf"
 git = "https://github.com/rust-lang/uuid"
 optional = true
 
+[dependencies.time]
+git = "https://github.com/rust-lang/time"
+
 [dev-dependencies.url]
 git = "https://github.com/servo/rust-url"
 


### PR DESCRIPTION
The disributed libtime has since been deprecated.
