### PR TITLE
add send to TlsStream traits to make sendable for tokio-postgres

### DIFF
--- a/tokio-postgres-openssl/src/lib.rs
+++ b/tokio-postgres-openssl/src/lib.rs
@@ -52,7 +52,7 @@ impl TlsConnect for TlsConnector {
         &self,
         domain: &str,
         socket: Socket,
-    ) -> Box<Future<Item = Box<TlsStream>, Error = Box<Error + Sync + Send>> + Sync + Send> {
+    ) -> Box<Future<Item = Box<TlsStream + Send>, Error = Box<Error + Sync + Send>> + Sync + Send> {
         let f = self
             .connector
             .configure()
@@ -67,7 +67,7 @@ impl TlsConnect for TlsConnector {
                 move |ssl| {
                     ssl.connect_async(&domain, socket)
                         .map(|s| {
-                            let s: Box<TlsStream> = Box::new(SslStream(s));
+                            let s: Box<TlsStream + Send> = Box::new(SslStream(s));
                             s
                         })
                         .map_err(|e| {

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -57,8 +57,8 @@ fn next_portal() -> String {
 
 pub enum TlsMode {
     None,
-    Prefer(Box<TlsConnect>),
-    Require(Box<TlsConnect>),
+    Prefer(Box<TlsConnect + Send>),
+    Require(Box<TlsConnect + Send>),
 }
 
 pub fn cancel_query(params: ConnectParams, tls: TlsMode, cancel_data: CancelData) -> CancelQuery {

--- a/tokio-postgres/src/proto/connect.rs
+++ b/tokio-postgres/src/proto/connect.rs
@@ -65,20 +65,20 @@ pub enum Connect {
     SendingSsl {
         future: WriteAll<Socket, Vec<u8>>,
         params: ConnectParams,
-        connector: Box<TlsConnect>,
+        connector: Box<TlsConnect + Send>,
         required: bool,
     },
     #[state_machine_future(transitions(ConnectingTls, Ready))]
     ReadingSsl {
         future: ReadExact<Socket, [u8; 1]>,
         params: ConnectParams,
-        connector: Box<TlsConnect>,
+        connector: Box<TlsConnect + Send>,
         required: bool,
     },
     #[state_machine_future(transitions(Ready))]
     ConnectingTls {
         future:
-            Box<Future<Item = Box<TlsStream>, Error = Box<StdError + Sync + Send>> + Sync + Send>,
+            Box<Future<Item = Box<TlsStream + Send>, Error = Box<StdError + Sync + Send>> + Sync + Send>,
         params: ConnectParams,
     },
     #[state_machine_future(ready)]

--- a/tokio-postgres/src/tls.rs
+++ b/tokio-postgres/src/tls.rs
@@ -55,7 +55,7 @@ pub trait TlsConnect {
         &self,
         domain: &str,
         socket: Socket,
-    ) -> Box<Future<Item = Box<TlsStream>, Error = Box<Error + Sync + Send>> + Sync + Send>;
+    ) -> Box<Future<Item = Box<TlsStream + Send>, Error = Box<Error + Sync + Send>> + Sync + Send>;
 }
 
 pub trait TlsStream: 'static + Sync + Send + AsyncRead + AsyncWrite {


### PR DESCRIPTION
These were previously implicitly not sendable, though there doesn't seem
to be a good reason for it (that I can see).

If there is a reason that I'm overlooking that would make this a bad idea, please let me know!