### PR TITLE
add derive(Clone) to tokio_postgres::Client

### DIFF
--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -44,6 +44,7 @@ where
     CancelQuery(CancelFuture::new(stream, tls_mode, cancel_data))
 }
 
+#[derive(Clone)]
 pub struct Client(proto::Client);
 
 impl Client {


### PR DESCRIPTION
This allows it to be shared among multiple futures.