### PR TITLE
Update tokio

### DIFF
--- a/tokio-postgres-openssl/Cargo.toml
+++ b/tokio-postgres-openssl/Cargo.toml
@@ -7,9 +7,6 @@ authors = ["Steven Fackler <sfackler@gmail.com>"]
 bytes = "0.4"
 futures = "0.1"
 openssl = "0.10"
-tokio-io = "0.1"
+tokio = "0.1.9"
 tokio-openssl = "0.2"
 tokio-postgres = { version = "0.3", path = "../tokio-postgres" }
-
-[dev-dependencies]
-tokio = "0.1.7"

--- a/tokio-postgres-openssl/src/lib.rs
+++ b/tokio-postgres-openssl/src/lib.rs
@@ -1,12 +1,9 @@
 extern crate bytes;
 extern crate futures;
 extern crate openssl;
-extern crate tokio_io;
+extern crate tokio;
 extern crate tokio_openssl;
 extern crate tokio_postgres;
-
-#[cfg(test)]
-extern crate tokio;
 
 use bytes::{Buf, BufMut};
 use futures::{Future, IntoFuture, Poll};
@@ -14,7 +11,7 @@ use openssl::error::ErrorStack;
 use openssl::ssl::{ConnectConfiguration, SslConnector, SslMethod, SslRef};
 use std::error::Error;
 use std::io::{self, Read, Write};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_openssl::ConnectConfigurationExt;
 use tokio_postgres::tls::{Socket, TlsConnect, TlsStream};
 

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -43,8 +43,8 @@ phf = "=0.7.22"
 postgres-protocol = { version = "0.3.0", path = "../postgres-protocol" }
 postgres-shared = { version = "0.4.0", path = "../postgres-shared" }
 state_machine_future = "0.1.7"
+tokio = "0.1.11"
 tokio-codec = "0.1"
-tokio-io = "0.1"
 tokio-tcp = "0.1"
 tokio-timer = "0.2"
 
@@ -52,5 +52,4 @@ tokio-timer = "0.2"
 tokio-uds = "0.2.1"
 
 [dev-dependencies]
-tokio = "0.1.7"
 env_logger = "0.5"

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -44,7 +44,6 @@ postgres-protocol = { version = "0.3.0", path = "../postgres-protocol" }
 postgres-shared = { version = "0.4.0", path = "../postgres-shared" }
 state_machine_future = "0.1.7"
 tokio = "0.1.11"
-tokio-codec = "0.1"
 tokio-tcp = "0.1"
 tokio-timer = "0.2"
 

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -44,7 +44,6 @@ postgres-protocol = { version = "0.3.0", path = "../postgres-protocol" }
 postgres-shared = { version = "0.4.0", path = "../postgres-shared" }
 state_machine_future = "0.1.7"
 tokio = "0.1.11"
-tokio-timer = "0.2"
 
 [target.'cfg(unix)'.dependencies]
 tokio-uds = "0.2.1"

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -43,7 +43,7 @@ phf = "=0.7.22"
 postgres-protocol = { version = "0.3.0", path = "../postgres-protocol" }
 postgres-shared = { version = "0.4.0", path = "../postgres-shared" }
 state_machine_future = "0.1.7"
-tokio = "0.1.11"
+tokio = "0.1.9"
 
 [target.'cfg(unix)'.dependencies]
 tokio-uds = "0.2.1"

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -44,7 +44,6 @@ postgres-protocol = { version = "0.3.0", path = "../postgres-protocol" }
 postgres-shared = { version = "0.4.0", path = "../postgres-shared" }
 state_machine_future = "0.1.7"
 tokio = "0.1.11"
-tokio-tcp = "0.1"
 tokio-timer = "0.2"
 
 [target.'cfg(unix)'.dependencies]

--- a/tokio-postgres/src/error/mod.rs
+++ b/tokio-postgres/src/error/mod.rs
@@ -5,7 +5,7 @@ use postgres_protocol::message::backend::{ErrorFields, ErrorResponseBody};
 use std::error;
 use std::fmt;
 use std::io;
-use tokio_timer;
+use tokio::timer;
 
 pub use self::sqlstate::*;
 
@@ -493,7 +493,7 @@ impl Error {
         Error::new(Kind::Connect, Some(Box::new(e)))
     }
 
