### PR TITLE
Allow creating new io errors.

### DIFF
--- a/tokio-postgres/src/error/mod.rs
+++ b/tokio-postgres/src/error/mod.rs
@@ -485,7 +485,7 @@ impl Error {
     }
 
     #[cfg(feature = "runtime")]
-    pub(crate) fn connect(e: io::Error) -> Error {
+    pub fn connect(e: io::Error) -> Error {
         Error::new(Kind::Connect, Some(Box::new(e)))
     }
 }


### PR DESCRIPTION
bb8 needs to create TimedOut errors, ideally in the same type that tokio-postgres uses so I don't have to create a wrapper.