### PR TITLE
Correct misnamed feature in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,9 @@ implementations for `uuid`'s `Uuid` type.
 [JSON and JSONB](http://www.postgresql.org/docs/9.4/static/datatype-json.html)
 support is provided optionally by the `rustc-serialize` feature, which adds
 `ToSql` and `FromSql` implementations for `rustc-serialize`'s `Json` type, and
-the `serde` feature, which adds implementations for `serde_json`'s `Value`
-type.
+the `serde_json` feature, which adds implementations for `serde_json`'s `Value`
+type. The `serde` feature provides implementations for the older
+`serde::json::Value` type.
 
 ### TIMESTAMP/TIMESTAMPTZ/DATE/TIME types
 


### PR DESCRIPTION
The README indicated `serde` as the feature corresponding to `serde_json::Value`’s FromSql and ToSql implementations, when it is in fact the `serde_json` feature.

The corresponding module documentation gives the right information.

This is my first github pull request ever, please do tell me if I did anything wrong!