### PR TITLE
Correct build error on non-unix targets for tokio-postgres

### DIFF
--- a/tokio-postgres/src/stream.rs
+++ b/tokio-postgres/src/stream.rs
@@ -47,7 +47,7 @@ pub fn connect(
         #[cfg(not(unix))]
         Host::Unix(_) => {
             Either::B(
-                Err(ConnectError::ConnectParams(
+                Err(error::connect(
                     "unix sockets are not supported on this \
                                                        platform"
                         .into(),


### PR DESCRIPTION
The latest release of tokio-postgres (version "0.3.0") don't build on non unix platform due to a missing error renaming (forgot when error reform was done).