### PR TITLE
Add savepoint method to Transaction

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -202,9 +202,9 @@ fn test_nested_transactions() {
             }
 
             {
-                let trans3 = or_panic!(trans2.transaction());
-                or_panic!(trans3.execute("INSERT INTO foo (id) VALUES (6)", &[]));
-                assert!(trans3.commit().is_ok());
+                let sp = or_panic!(trans2.savepoint("custom"));
+                or_panic!(sp.execute("INSERT INTO foo (id) VALUES (6)", &[]));
+                assert!(sp.commit().is_ok());
             }
 
             assert!(trans2.commit().is_ok());
@@ -250,10 +250,10 @@ fn test_nested_transactions_finish() {
             }
 
             {
-                let trans3 = or_panic!(trans2.transaction());
-                or_panic!(trans3.execute("INSERT INTO foo (id) VALUES (6)", &[]));
-                trans3.set_commit();
-                assert!(trans3.finish().is_ok());
+                let sp = or_panic!(trans2.savepoint("custom"));
+                or_panic!(sp.execute("INSERT INTO foo (id) VALUES (6)", &[]));
+                sp.set_commit();
+                assert!(sp.finish().is_ok());
             }
 
             trans2.set_commit();
@@ -292,6 +292,15 @@ fn test_trans_with_nested_trans() {
     let trans = or_panic!(conn.transaction());
     let _trans2 = or_panic!(trans.transaction());
     trans.transaction().unwrap();
+}
+
+#[test]
+#[should_panic(expected = "active transaction")]
+fn test_trans_with_savepoints() {
+    let conn = or_panic!(Connection::connect("postgres://postgres@localhost", SslMode::None));
+    let trans = or_panic!(conn.transaction());
+    let _sp = or_panic!(trans.savepoint("custom"));
+    trans.savepoint("custom2").unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Fixes #179 

This change creates a `Transaction.savepoint` method, which is equivalent
to `Transaction.transaction`, but takes a custom name for the nested
transaction's savepoint name.