### PR TITLE
To_String() cleanup for to_owned on method calls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!                   )", &[]).unwrap();
 //!     let me = Person {
 //!         id: 0,
-//!         name: "Steven".to_string(),
+//!         name: "Steven".to_owned(),
 //!         data: None
 //!     };
 //!     conn.execute("INSERT INTO person (name, data) VALUES ($1, $2)",
@@ -867,7 +867,7 @@ impl Connection {
     ///     target: ConnectTarget::Unix(some_crazy_path),
     ///     port: None,
     ///     user: Some(UserInfo {
-    ///         user: "postgres".to_string(),
+    ///         user: "postgres".to_owned(),
     ///         password: None
     ///     }),
     ///     database: None,

--- a/src/url.rs
+++ b/src/url.rs
@@ -65,9 +65,9 @@ impl Url {
         // query and fragment
         let (query, fragment) = try!(get_query_fragment(rest));
 
-        let url = Url::new(scheme.to_string(),
+        let url = Url::new(scheme.to_owned(),
                             userinfo,
-                            host.to_string(),
+                            host.to_owned(),
                             port,
                             path,
                             query,
@@ -180,22 +180,22 @@ pub fn get_scheme(rawurl: &str) -> DecodeResult<(&str, &str)> {
             '0' ... '9' | '+' | '-' | '.' => {
                 if i != 0 { continue }
 
-                Err("url: Scheme must begin with a letter.".to_string())
+                Err("url: Scheme must begin with a letter.".to_owned())
             }
             ':' => {
                 if i == 0 {
-                    Err("url: Scheme cannot be empty.".to_string())
+                    Err("url: Scheme cannot be empty.".to_owned())
                 } else {
                     Ok((&rawurl[0..i], &rawurl[i+1..rawurl.len()]))
                 }
             }
-            _ => Err("url: Invalid character in scheme.".to_string()),
+            _ => Err("url: Invalid character in scheme.".to_owned()),
         };
 
         return result;
     }
 
-    Err("url: Scheme must be terminated with a colon.".to_string())
+    Err("url: Scheme must be terminated with a colon.".to_owned())
 }
 
 // returns userinfo, host, port, and unparsed part, or an error
@@ -255,7 +255,7 @@ fn get_authority(rawurl: &str) ->
             ':' | '@' | '?' | '#' | '/' => {
                 // separators, don't change anything
             }
-            _ => return Err("Illegal character in authority".to_string()),
+            _ => return Err("Illegal character in authority".to_owned()),
         }
 
         // now process states
@@ -271,7 +271,7 @@ fn get_authority(rawurl: &str) ->
                 // multiple colons means ipv6 address.
                 if input == Input::Unreserved {
                     return Err(
-                        "Illegal characters in IPv6 address.".to_string());
+                        "Illegal characters in IPv6 address.".to_owned());
                 }
                 st = State::Ip6Host;
               }
@@ -288,7 +288,7 @@ fn get_authority(rawurl: &str) ->
               }
               State::Ip6Port => {
                 if input == Input::Unreserved {
-                    return Err("Illegal characters in authority.".to_string());
+                    return Err("Illegal characters in authority.".to_owned());
                 }
                 st = State::Ip6Host;
               }
@@ -299,7 +299,7 @@ fn get_authority(rawurl: &str) ->
                     st = State::InPort;
                 }
               }
-              _ => return Err("Invalid ':' in authority.".to_string()),
+              _ => return Err("Invalid ':' in authority.".to_owned()),
             }
             input = Input::Digit; // reset input class
           }
@@ -319,7 +319,7 @@ fn get_authority(rawurl: &str) ->
                 userinfo = Some(UserInfo::new(user, Some(pass)));
                 st = State::InHost;
               }
-              _ => return Err("Invalid '@' in authority.".to_string()),
+              _ => return Err("Invalid '@' in authority.".to_owned()),
             }
             begin = i+1;
           }
@@ -338,7 +338,7 @@ fn get_authority(rawurl: &str) ->
       State::PassHostPort
       | State::Ip6Port => {
         if input != Input::Digit {
-            return Err("Non-digit characters in port.".to_string());
+            return Err("Non-digit characters in port.".to_owned());
         }
         host = &rawurl[begin..pos];
         port = Some(&rawurl[pos+1..end]);
@@ -347,7 +347,7 @@ fn get_authority(rawurl: &str) ->
       | State::InHost => host = &rawurl[begin..end],
       State::InPort => {
         if input != Input::Digit {
-            return Err("Non-digit characters in port.".to_string());
+            return Err("Non-digit characters in port.".to_owned());
         }
         port = Some(&rawurl[pos+1..end]);
       }
@@ -384,13 +384,13 @@ fn get_path(rawurl: &str, is_authority: bool) -> DecodeResult<(String, &str)> {
             end = i;
             break;
           }
-          _ => return Err("Invalid character in path.".to_string())
+          _ => return Err("Invalid character in path.".to_owned())
         }
     }
 
     if is_authority && end != 0 && !rawurl.starts_with("/") {
         Err("Non-empty path must begin with \
-            '/' in presence of authority.".to_string())
+            '/' in presence of authority.".to_owned())
     } else {
         Ok((try!(decode_component(&rawurl[0..end])), &rawurl[end..len]))
     }

