### PR TITLE
Use relaxed memory ordering for next_statement / next_portal

### DIFF
--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -111,12 +111,12 @@ pub mod types;
 
 fn next_statement() -> String {
     static ID: AtomicUsize = AtomicUsize::new(0);
-    format!("s{}", ID.fetch_add(1, Ordering::SeqCst))
+    format!("s{}", ID.fetch_add(1, Ordering::Relaxed))
 }
 
 fn next_portal() -> String {
     static ID: AtomicUsize = AtomicUsize::new(0);
-    format!("p{}", ID.fetch_add(1, Ordering::SeqCst))
+    format!("p{}", ID.fetch_add(1, Ordering::Relaxed))
 }
 
 /// A convenience function which parses a connection string and connects to the database.


### PR DESCRIPTION
As far as I understood the code, no memory ordering is imposed on the next_statement / next_portal counters, they just need to be unique, so Ordering::Relaxed should be fine.

Rationale for this change:
I'm currently protoyping / benchmarking an application that can process a huge amount of "insert" statements into postgresql, using your tokio-postgres master branch. (Thank you again for implementing pipelining just in time, by the way!). 

I noticed that if I use many connections, my program has much higher throughput if I split it into multiple processes. This indicates some sort of global bottleneck in the hot path. Apart from memory allocations, the only global state (across connections) which I count pinpoint are these two counters.

[Ordering::Relaxed should be fine, at least reddit thinks so](https://www.reddit.com/r/rust/comments/aeii1i/is_memory_orderingrelaxed_sufficient_to_generate/). (I didn't mention rust-postgres in the discussion because I wasn't sure whether I should or whether it's relevant).

With just a pipeline of single "INSERT INTO table VALUES ... ON CONFLICT ... WHERE", I get roughtly the following numbers on my test data set (~10M rows, 8 GB). Note that this is "upserting" live data, so I can't just use COPY_IN:

1 process, 6 connections:
master branch@5b04594: 41884 inserts / second
relaxed branch: 42770 inserts / second
+ ~2% (no real effect, yet)

1 process, 12 connections:
master branch@5b04594: 43589 inserts / second
relaxed branch: 50922 inserts / second
+ ~17%

I also tried to [move the counters into the Client struct](https://github.com/kosta/rust-postgres/commits/no-static-ids), which was even faster for many connections but seemed slower for few connections. I guess that is due to more indirections, so I'm not sure that that branch is the right trade-off.

If you're interested, I will explore some more performance improvements as time permits. I want to make sure network and "disk" bandwidths are the real bottleneck when using this library :)

Let me know that you think.