### PR TITLE
Fixes for bb8

### DIFF
--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -1136,6 +1136,15 @@ impl Connection {
     pub fn parameter(&self, param: &str) -> Option<&str> {
         self.0.parameters.get(param).map(|s| &**s)
     }
+
+    /// Returns whether or not the stream has been desynchronized due to an
+    /// error in the communication channel with the server.
+    ///
+    /// If this has occurred, all further queries will immediately return an
+    /// error.
+    pub fn is_desynchronized(&self) -> bool {
+        self.0.desynchronized
+    }
 }
 
 /// A stream of asynchronous Postgres notifications.

--- a/tokio-postgres/src/tls/mod.rs
+++ b/tokio-postgres/src/tls/mod.rs
@@ -32,7 +32,7 @@ impl TlsStream for Stream {
 pub trait Handshake: 'static + Sync + Send {
     /// Performs a TLS handshake, returning a wrapped stream.
     fn handshake(
-        self: Box<Self>,
+        &self,
         host: &str,
         stream: Stream,
     ) -> Box<Future<Item = Box<TlsStream>, Error = Box<Error + Sync + Send>> + Send>;

--- a/tokio-postgres/src/tls/openssl.rs
+++ b/tokio-postgres/src/tls/openssl.rs
@@ -40,7 +40,7 @@ impl From<SslConnector> for OpenSsl {
 
 impl Handshake for OpenSsl {
     fn handshake(
-        self: Box<Self>,
+        &self,
         host: &str,
         stream: Stream,
     ) -> Box<Future<Item = Box<TlsStream>, Error = Box<Error + Sync + Send>> + Send> {


### PR DESCRIPTION
To write bb8 (https://github.com/khuey/bb8) I made a few modifications to tokio_postgres. These do change the exposed interface.

- `Handshake` no longer consumes itself. This wasn't necessary and allows a single `Handshake` to be shared among multiple connections.
- An `is_desynchronized` is added, mirroring the one in sync `postgres`.
- The `TlsMode` enum now holds references, like its equivalent in sync `postgres`. This requires bounding a couple futures to the lifetime of the `TlsMode`. I expect this to be the most controversial part. Since you can still shove your `Handshake` in a `lazy_static!` to get the static lifetime if you really need it I don't think this is a huge issue.