### PR TITLE
Allow FromSql to borrow from the buffer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     working_directory: ~/build
     docker:
-      - image: rust:1.21.0
+      - image: rust:1.23.0
         environment:
           RUSTFLAGS: -D warnings
       - image: sfackler/rust-postgres-test:3

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -3,8 +3,6 @@ extern crate marksman_escape;
 extern crate phf_codegen;
 extern crate regex;
 
-#[allow(unused_imports)]
-use std::ascii::AsciiExt;
 use std::path::Path;
 
 mod sqlstate;

--- a/codegen/src/type_gen.rs
+++ b/codegen/src/type_gen.rs
@@ -1,11 +1,9 @@
+use marksman_escape::Escape;
 use regex::Regex;
-#[allow(unused_imports)]
-use std::ascii::AsciiExt;
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
-use marksman_escape::Escape;
 
 use snake_to_camel;
 
@@ -178,8 +176,7 @@ fn make_impl(w: &mut BufWriter<File>, types: &BTreeMap<u32, Type>) {
             w,
             "            {} => Some(Inner::{}),
 ",
-            oid,
-            type_.variant
+            oid, type_.variant
         ).unwrap();
     }
 
@@ -194,14 +191,12 @@ fn make_impl(w: &mut BufWriter<File>, types: &BTreeMap<u32, Type>) {
 ",
     ).unwrap();
 
-
     for (oid, type_) in types {
         write!(
             w,
             "            Inner::{} => {},
 ",
-            type_.variant,
-            oid
+            type_.variant, oid
         ).unwrap();
     }
 
@@ -231,8 +226,7 @@ fn make_impl(w: &mut BufWriter<File>, types: &BTreeMap<u32, Type>) {
                 V
             }}
 ",
-            type_.variant,
-            kind
+            type_.variant, kind
         ).unwrap();
     }
 
@@ -252,8 +246,7 @@ fn make_impl(w: &mut BufWriter<File>, types: &BTreeMap<u32, Type>) {
             w,
             r#"            Inner::{} => "{}",
 "#,
-            type_.variant,
-            type_.name
+            type_.variant, type_.name
         ).unwrap();
     }
 

--- a/postgres-shared/src/rows.rs
+++ b/postgres-shared/src/rows.rs
@@ -1,12 +1,10 @@
 use fallible_iterator::FallibleIterator;
 use postgres_protocol::message::backend::DataRowBody;
-#[allow(unused_imports)]
-use std::ascii::AsciiExt;
 use std::io;
 use std::ops::Range;
 
-use stmt::Column;
 use rows::sealed::Sealed;
