### PR TITLE
Added imports for members of enums

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,9 @@ use phf;
 use Result;
 use types::Type;
 
+use self::ConnectError::*;
+use self::Error::*;
+
 macro_rules! make_errors(
     ($($code:expr => $error:ident),+) => (
         /// SQLSTATE error codes

--- a/src/io.rs
+++ b/src/io.rs
@@ -6,7 +6,10 @@ use std::io::{Stream, IoResult};
 
 use {ConnectParams, SslMode, ConnectTarget, ConnectError};
 use message;
-use message::{SslRequest, WriteMessage};
+use message::WriteMessage;
+use message::FrontendMessage::SslRequest;
+
+use self::InternalStream::{TcpStream, UnixStream};
 
 const DEFAULT_PORT: Port = 5432;
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -3,6 +3,9 @@ use std::mem;
 
 use types::Oid;
 
+use self::BackendMessage::*;
+use self::FrontendMessage::*;
+
 pub const PROTOCOL_VERSION: u32 = 0x0003_0000;
 pub const CANCEL_CODE: u32 = 80877102;
 pub const SSL_CODE: u32 = 80877103;

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -3,6 +3,9 @@
 use std::mem;
 use std::slice;
 
+use self::ArrayParent::{SliceParent, MutSliceParent, BaseParent};
+use self::MutArrayParent::{MutSliceMutParent, MutBaseParent};
+
 /// Information about a dimension of an array
 #[deriving(PartialEq, Eq, Clone)]
 pub struct DimensionInfo {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -5,8 +5,9 @@ use std::io::{ByRefReader, MemWriter, BufReader};
 
 use self::Type::*;
 use Result;
-use error::{PgWrongType, PgWasNull, PgBadData};
-use types::range::{Inclusive, Exclusive, Range};
+use error::Error::{PgWrongType, PgWasNull, PgBadData};
+use types::range::Range;
+use types::range::BoundType::{Inclusive, Exclusive};
 
 macro_rules! check_types(
     ($($expected:pat)|+, $actual:ident) => (

--- a/src/types/range.rs
+++ b/src/types/range.rs
@@ -3,6 +3,10 @@ use std::fmt;
 use std::i32;
 use std::i64;
 
+use self::BoundSide::{Lower, Upper};
+use self::BoundType::{Inclusive, Exclusive};
+use self::InnerRange::{Empty, Normal};
+
 /// The `range!` macro can make it easier to create ranges. It roughly mirrors
 /// traditional mathematic range syntax.
 ///


### PR DESCRIPTION
[This push](https://github.com/rust-lang/rust/pull/18973) requires that all used members of an `enum` are imported, breaking `master`.  This pull request fixes this problem.
