### PR TITLE
bump openssl to v0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ phf_codegen = "0.7"
 
 [dependencies]
 phf = "0.7"
-openssl = "0.5"
+openssl = "0.6"
 log = "0.3"
 rustc-serialize = "0.3"
 byteorder = "0.3"


### PR DESCRIPTION
since a lot of project like nickle.rs, iron, hyper already upgrade openssl. it's a good idea to update openssl as well.