### PR TITLE
Update uuid to 0.6

### DIFF
--- a/postgres-shared/Cargo.toml
+++ b/postgres-shared/Cargo.toml
@@ -29,4 +29,4 @@ geo = { version = "0.4", optional = true }
 rustc-serialize = { version = "0.3", optional = true }
 serde_json = { version = "1.0", optional = true }
 time = { version = "0.1.14", optional = true }
-uuid = { version = "0.5", optional = true }
+uuid = { version = "0.6", optional = true }


### PR DESCRIPTION
Hey

Updating this crate to 0.6 since the new release is out. There are no further changes required.