### PR TITLE
Handle malformed percent-encoding

### DIFF
--- a/src/url.rs
+++ b/src/url.rs
@@ -131,8 +131,17 @@ fn decode_inner(c: &str, full_url: bool) -> DecodeResult<String> {
                             }
                         };
 
+                        let bytes_from_hex = match Vec::<u8>::from_hex(&bytes) {
+                            Ok(b) => b,
+                            _ => {
+                                return Err("Malformed input: found '%' followed by \
+                                            invalid hex  values. Character '%' must \
+                                            escaped.".to_owned())
+                            }
+                        };
+
                         // Only decode some characters if full_url:
-                        match Vec::<u8>::from_hex(&bytes).unwrap()[0] as char {
+                        match bytes_from_hex[0] as char {
                             // gen-delims:
                             ':' |
                             '/' |

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -939,6 +939,11 @@ fn test_get_opt_wrong_type() {
 }
 
 #[test]
+fn url_unencoded_password() {
+    assert!("postgresql://username:password%1*@localhost".into_connect_params().is_err())
+}
+
+#[test]
 fn url_encoded_password() {
     let params = "postgresql://username%7b%7c:password%7b%7c@localhost".into_connect_params().unwrap();
     assert_eq!("username{|", &params.user.as_ref().unwrap().user[..]);


### PR DESCRIPTION
I made the mistake of assuming percent encoding would be done internally and hit a panic. This fix checks the result of `Vec::<u8>::from_hex` for invalid hex values that could result from a user passing a password like `%1*`.

Closes #182