+use stmt::Column;
 
 mod sealed {
     use stmt::Column;

--- a/postgres-shared/src/types/bit_vec.rs
+++ b/postgres-shared/src/types/bit_vec.rs
@@ -1,12 +1,12 @@
 extern crate bit_vec;
 
-use postgres_protocol::types;
 use self::bit_vec::BitVec;
+use postgres_protocol::types;
 use std::error::Error;
 
 use types::{FromSql, IsNull, ToSql, Type, BIT, VARBIT};
 
-impl FromSql for BitVec {
+impl<'a> FromSql<'a> for BitVec {
     fn from_sql(_: &Type, raw: &[u8]) -> Result<BitVec, Box<Error + Sync + Send>> {
         let varbit = types::varbit_from_sql(raw)?;
         let mut bitvec = BitVec::from_bytes(varbit.bytes());

--- a/postgres-shared/src/types/chrono.rs
+++ b/postgres-shared/src/types/chrono.rs
@@ -1,8 +1,8 @@
 extern crate chrono;
 
-use postgres_protocol::types;
 use self::chrono::{DateTime, Duration, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime,
                    Utc};
+use postgres_protocol::types;
 use std::error::Error;
 
 use types::{FromSql, IsNull, ToSql, Type, DATE, TIME, TIMESTAMP, TIMESTAMPTZ};
@@ -11,7 +11,7 @@ fn base() -> NaiveDateTime {
     NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0)
 }
 
-impl FromSql for NaiveDateTime {
+impl<'a> FromSql<'a> for NaiveDateTime {
     fn from_sql(_: &Type, raw: &[u8]) -> Result<NaiveDateTime, Box<Error + Sync + Send>> {
         let t = types::timestamp_from_sql(raw)?;
         Ok(base() + Duration::microseconds(t))
@@ -34,7 +34,7 @@ impl ToSql for NaiveDateTime {
     to_sql_checked!();
 }
 
-impl FromSql for DateTime<Utc> {
+impl<'a> FromSql<'a> for DateTime<Utc> {
     fn from_sql(type_: &Type, raw: &[u8]) -> Result<DateTime<Utc>, Box<Error + Sync + Send>> {
         let naive = NaiveDateTime::from_sql(type_, raw)?;
         Ok(DateTime::from_utc(naive, Utc))
@@ -52,7 +52,7 @@ impl ToSql for DateTime<Utc> {
     to_sql_checked!();
 }
 
-impl FromSql for DateTime<Local> {
+impl<'a> FromSql<'a> for DateTime<Local> {
     fn from_sql(type_: &Type, raw: &[u8]) -> Result<DateTime<Local>, Box<Error + Sync + Send>> {
         let utc = DateTime::<Utc>::from_sql(type_, raw)?;
         Ok(utc.with_timezone(&Local))
@@ -70,7 +70,7 @@ impl ToSql for DateTime<Local> {
     to_sql_checked!();
 }
 
-impl FromSql for DateTime<FixedOffset> {
+impl<'a> FromSql<'a> for DateTime<FixedOffset> {
     fn from_sql(
         type_: &Type,
         raw: &[u8],
@@ -91,7 +91,7 @@ impl ToSql for DateTime<FixedOffset> {
     to_sql_checked!();
 }
 
-impl FromSql for NaiveDate {
+impl<'a> FromSql<'a> for NaiveDate {
     fn from_sql(_: &Type, raw: &[u8]) -> Result<NaiveDate, Box<Error + Sync + Send>> {
         let jd = types::date_from_sql(raw)?;
         Ok(base().date() + Duration::days(jd as i64))
@@ -115,7 +115,7 @@ impl ToSql for NaiveDate {
     to_sql_checked!();
 }
 
-impl FromSql for NaiveTime {
+impl<'a> FromSql<'a> for NaiveTime {
     fn from_sql(_: &Type, raw: &[u8]) -> Result<NaiveTime, Box<Error + Sync + Send>> {
         let usec = types::time_from_sql(raw)?;
         Ok(NaiveTime::from_hms(0, 0, 0) + Duration::microseconds(usec))

--- a/postgres-shared/src/types/eui48.rs
+++ b/postgres-shared/src/types/eui48.rs
@@ -1,12 +1,12 @@
 extern crate eui48;
 
 use self::eui48::MacAddress;
-use std::error::Error;
 use postgres_protocol::types;
+use std::error::Error;
 
-use types::{FromSql, ToSql, Type, IsNull, MACADDR};
+use types::{FromSql, IsNull, ToSql, Type, MACADDR};
 
-impl FromSql for MacAddress {
+impl<'a> FromSql<'a> for MacAddress {
     fn from_sql(_: &Type, raw: &[u8]) -> Result<MacAddress, Box<Error + Sync + Send>> {
         let bytes = types::macaddr_from_sql(raw)?;
         Ok(MacAddress::new(bytes))

--- a/postgres-shared/src/types/geo.rs
+++ b/postgres-shared/src/types/geo.rs
@@ -1,13 +1,13 @@
 extern crate geo;
 
-use postgres_protocol::types;
 use self::geo::{Bbox, LineString, Point};
-use std::error::Error;
 use fallible_iterator::FallibleIterator;
+use postgres_protocol::types;
+use std::error::Error;
 
-use types::{FromSql, ToSql, IsNull, Type, POINT, BOX, PATH};
+use types::{FromSql, IsNull, ToSql, Type, BOX, PATH, POINT};
 
-impl FromSql for Point<f64> {
+impl<'a> FromSql<'a> for Point<f64> {
     fn from_sql(_: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
         let point = types::point_from_sql(raw)?;
         Ok(Point::new(point.x(), point.y()))
@@ -26,7 +26,7 @@ impl ToSql for Point<f64> {
     to_sql_checked!();
 }
 
-impl FromSql for Bbox<f64> {
+impl<'a> FromSql<'a> for Bbox<f64> {
     fn from_sql(_: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
         let bbox = types::box_from_sql(raw)?;
         Ok(Bbox {
@@ -50,7 +50,7 @@ impl ToSql for Bbox<f64> {
     to_sql_checked!();
 }
 
-impl FromSql for LineString<f64> {
+impl<'a> FromSql<'a> for LineString<f64> {
     fn from_sql(_: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
         let path = types::path_from_sql(raw)?;
         let points = path.points().map(|p| Point::new(p.x(), p.y())).collect()?;

--- a/postgres-shared/src/types/rustc_serialize.rs
+++ b/postgres-shared/src/types/rustc_serialize.rs
@@ -1,12 +1,12 @@
 extern crate rustc_serialize;
 
 use self::rustc_serialize::json;
-use std::io::{Read, Write};
 use std::error::Error;
+use std::io::{Read, Write};
 
 use types::{FromSql, IsNull, ToSql, Type, JSON, JSONB};
 
-impl FromSql for json::Json {
+impl<'a> FromSql<'a> for json::Json {
     fn from_sql(ty: &Type, mut raw: &[u8]) -> Result<json::Json, Box<Error + Sync + Send>> {
         if *ty == JSONB {
             let mut b = [0; 1];

--- a/postgres-shared/src/types/serde_json.rs
+++ b/postgres-shared/src/types/serde_json.rs
@@ -6,7 +6,7 @@ use std::io::{Read, Write};
 
 use types::{FromSql, IsNull, ToSql, Type, JSON, JSONB};
 
-impl FromSql for Value {
+impl<'a> FromSql<'a> for Value {
     fn from_sql(ty: &Type, mut raw: &[u8]) -> Result<Value, Box<Error + Sync + Send>> {
         if *ty == JSONB {
             let mut b = [0; 1];

--- a/postgres-shared/src/types/time.rs
+++ b/postgres-shared/src/types/time.rs
@@ -1,10 +1,10 @@
 extern crate time;
 
 use self::time::Timespec;
-use std::error::Error;
 use postgres_protocol::types;
+use std::error::Error;
 
-use types::{Type, FromSql, ToSql, IsNull, TIMESTAMP, TIMESTAMPTZ};
+use types::{FromSql, IsNull, ToSql, Type, TIMESTAMP, TIMESTAMPTZ};
 
 const USEC_PER_SEC: i64 = 1_000_000;
 const NSEC_PER_USEC: i64 = 1_000;
@@ -12,7 +12,7 @@ const NSEC_PER_USEC: i64 = 1_000;
 // Number of seconds from 1970-01-01 to 2000-01-01
 const TIME_SEC_CONVERSION: i64 = 946684800;
 
-impl FromSql for Timespec {
+impl<'a> FromSql<'a> for Timespec {
     fn from_sql(_: &Type, raw: &[u8]) -> Result<Timespec, Box<Error + Sync + Send>> {
         let t = types::timestamp_from_sql(raw)?;
         let mut sec = t / USEC_PER_SEC + TIME_SEC_CONVERSION;

--- a/postgres-shared/src/types/uuid.rs
+++ b/postgres-shared/src/types/uuid.rs
@@ -1,12 +1,12 @@
 extern crate uuid;
 
-use postgres_protocol::types;
 use self::uuid::Uuid;
+use postgres_protocol::types;
 use std::error::Error;
 
-use types::{FromSql, ToSql, Type, IsNull, UUID};
+use types::{FromSql, IsNull, ToSql, Type, UUID};
 
-impl FromSql for Uuid {
+impl<'a> FromSql<'a> for Uuid {
     fn from_sql(_: &Type, raw: &[u8]) -> Result<Uuid, Box<Error + Sync + Send>> {
         let bytes = types::uuid_from_sql(raw)?;
         Ok(Uuid::from_bytes(&bytes).unwrap())

--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -80,6 +80,11 @@ extern crate postgres_shared;
 extern crate socket2;
 
 use fallible_iterator::FallibleIterator;
+use postgres_protocol::authentication;
+use postgres_protocol::authentication::sasl::{self, ScramSha256};
+use postgres_protocol::message::backend::{self, ErrorFields};
+use postgres_protocol::message::frontend;
+use postgres_shared::rows::RowData;
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
@@ -88,38 +93,33 @@ use std::mem;
 use std::result;
 use std::sync::Arc;
 use std::time::Duration;
-use postgres_protocol::authentication;
-use postgres_protocol::authentication::sasl::{self, ScramSha256};
-use postgres_protocol::message::backend::{self, ErrorFields};
-use postgres_protocol::message::frontend;
-use postgres_shared::rows::RowData;
 
 use error::{DbError, UNDEFINED_COLUMN, UNDEFINED_TABLE};
-use tls::TlsHandshake;
 use notification::{Notification, Notifications};
 use params::{IntoConnectParams, User};
 use priv_io::MessageStream;
 use rows::Rows;
 use stmt::{Column, Statement};
+use tls::TlsHandshake;
 use transaction::{IsolationLevel, Transaction};
 use types::{Field, FromSql, IsNull, Kind, Oid, ToSql, Type, CHAR, NAME, OID};
 
 #[doc(inline)]
+pub use error::Error;
+#[doc(inline)]
 pub use postgres_shared::CancelData;
 #[doc(inline)]
 pub use postgres_shared::{error, types};
-#[doc(inline)]
-pub use error::Error;
 
 #[macro_use]
 mod macros;
 
-mod priv_io;
-pub mod tls;
 pub mod notification;
 pub mod params;
+mod priv_io;
 pub mod rows;
 pub mod stmt;
+pub mod tls;
 pub mod transaction;
 
 const TYPEINFO_QUERY: &'static str = "__typeinfo";

--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -2,13 +2,11 @@
 
 use std::cell::Cell;
 use std::fmt;
-#[allow(unused_imports)]
-use std::ascii::AsciiExt;
 
-use {bad_response, Connection, Result};
 use rows::Rows;
 use stmt::Statement;
 use types::ToSql;
+use {bad_response, Connection, Result};
 
 /// An enumeration of transaction isolation levels.
 ///

--- a/postgres/tests/test.rs
+++ b/postgres/tests/test.rs
@@ -1321,20 +1321,6 @@ fn test_parameter() {
 }
 
 #[test]
-fn test_get_bytes() {
-    let conn = or_panic!(Connection::connect(
-        "postgres://postgres@localhost:5433",
-        TlsMode::None,
-    ));
-    let stmt = or_panic!(conn.prepare("SELECT '\\x00010203'::BYTEA"));
-    let result = or_panic!(stmt.query(&[]));
-    assert_eq!(
-        b"\x00\x01\x02\x03",
-        result.iter().next().unwrap().get_bytes(0).unwrap()
-    );
-}
-
-#[test]
 fn url_unencoded_password() {
     assert!(
         "postgresql://username:password%1*@localhost:5433"

--- a/tokio-postgres/src/rows.rs
+++ b/tokio-postgres/src/rows.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 #[doc(inline)]
 pub use postgres_shared::rows::RowIndex;
 
-use types::{WrongType, FromSql};
+use types::{FromSql, WrongType};
 
 /// A row from Postgres.
 pub struct Row {
@@ -44,9 +44,9 @@ impl Row {
     ///
     /// Panics if the index does not reference a column or the return type is
     /// not compatible with the Postgres type.
-    pub fn get<T, I>(&self, idx: I) -> T
+    pub fn get<'a, T, I>(&'a self, idx: I) -> T
     where
-        T: FromSql,
+        T: FromSql<'a>,
         I: RowIndex + fmt::Debug,
     {
         match self.try_get(&idx) {
@@ -64,9 +64,9 @@ impl Row {
     /// Returns `None` if the index does not reference a column, `Some(Err(..))`
     /// if there was an error converting the result value, and `Some(Ok(..))`
     /// on success.
-    pub fn try_get<T, I>(&self, idx: I) -> Result<Option<T>, Box<Error + Sync + Send>>
+    pub fn try_get<'a, T, I>(&'a self, idx: I) -> Result<Option<T>, Box<Error + Sync + Send>>
     where
-        T: FromSql,
+        T: FromSql<'a>,
         I: RowIndex,
     {
         let idx = match idx.__idx(&self.columns) {

--- a/tokio-postgres/src/test.rs
+++ b/tokio-postgres/src/test.rs
@@ -313,7 +313,7 @@ fn domain() {
         to_sql_checked!();
     }
 
-    impl FromSql for SessionId {
+    impl<'a> FromSql<'a> for SessionId {
         fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<StdError + Sync + Send>> {
             Vec::<u8>::from_sql(ty, raw).map(SessionId)
         }


### PR DESCRIPTION
This allows for in-place deserialization of text and bytea values in
particular.

Row::get_bytes is removed since it previously existed for this use case.

Closes #281