### PR TITLE
Update to new FromStr

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -533,10 +533,10 @@ impl DbError {
             detail: map.remove(&b'D'),
             hint: map.remove(&b'H'),
             position: match map.remove(&b'P') {
-                Some(pos) => Some(ErrorPosition::Normal(try!(pos.parse().ok_or(())))),
+                Some(pos) => Some(ErrorPosition::Normal(try!(pos.parse().ok().ok_or(())))),
                 None => match map.remove(&b'p') {
                     Some(pos) => Some(ErrorPosition::Internal {
-                        position: try!(pos.parse().ok_or(())),
+                        position: try!(pos.parse().ok().ok_or(())),
                         query: try!(map.remove(&b'q').ok_or(()))
                     }),
                     None => None
@@ -549,7 +549,7 @@ impl DbError {
             datatype: map.remove(&b'd'),
             constraint: map.remove(&b'n'),
             file: try!(map.remove(&b'F').ok_or(())),
-            line: try!(map.remove(&b'L').and_then(|l| l.parse()).ok_or(())),
+            line: try!(map.remove(&b'L').and_then(|l| l.parse().ok()).ok_or(())),
             routine: try!(map.remove(&b'R').ok_or(())),
         })
     }

--- a/src/url.rs
+++ b/src/url.rs
@@ -371,7 +371,7 @@ fn get_authority(rawurl: &str) ->
     // If we have a port string, ensure it parses to u16.
     let port = match port {
         None => None,
-        opt => match opt.and_then(|p| FromStr::from_str(p)) {
+        opt => match opt.and_then(|p| FromStr::from_str(p).ok()) {
             None => return Err(format!("Failed to parse port: {:?}", port)),
             opt => opt
         }
@@ -428,14 +428,16 @@ fn get_query_fragment(rawurl: &str) -> DecodeResult<(Query, Option<String>)> {
 }
 
 impl FromStr for Url {
-    fn from_str(s: &str) -> Option<Url> {
-        Url::parse(s).ok()
+    type Err = String;
+    fn from_str(s: &str) -> Result<Url, String> {
+        Url::parse(s)
     }
 }
 
 impl FromStr for Path {
-    fn from_str(s: &str) -> Option<Path> {
-        Path::parse(s).ok()
+    type Err = String;
+    fn from_str(s: &str) -> Result<Path, String> {
+        Path::parse(s)
     }
 }
 


### PR DESCRIPTION
This updates rust-postgres to work with the new FromStr in the git master version of rustc.

You might want to wait to merge this until rustc manages to release a new nightly, otherwise Travis will fail all tests.