### PR TITLE
Add legacy 'with-uuid-0.7' feature.

### DIFF
--- a/postgres-shared/Cargo.toml
+++ b/postgres-shared/Cargo.toml
@@ -15,6 +15,7 @@ with-rustc-serialize = ["rustc-serialize"]
 with-serde_json = ["serde_json"]
 with-time = ["time"]
 with-uuid = ["uuid"]
+"with-uuid-0.7" = ["uuid-07"]
 
 [dependencies]
 hex = "0.2"
@@ -30,3 +31,4 @@ rustc-serialize = { version = "0.3", optional = true }
 serde_json = { version = "1.0", optional = true }
 time = { version = "0.1.14", optional = true }
 uuid = { version = "0.5", optional = true }
+uuid-07 = { version = "0.7", package = "uuid", optional = true }

--- a/postgres-shared/src/types/mod.rs
+++ b/postgres-shared/src/types/mod.rs
@@ -70,6 +70,8 @@ where
 mod bit_vec;
 #[cfg(feature = "with-uuid")]
 mod uuid;
+#[cfg(feature = "with-uuid-0.7")]
+mod uuid_07;
 #[cfg(feature = "with-time")]
 mod time;
 #[cfg(feature = "with-rustc-serialize")]

--- a/postgres-shared/src/types/uuid_07.rs
+++ b/postgres-shared/src/types/uuid_07.rs
@@ -1,0 +1,26 @@
+extern crate uuid_07;
+
+use postgres_protocol::types;
+use self::uuid_07::Uuid;
+use std::error::Error;
+
+use types::{FromSql, ToSql, Type, IsNull, UUID};
+
+impl FromSql for Uuid {
+    fn from_sql(_: &Type, raw: &[u8]) -> Result<Uuid, Box<Error + Sync + Send>> {
+        let bytes = types::uuid_from_sql(raw)?;
+        Ok(Uuid::from_bytes(bytes))
+    }
+
+    accepts!(UUID);
+}
+
+impl ToSql for Uuid {
+    fn to_sql(&self, _: &Type, w: &mut Vec<u8>) -> Result<IsNull, Box<Error + Sync + Send>> {
+        types::uuid_to_sql(*self.as_bytes(), w);
+        Ok(IsNull::No)
+    }
+
+    accepts!(UUID);
+    to_sql_checked!();
+}

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -20,6 +20,7 @@ features = [
     "with-serde_json",
     "with-time",
     "with-uuid",
+    "with-uuid-0.7",
     "with-openssl",
     "with-native-tls",
 ]
@@ -46,6 +47,7 @@ with-rustc-serialize = ["postgres-shared/with-rustc-serialize"]
 with-serde_json = ["postgres-shared/with-serde_json"]
 with-time = ["postgres-shared/with-time"]
 with-uuid = ["postgres-shared/with-uuid"]
+"with-uuid-0.7" = ["postgres-shared/with-uuid-0.7"]
 
 with-openssl = ["openssl"]
 with-native-tls = ["native-tls"]


### PR DESCRIPTION
Note: this obviously can't go into master.

I based it on the `postgres-v0.15.2` tag, it could go into a `postgres-v0.15` branch.

I can do the small release preparation stuff as well for a patch release.

Closes #411 