### PR TITLE
Support uuid 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ openssl = { version = ">= 0.6.4, < 0.8", optional = true }
 serde_json = { version = ">= 0.6, < 0.9", optional = true }
 time = { version = "0.1.14", optional = true }
 unix_socket = { version = "0.5", optional = true }
-uuid = { version = ">= 0.1, < 0.3", optional = true }
+uuid = { version = ">= 0.1, < 0.4", optional = true }
 security-framework = { version = "0.1.2", optional = true }
 bit-vec = { version = "0.4", optional = true }
 eui48 = { version = "0.1", optional = true }


### PR DESCRIPTION
Uuid 0.3 has been out for a few weeks and supports serde 0.8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfackler/rust-postgres/199)
<!-- Reviewable:end -->
