### PR TITLE
Change example to avoid compiler warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ fn main() {
             name: row.get(1),
             data: row.get(2),
         };
-        println!("Found person {}", person.name);
+        println!("Found person {}: {}", person.id, person.name);
     }
 }
 ```


### PR DESCRIPTION
Added person.id to output so that the compiler won't complain that the id field in the structure is never used. I know this isn't a big thing, but warnings like that can cause confusion for new users. 