--- a/tests/types/mod.rs
+++ b/tests/types/mod.rs
@@ -52,8 +52,8 @@ fn test_i8_params() {
 
 #[test]
 fn test_name_params() {
-    test_type("NAME", &[(Some("hello world".to_string()), "'hello world'"),
-                       (Some("イロハニホヘト チリヌルヲ".to_string()), "'イロハニホヘト チリヌルヲ'"),
+    test_type("NAME", &[(Some("hello world".to_owned()), "'hello world'"),
+                       (Some("イロハニホヘト チリヌルヲ".to_owned()), "'イロハニホヘト チリヌルヲ'"),
                        (None, "NULL")]);
 }
 
@@ -99,15 +99,15 @@ fn test_f64_params() {
 
 #[test]
 fn test_varchar_params() {
-    test_type("VARCHAR", &[(Some("hello world".to_string()), "'hello world'"),
-                          (Some("イロハニホヘト チリヌルヲ".to_string()), "'イロハニホヘト チリヌルヲ'"),
+    test_type("VARCHAR", &[(Some("hello world".to_owned()), "'hello world'"),
+                          (Some("イロハニホヘト チリヌルヲ".to_owned()), "'イロハニホヘト チリヌルヲ'"),
                           (None, "NULL")]);
 }
 
 #[test]
 fn test_text_params() {
-    test_type("TEXT", &[(Some("hello world".to_string()), "'hello world'"),
-                       (Some("イロハニホヘト チリヌルヲ".to_string()), "'イロハニホヘト チリヌルヲ'"),
+    test_type("TEXT", &[(Some("hello world".to_owned()), "'hello world'"),
+                       (Some("イロハニホヘト チリヌルヲ".to_owned()), "'イロハニホヘト チリヌルヲ'"),
                        (None, "NULL")]);
 }
 
@@ -123,7 +123,7 @@ fn test_bpchar_params() {
     let stmt = or_panic!(conn.prepare("SELECT b FROM foo ORDER BY id"));
     let res = or_panic!(stmt.query(&[]));
 
-    assert_eq!(vec!(Some("12345".to_string()), Some("123  ".to_string()), None),
+    assert_eq!(vec!(Some("12345".to_owned()), Some("123  ".to_owned()), None),
                res.iter().map(|row| row.get(0)).collect::<Vec<_>>());
 }
 
@@ -158,10 +158,10 @@ fn test_hstore_params() {
         })
     }
     test_type("hstore",
-              &[(Some(make_map!("a".to_string() => Some("1".to_string()))), "'a=>1'"),
-               (Some(make_map!("hello".to_string() => Some("world!".to_string()),
-                               "hola".to_string() => Some("mundo!".to_string()),
-                               "what".to_string() => None)),
+              &[(Some(make_map!("a".to_owned() => Some("1".to_owned()))), "'a=>1'"),
+               (Some(make_map!("hello".to_owned() => Some("world!".to_owned()),
+                               "hola".to_owned() => Some("mundo!".to_owned()),
+                               "what".to_owned() => None)),
                 "'hello=>world!,hola=>mundo!,what=>NULL'"),
                 (None, "NULL")]);
 }
@@ -203,7 +203,7 @@ fn test_slice() {
 
     let stmt = conn.prepare("SELECT f FROM foo WHERE id = ANY($1)").unwrap();
     let result = stmt.query(&[&Slice(&[1i32, 3, 4])]).unwrap();
-    assert_eq!(vec!["a".to_string(), "c".to_string(), "d".to_string()],
+    assert_eq!(vec!["a".to_owned(), "c".to_owned(), "d".to_owned()],
                result.iter().map(|r| r.get::<_, String>(0)).collect::<Vec<_>>());
 }
 


### PR DESCRIPTION
Hi,

This PR cleans up the calls of to_string in method calls. 

We should favor the usage of to_owned as to_string uses the whole formatting machinery just to clone a string. 

Using .to_owned() is lighter on resources.

Thanks for looking into it !