### PR TITLE
Switch to using old_path for new rustc

### DIFF
--- a/src/url.rs
+++ b/src/url.rs
@@ -10,7 +10,7 @@
 
 use std::fmt;
 use std::str::FromStr;
-use std::path::BytesContainer;
+use std::old_path::BytesContainer;
 use std::num;
 use std::str;
 


### PR DESCRIPTION
New rustc has moved path to old_path in preparation for the new path module.
This change switches to old_path to enable rust-postgres to continue to build.