### PR TITLE
Ignore InvalidCatalogName errors for pg_catalog queries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,6 +421,8 @@ impl InnerConnection {
             Err(Error::Io(e)) => return Err(ConnectError::Io(e)),
             // Old versions of Postgres and things like Redshift don't support enums
             Err(Error::Db(ref e)) if e.code == SqlState::UndefinedTable => {}
+            // Some Postgres compliant databases are missing a pg_catalog
+            Err(Error::Db(ref e)) if e.code == SqlState::InvalidCatalogName => return Ok(()),
             Err(Error::Db(e)) => return Err(ConnectError::Db(e)),
             Err(Error::Conversion(_)) => unreachable!(),
         }


### PR DESCRIPTION
Fixes #171. See https://github.com/sfackler/rust-postgres/issues/171#issuecomment-219171884.