### PR TITLE
Handle non unix case in poll_start of PollConnect

### DIFF
--- a/tokio-postgres/src/proto/connect.rs
+++ b/tokio-postgres/src/proto/connect.rs
@@ -110,7 +110,14 @@ impl PollConnect for Connect {
                     params: state.params,
                     tls: state.tls,
                 })
-            }
+            },
+            #[cfg(not(unix))]
+            Host::Unix(_) => {
+                Err(Error::connect(io::Error::new(
+                    io::ErrorKind::Other,
+                    "unix sockets are not supported on this platform",
+                )))
+            },
         }
     }
 


### PR DESCRIPTION
Someone forgot to handle the non unix case for this match which prevented a build on windows.

A similar bit of code already existed here in line 51 to 56:
https://github.com/sfackler/rust-postgres/blob/5ad78500095c0a9a59533b9164f46edd23cb9e1b/tokio-postgres/src/stream.rs