### PR TITLE
Change "rustc-serialize" to rustc_serialize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ extern crate byteorder;
 extern crate log;
 extern crate openssl;
 extern crate phf;
-extern crate "rustc-serialize" as serialize;
+extern crate rustc_serialize as serialize;
 #[cfg(feature = "unix_socket")]
 extern crate unix_socket;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,7 @@
 #![feature(core, std_misc, thread_sleep)]
 
 extern crate postgres;
-extern crate "rustc-serialize" as serialize;
+extern crate rustc_serialize as serialize;
 extern crate url;
 extern crate openssl;
 


### PR DESCRIPTION
```bash
$ rustc -V
rustc 1.0.0-nightly (123a754cb 2015-03-24) (built 2015-03-25)
$ cargo build
    Updating registry `https://github.com/rust-lang/crates.io-index`
   Compiling rustc-serialize v0.3.7
   Compiling libc v0.1.3
   Compiling bitflags v0.1.1
   Compiling phf_shared v0.6.18
   Compiling log v0.2.5
   Compiling gcc v0.3.3
   Compiling byteorder v0.3.3
   Compiling pkg-config v0.3.2
note: use an identifier not in quotes instead
   Compiling log v0.3.0
   Compiling phf v0.6.18
   Compiling rand v0.3.0
   Compiling openssl-sys v0.5.2
   Compiling openssl v0.5.2
   Compiling phf_generator v0.6.18
   Compiling phf_codegen v0.6.18
   Compiling postgres v0.7.3 (file:///Users/nagyg/Development/_rust/rust-postgres)
build.rs:7:5: 7:22 warning: use of deprecated item: use std::convert::AsRef<Path> instead, #[warn(deprecated)] on by default
build.rs:7 use std::path::AsPath;
               ^~~~~~~~~~~~~~~~~
src/lib.rs:54:14: 54:31 warning: obsolete syntax: "crate-name"
src/lib.rs:54 extern crate "rustc-serialize" as serialize;
                           ^~~~~~~~~~~~~~~~~
note: use an identifier not in quotes instead
src/lib.rs:54:1: 54:45 warning: crate names soon cannot contain hyphens: rustc-serialize
src/lib.rs:54 extern crate "rustc-serialize" as serialize;
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:54:1: 54:45 error: can't find crate for `serialize`
src/lib.rs:54 extern crate "rustc-serialize" as serialize;
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to previous error
Could not compile `postgres`.

To learn more, run the command again with --verbose.
```