### PR TITLE
make rust-crypto dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ byteorder = "0.3"
 debug-builders = "0.1"
 log = "0.3"
 phf = "0.7"
-rust-crypto = "0.2"
+rust-crypto = { version = "0.2", optional = true }
 rustc-serialize = "0.3"
 chrono = { version = "0.2.14", optional = true }
 openssl = { version = "0.6", optional = true }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -710,11 +710,13 @@ fn test_plaintext_pass_wrong_pass() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "rust-crypto"), ignore)]
 fn test_md5_pass() {
     or_panic!(Connection::connect("postgres://md5_user:password@localhost/postgres", &SslMode::None));
 }
 
 #[test]
+#[cfg_attr(not(feature = "rust-crypto"), ignore)]
 fn test_md5_pass_no_pass() {
     let ret = Connection::connect("postgres://md5_user@localhost/postgres", &SslMode::None);
     match ret {
@@ -725,6 +727,7 @@ fn test_md5_pass_no_pass() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "rust-crypto"), ignore)]
 fn test_md5_pass_wrong_pass() {
     let ret = Connection::connect("postgres://md5_user:asdf@localhost/postgres", &SslMode::None);
     match ret {


### PR DESCRIPTION
 - Some projects &/or people don't need md5 auth.
 - rust-crypto appears fairly inactive (no merges since April)