### PR TITLE
Automatically determine flags for array serialization

### DIFF
--- a/postgres-shared/src/types/mod.rs
+++ b/postgres-shared/src/types/mod.rs
@@ -588,7 +588,6 @@ impl<'a, T: ToSql> ToSql for &'a [T] {
 
         types::array_to_sql(
             Some(dimension),
-            true,
             member_type.oid(),
             self.iter(),
             |e, w| match e.to_sql(member_type, w)? {


### PR DESCRIPTION
This way it automatically works with versions of postgres that didn't
support null array entries as long as the data doesn't actually have a
null