### PR TITLE
Remove now-gone with-openssl from docs metadata.

### DIFF
--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -17,7 +17,6 @@ features = [
     "with-geo-0.10",
     "with-serde_json-1",
     "with-uuid-0.6",
-    "with-openssl",
 ]
 
 [badges]


### PR DESCRIPTION
Trivial fix.