### PR TITLE
Make Rows a fully owned type

### DIFF
--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -224,16 +224,6 @@ struct StatementInfo {
     columns: Vec<Column>,
 }
 
-impl fmt::Debug for StatementInfo {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("Statement")
-            .field("name", &self.name)
-            .field("parameter_types", &self.param_types)
-            .field("columns", &self.columns)
-            .finish()
-    }
-}
-
 struct InnerConnection {
     stream: MessageStream,
     notice_handler: Box<HandleNotice>,

--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -218,6 +218,7 @@ pub enum TlsMode<'a> {
     Require(&'a TlsHandshake),
 }
 
+#[derive(Debug)]
 struct StatementInfo {
     name: String,
     param_types: Vec<Type>,

--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -218,10 +218,22 @@ pub enum TlsMode<'a> {
     Require(&'a TlsHandshake),
 }
 
-struct StatementInfo {
+// Needs to be pub since `RowIndex` is pub.
+#[doc(hidden)]
+pub struct StatementInfo {
     name: String,
     param_types: Vec<Type>,
     columns: Vec<Column>,
+}
+
+impl fmt::Debug for StatementInfo {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Statement")
+            .field("name", &self.name)
+            .field("parameter_types", &self.param_types)
+            .field("columns", &self.columns)
+            .finish()
+    }
 }
 
 struct InnerConnection {
@@ -1082,7 +1094,7 @@ impl Connection {
     ///     println!("foo: {}", foo);
     /// }
     /// ```
-    pub fn query<'a>(&'a self, query: &str, params: &[&ToSql]) -> Result<Rows<'a>> {
+    pub fn query(&self, query: &str, params: &[&ToSql]) -> Result<Rows<'static>> {
         let (param_types, columns) = self.0.borrow_mut().raw_prepare("", query)?;
         let info = Arc::new(StatementInfo {
                                 name: String::new(),
@@ -1300,7 +1312,7 @@ pub trait GenericConnection {
     fn execute(&self, query: &str, params: &[&ToSql]) -> Result<u64>;
 
     /// Like `Connection::query`.
-    fn query<'a>(&'a self, query: &str, params: &[&ToSql]) -> Result<Rows<'a>>;
+    fn query<'a>(&'a self, query: &str, params: &[&ToSql]) -> Result<Rows<'static>>;
 
     /// Like `Connection::prepare`.
     fn prepare<'a>(&'a self, query: &str) -> Result<Statement<'a>>;
@@ -1323,7 +1335,7 @@ impl GenericConnection for Connection {
         self.execute(query, params)
     }
 
-    fn query<'a>(&'a self, query: &str, params: &[&ToSql]) -> Result<Rows<'a>> {
+    fn query<'a>(&'a self, query: &str, params: &[&ToSql]) -> Result<Rows<'static>> {
         self.query(query, params)
     }
 
@@ -1353,7 +1365,7 @@ impl<'a> GenericConnection for Transaction<'a> {
         self.execute(query, params)
     }
 
-    fn query<'b>(&'b self, query: &str, params: &[&ToSql]) -> Result<Rows<'b>> {
+    fn query<'b>(&'b self, query: &str, params: &[&ToSql]) -> Result<Rows<'static>> {
         self.query(query, params)
     }
 
@@ -1396,9 +1408,8 @@ trait OtherNew {
     fn new(name: String, oid: Oid, kind: Kind, schema: String) -> Other;
 }
 
-trait RowsNew<'a> {
-    fn new(stmt: &'a Statement<'a>, data: Vec<RowData>) -> Rows<'a>;
-    fn new_owned(stmt: Statement<'a>, data: Vec<RowData>) -> Rows<'a>;
+trait RowsNew {
+    fn new(stmt: &Statement, data: Vec<RowData>) -> Rows<'static>;
 }
 
 trait LazyRowsNew<'trans, 'stmt> {
@@ -1421,7 +1432,9 @@ trait StatementInternals<'conn> {
 
     fn conn(&self) -> &'conn Connection;
 
-    fn into_query(self, params: &[&ToSql]) -> Result<Rows<'conn>>;
+    fn info(&self) -> &Arc<StatementInfo>;
+
+    fn into_query(self, params: &[&ToSql]) -> Result<Rows<'static>>;
 }
 
 trait ColumnNew {

--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -218,9 +218,7 @@ pub enum TlsMode<'a> {
     Require(&'a TlsHandshake),
 }
 
-// Needs to be pub since `RowIndex` is pub.
-#[doc(hidden)]
-pub struct StatementInfo {
+struct StatementInfo {
     name: String,
     param_types: Vec<Type>,
     columns: Vec<Column>,

--- a/postgres/src/stmt.rs
+++ b/postgres/src/stmt.rs
@@ -30,18 +30,6 @@ impl<'a> fmt::Debug for Statement<'a> {
     }
 }
 
-impl<'a> AsRef<StatementInfo> for Statement<'a> {
-    fn as_ref(&self) -> &StatementInfo {
-        &*self.info
-    }
-}
-
-impl AsRef<StatementInfo> for StatementInfo {
-    fn as_ref(&self) -> &StatementInfo {
-        self
-    }
-}
-
 impl<'conn> Drop for Statement<'conn> {
     fn drop(&mut self) {
         let _ = self.finish_inner();

--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -228,7 +228,7 @@ impl<'conn> Transaction<'conn> {
     }
 
     /// Like `Connection::query`.
-    pub fn query<'a>(&'a self, query: &str, params: &[&ToSql]) -> Result<Rows<'a>> {
+    pub fn query<'a>(&'a self, query: &str, params: &[&ToSql]) -> Result<Rows<'static>> {
         self.conn.query(query, params)
     }
 

--- a/postgres/tests/test.rs
+++ b/postgres/tests/test.rs
@@ -1088,11 +1088,11 @@ fn test_row_case_insensitive() {
     conn.batch_execute("CREATE TEMPORARY TABLE foo (foo INT, \"bAr\" INT, \"Bar\" INT);")
         .unwrap();
     let stmt = conn.prepare("SELECT * FROM foo").unwrap();
-    assert_eq!(Some(0), "foo".idx(&stmt));
-    assert_eq!(Some(0), "FOO".idx(&stmt));
-    assert_eq!(Some(1), "bar".idx(&stmt));
-    assert_eq!(Some(1), "bAr".idx(&stmt));
-    assert_eq!(Some(2), "Bar".idx(&stmt));
+    assert_eq!(Some(0), "foo".idx(&stmt.columns()));
+    assert_eq!(Some(0), "FOO".idx(&stmt.columns()));
+    assert_eq!(Some(1), "bar".idx(&stmt.columns()));
+    assert_eq!(Some(1), "bAr".idx(&stmt.columns()));
+    assert_eq!(Some(2), "Bar".idx(&stmt.columns()));
 }
 
 #[test]


### PR DESCRIPTION
This allows Rows to outlive a statement and be sent to 'static threads.

Resolves #263.