### PR TITLE
Added convenience impl IntoConnectParams for String

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -66,6 +66,12 @@ impl<'a> IntoConnectParams for &'a str {
     }
 }
 
+impl IntoConnectParams for String {
+    fn into_connect_params(self) -> Result<ConnectParams, Box<Error + Sync + Send>> {
+        self.as_str().into_connect_params()
+    }
+}
+
 impl IntoConnectParams for Url {
     fn into_connect_params(self) -> Result<ConnectParams, Box<Error + Sync + Send>> {
         let Url { host, port, user, path: url::Path { mut path, query: options, .. }, .. } = self;


### PR DESCRIPTION
Currently one must convert `String`s to `&str` using `.as_str()` in order to invoke `Connection::connect`.
This may be avoided if `String`s refer to the implementation of `&str` for `IntoConnectParams`

Here's an example before and after this change.

Before:
```
let conn = Connection::connect(env::var("DATABASE_URL").unwrap().as_str(), 
                               TlsMode::None)
```
After:
```
let conn = Connection::connect(env::var("DATABASE_URL").unwrap(), TlsMode::None)
```