### PR TITLE
Update openssl version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "tests/test.rs"
 [dependencies]
 phf = "0.6"
 phf_macros = "0.6"
-openssl = "0.3.0"
+openssl = "0.4.0"
 time = "0.1.14"
 log = "0.2"
 rustc-serialize = "0.2"


### PR DESCRIPTION
Current openssl version conflicts with [hyper](https://github.com/hyperium/hyper) and [cookie-rs](https://github.com/alexcrichton/cookie-rs). 

I need them both in my [postgres-example](https://github.com/rustless/rustless/tree/master/examples/postgres).