### PR TITLE
Add a way to query ambiguous column

### DIFF
--- a/postgres-shared/src/stmt.rs
+++ b/postgres-shared/src/stmt.rs
@@ -1,17 +1,21 @@
+use postgres_protocol::Oid;
+
 use types::Type;
 
 /// Information about a column of a Postgres query.
 #[derive(Debug)]
 pub struct Column {
+    table: Oid,
     name: String,
     type_: Type,
 }
 
 impl Column {
     #[doc(hidden)]
-    pub fn new(name: String, type_: Type) -> Column {
+    pub fn new(name: String, table: Oid, type_: Type) -> Column {
         Column {
             name: name,
+            table,
             type_: type_,
         }
     }
@@ -19,6 +23,11 @@ impl Column {
     /// Returns the name of the column.
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// Returns the table of the column.
+    pub fn table(&self) -> Oid {
+        self.table
     }
 
     /// Returns the type of the column.

--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -529,6 +529,7 @@ impl InnerConnection {
                 .and_then(|field| {
                     Ok(Column::new(
                         field.name().to_owned(),
+                        field.table_oid(),
                         self.get_type(field.type_oid())?,
                     ))
                 })

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -632,7 +632,7 @@ impl Connection {
                 match m {
                     backend::Message::RowDescription(body) => {
                         match body.fields()
-                            .map(|f| (f.name().to_owned(), f.type_oid()))
+                            .map(|f| (f.name().to_owned(), f.type_oid(), f.table_oid()))
                             .collect::<Vec<_>>() {
                                 Ok(d) => Ok((p, d, s)),
                                 Err(e) => Err((error::io(e), Connection(s))),
@@ -651,7 +651,7 @@ impl Connection {
                 s.get_types(r.into_iter(),
                             vec![],
                             |f| f.1,
-                            |f, t| Column::new(f.0, t))
+                            |f, t| Column::new(f.0, f.2, t))
                     .map(|(r, s)| (p, r, s))
             })
             .boxed2()


### PR DESCRIPTION
Hi.
I'd like to have this stuff to use in my ORM.
If necessary, I can put it behind a feature flag.
Here's how it would be used:
```rust
extern crate postgres;

use postgres::{Connection, TableColumn, TlsMode};

struct Person {
    id: i32,
    name: String,
    data: Option<Vec<u8>>,
}

fn main() {
    let conn = Connection::connect("postgres://postgres@localhost", TlsMode::None).unwrap();
    //conn.execute("DROP TABLE person", &[]).unwrap();
    conn.execute("CREATE TABLE IF NOT EXISTS person (
                    id              SERIAL PRIMARY KEY,
                    name            VARCHAR NOT NULL,
                    data            BYTEA
                  )", &[]).unwrap();
    conn.execute("CREATE TABLE IF NOT EXISTS address (
                    id              SERIAL PRIMARY KEY,
                    address         VARCHAR NOT NULL,
                    person          INTEGER REFERENCES person(id)
                  )", &[]).unwrap();
    let mut me = Person {
        id: 0,
        name: "Steven".to_string(),
        data: None,
    };
    let rows = conn.query("INSERT INTO person (name, data) VALUES ($1, $2) RETURNING id",
                 &[&me.name, &me.data]).unwrap();
    let row = rows.iter().next().unwrap();
    me.id = row.get(0);
    conn.execute("INSERT INTO address (address, person) VALUES ($1, $2)",
                 &[&"my address", &me.id]).unwrap();
    for row in &conn.query("SELECT id, name, data FROM person", &[]).unwrap() {
        let person = Person {
            id: row.get(0),
            name: row.get(1),
            data: row.get(2),
        };
        println!("Found person {}", person.name);
    }

    let oid = 19173;
    let address_oid = 19185;
    let stmt = conn.prepare("SELECT * FROM person
                            INNER JOIN address
                                ON address.person = person.id").unwrap();
    for row in &stmt.query(&[]).unwrap() {
        let person = Person {
            //id: row.get(0),
            id: row.get(TableColumn::new("id", oid)),
            //name: row.get("name"),
            name: row.get(TableColumn::new("name", oid)),
            data: row.get(2),
        };
        let address_id: i32 = row.get(TableColumn::new("id", address_oid));
        println!("Found person {}. {} at address {}", person.id, person.name, address_id);
    }
}
```
Thanks.