-    pub(crate) fn timer(e: tokio_timer::Error) -> Error {
+    pub(crate) fn timer(e: timer::Error) -> Error {
         Error::new(Kind::Timer, Some(Box::new(e)))
     }
 

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -5,8 +5,8 @@ extern crate futures_cpupool;
 extern crate phf;
 extern crate postgres_protocol;
 extern crate postgres_shared;
+extern crate tokio;
 extern crate tokio_codec;
-extern crate tokio_io;
 extern crate tokio_tcp;
 extern crate tokio_timer;
 

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -6,7 +6,6 @@ extern crate phf;
 extern crate postgres_protocol;
 extern crate postgres_shared;
 extern crate tokio;
-extern crate tokio_timer;
 
 #[macro_use]
 extern crate futures;

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -6,7 +6,6 @@ extern crate phf;
 extern crate postgres_protocol;
 extern crate postgres_shared;
 extern crate tokio;
-extern crate tokio_tcp;
 extern crate tokio_timer;
 
 #[macro_use]

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -6,7 +6,6 @@ extern crate phf;
 extern crate postgres_protocol;
 extern crate postgres_shared;
 extern crate tokio;
-extern crate tokio_codec;
 extern crate tokio_tcp;
 extern crate tokio_timer;
 

--- a/tokio-postgres/src/proto/cancel.rs
+++ b/tokio-postgres/src/proto/cancel.rs
@@ -1,7 +1,7 @@
 use futures::{Future, Poll};
 use postgres_protocol::message::frontend;
 use state_machine_future::RentToOwn;
-use tokio_io::io::{self, Flush, WriteAll};
+use tokio::io::{self, Flush, WriteAll};
 
 use error::Error;
 use params::ConnectParams;

--- a/tokio-postgres/src/proto/codec.rs
+++ b/tokio-postgres/src/proto/codec.rs
@@ -1,7 +1,7 @@
 use bytes::BytesMut;
 use postgres_protocol::message::backend;
 use std::io;
-use tokio_codec::{Decoder, Encoder};
+use tokio::codec::{Decoder, Encoder};
 
 pub struct PostgresCodec;
 

--- a/tokio-postgres/src/proto/connect.rs
+++ b/tokio-postgres/src/proto/connect.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use std::vec;
 use tokio::io::{read_exact, write_all, ReadExact, WriteAll};
 use tokio::net::{tcp, TcpStream};
-use tokio_timer::Delay;
+use tokio::timer::Delay;
 
 #[cfg(unix)]
 use tokio_uds::{self, UnixStream};

--- a/tokio-postgres/src/proto/connect.rs
+++ b/tokio-postgres/src/proto/connect.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::time::{Duration, Instant};
 use std::vec;
-use tokio_io::io::{read_exact, write_all, ReadExact, WriteAll};
+use tokio::io::{read_exact, write_all, ReadExact, WriteAll};
 use tokio_tcp::{self, TcpStream};
 use tokio_timer::Delay;
 

--- a/tokio-postgres/src/proto/connect.rs
+++ b/tokio-postgres/src/proto/connect.rs
@@ -8,7 +8,7 @@ use std::net::{SocketAddr, ToSocketAddrs};
 use std::time::{Duration, Instant};
 use std::vec;
 use tokio::io::{read_exact, write_all, ReadExact, WriteAll};
-use tokio_tcp::{self, TcpStream};
+use tokio::net::{tcp, TcpStream};
 use tokio_timer::Delay;
 
 #[cfg(unix)]
@@ -42,7 +42,7 @@ pub enum Connect {
     #[state_machine_future(transitions(PreparingSsl))]
     ConnectingTcp {
         addrs: vec::IntoIter<SocketAddr>,
-        future: tokio_tcp::ConnectFuture,
+        future: tcp::ConnectFuture,
         timeout: Option<(Duration, Delay)>,
         params: ConnectParams,
         tls: TlsMode,

--- a/tokio-postgres/src/proto/connection.rs
+++ b/tokio-postgres/src/proto/connection.rs
@@ -4,7 +4,7 @@ use postgres_protocol::message::backend::Message;
 use postgres_protocol::message::frontend;
 use std::collections::{HashMap, VecDeque};
 use std::io;
-use tokio_codec::Framed;
+use tokio::codec::Framed;
 
 use proto::codec::PostgresCodec;
 use proto::copy_in::CopyInReceiver;

--- a/tokio-postgres/src/proto/handshake.rs
+++ b/tokio-postgres/src/proto/handshake.rs
@@ -9,7 +9,7 @@ use postgres_protocol::message::frontend;
 use state_machine_future::RentToOwn;
 use std::collections::HashMap;
 use std::io;
-use tokio_codec::Framed;
+use tokio::codec::Framed;
 
 use params::{ConnectParams, User};
 use proto::client::Client;

--- a/tokio-postgres/src/proto/socket.rs
+++ b/tokio-postgres/src/proto/socket.rs
@@ -2,7 +2,7 @@ use bytes::{Buf, BufMut};
 use futures::Poll;
 use std::io::{self, Read, Write};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_tcp::TcpStream;
+use tokio::net::TcpStream;
 
 #[cfg(unix)]
 use tokio_uds::UnixStream;

--- a/tokio-postgres/src/proto/socket.rs
+++ b/tokio-postgres/src/proto/socket.rs
@@ -1,7 +1,7 @@
 use bytes::{Buf, BufMut};
 use futures::Poll;
 use std::io::{self, Read, Write};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_tcp::TcpStream;
 
 #[cfg(unix)]

--- a/tokio-postgres/src/tls.rs
+++ b/tokio-postgres/src/tls.rs
@@ -2,7 +2,7 @@ use bytes::{Buf, BufMut};
 use futures::{Future, Poll};
 use std::error::Error;
 use std::io::{self, Read, Write};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 use proto;
 


### PR DESCRIPTION
This set of patches makes tokio-postgres and tokio-postgres-openssl ~~compatible with~~ utilize re-exports with the latest versions of tokio.

The only testing done on this is to ensure the tests pass locally.