### PR TITLE
Add generic immutable interface.

### DIFF
--- a/postgres/src/client.rs
+++ b/postgres/src/client.rs
@@ -375,14 +375,10 @@ where
 /// A trait allowing abstraction over connections and transactions
 pub trait GenericClient {
     /// Like `Client::execute`.
-    fn execute<T>(&self, query: &T, params: &[&dyn ToSql]) -> Result<u64, Error>
-    where
-        T: ?Sized + ToStatement;
+    fn execute(&self, query: &str, params: &[&dyn ToSql]) -> Result<u64, Error>;
 
     /// Like `Client::query`.
-    fn query<T>(&self, query: &T, params: &[&dyn ToSql]) -> Result<Vec<Row>, Error>
-    where
-        T: ?Sized + ToStatement;
+    fn query(&self, query: &str, params: &[&dyn ToSql]) -> Result<Vec<Row>, Error>;
 
     /// Like `Client::prepare`.
     fn prepare(&self, query: &str) -> Result<Statement, Error>;
@@ -392,16 +388,10 @@ pub trait GenericClient {
 }
 
 impl GenericClient for Client {
-    fn execute<T>(&self, query: &T, params: &[&dyn ToSql]) -> Result<u64, Error>
-    where
-        T: ?Sized + ToStatement,
-    {
+    fn execute(&self, query: &str, params: &[&dyn ToSql]) -> Result<u64, Error> {
         self.execute(query, params)
     }
-    fn query<T>(&self, query: &T, params: &[&dyn ToSql]) -> Result<Vec<Row>, Error>
-    where
-        T: ?Sized + ToStatement,
-    {
+    fn query(&self, query: &str, params: &[&dyn ToSql]) -> Result<Vec<Row>, Error> {
         self.query(query, params)
     }
     fn prepare(&self, query: &str) -> Result<Statement, Error> {

--- a/postgres/src/test.rs
+++ b/postgres/src/test.rs
@@ -6,7 +6,7 @@ use super::*;
 
 #[test]
 fn prepare() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
 
     let stmt = client.prepare("SELECT 1::INT, $1::TEXT").unwrap();
     assert_eq!(stmt.params(), &[Type::TEXT]);
@@ -17,7 +17,7 @@ fn prepare() {
 
 #[test]
 fn query_prepared() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
 
     let stmt = client.prepare("SELECT $1::TEXT").unwrap();
     let rows = client.query(&stmt, &[&"hello"]).unwrap();
@@ -27,7 +27,7 @@ fn query_prepared() {
 
 #[test]
 fn query_unprepared() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
 
     let rows = client.query("SELECT $1::TEXT", &[&"hello"]).unwrap();
     assert_eq!(rows.len(), 1);
@@ -36,13 +36,13 @@ fn query_unprepared() {
 
 #[test]
 fn transaction_commit() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
 
     client
         .simple_query("CREATE TEMPORARY TABLE foo (id SERIAL PRIMARY KEY)")
         .unwrap();
 
-    let mut transaction = client.transaction().unwrap();
+    let transaction = client.transaction().unwrap();
 
     transaction
         .execute("INSERT INTO foo DEFAULT VALUES", &[])
@@ -57,13 +57,13 @@ fn transaction_commit() {
 
 #[test]
 fn transaction_rollback() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
 
     client
         .simple_query("CREATE TEMPORARY TABLE foo (id SERIAL PRIMARY KEY)")
         .unwrap();
 
-    let mut transaction = client.transaction().unwrap();
+    let transaction = client.transaction().unwrap();
 
     transaction
         .execute("INSERT INTO foo DEFAULT VALUES", &[])
@@ -77,13 +77,13 @@ fn transaction_rollback() {
 
 #[test]
 fn transaction_drop() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
 
     client
         .simple_query("CREATE TEMPORARY TABLE foo (id SERIAL PRIMARY KEY)")
         .unwrap();
 
-    let mut transaction = client.transaction().unwrap();
+    let transaction = client.transaction().unwrap();
 
     transaction
         .execute("INSERT INTO foo DEFAULT VALUES", &[])
@@ -97,19 +97,19 @@ fn transaction_drop() {
 
 #[test]
 fn nested_transactions() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
 
     client
         .simple_query("CREATE TEMPORARY TABLE foo (id INT PRIMARY KEY)")
         .unwrap();
 
-    let mut transaction = client.transaction().unwrap();
+    let transaction = client.transaction().unwrap();
 
     transaction
         .execute("INSERT INTO foo (id) VALUES (1)", &[])
         .unwrap();
 
-    let mut transaction2 = transaction.transaction().unwrap();
+    let transaction2 = transaction.transaction().unwrap();
 
     transaction2
         .execute("INSERT INTO foo (id) VALUES (2)", &[])
@@ -123,13 +123,13 @@ fn nested_transactions() {
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].get::<_, i32>(0), 1);
 
-    let mut transaction3 = transaction.transaction().unwrap();
+    let transaction3 = transaction.transaction().unwrap();
 
     transaction3
         .execute("INSERT INTO foo (id) VALUES(3)", &[])
         .unwrap();
 
-    let mut transaction4 = transaction3.transaction().unwrap();
+    let transaction4 = transaction3.transaction().unwrap();
 
     transaction4
         .execute("INSERT INTO foo (id) VALUES(4)", &[])
@@ -148,7 +148,7 @@ fn nested_transactions() {
 
 #[test]
 fn copy_in() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
 
     client
         .simple_query("CREATE TEMPORARY TABLE foo (id INT, name TEXT)")
@@ -175,7 +175,7 @@ fn copy_in() {
 
 #[test]
 fn copy_out() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
 
     client
         .simple_query(
@@ -198,7 +198,7 @@ fn copy_out() {
 
 #[test]
 fn portal() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
 
     client
         .simple_query(
@@ -207,7 +207,7 @@ fn portal() {
         )
         .unwrap();
 
-    let mut transaction = client.transaction().unwrap();
+    let transaction = client.transaction().unwrap();
 
     let portal = transaction
         .bind("SELECT * FROM foo ORDER BY id", &[])

--- a/postgres/src/to_statement.rs
+++ b/postgres/src/to_statement.rs
@@ -14,13 +14,13 @@ mod sealed {
 /// This trait is "sealed" and cannot be implemented by anything outside this crate.
 pub trait ToStatement: sealed::Sealed {
     #[doc(hidden)]
-    fn __statement(&self, client: &mut Client) -> Result<Statement, Error>;
+    fn __statement(&self, client: &Client) -> Result<Statement, Error>;
 }
 
 impl sealed::Sealed for str {}
 
 impl ToStatement for str {
-    fn __statement(&self, client: &mut Client) -> Result<Statement, Error> {
+    fn __statement(&self, client: &Client) -> Result<Statement, Error> {
         client.prepare(self)
     }
 }
@@ -28,7 +28,7 @@ impl ToStatement for str {
 impl sealed::Sealed for Statement {}
 
 impl ToStatement for Statement {
-    fn __statement(&self, _: &mut Client) -> Result<Statement, Error> {
+    fn __statement(&self, _: &Client) -> Result<Statement, Error> {
         Ok(self.clone())
     }
 }

--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -187,15 +187,11 @@ impl<'a> Transaction<'a> {
 }
 
 impl<'a> GenericClient for Transaction<'a> {
-    fn execute<T>(&self, query: &T, params: &[&dyn ToSql]) -> Result<u64, Error>
-    where
-        T: ?Sized + ToStatement,
+    fn execute(&self, query: &str, params: &[&dyn ToSql]) -> Result<u64, Error>
     {
         self.execute(query, params)
     }
-    fn query<T>(&self, query: &T, params: &[&dyn ToSql]) -> Result<Vec<Row>, Error>
-    where
-        T: ?Sized + ToStatement,
+    fn query(&self, query: &str, params: &[&dyn ToSql]) -> Result<Vec<Row>, Error>
     {
         self.query(query, params)
     }

--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -187,12 +187,10 @@ impl<'a> Transaction<'a> {
 }
 
 impl<'a> GenericClient for Transaction<'a> {
-    fn execute(&self, query: &str, params: &[&dyn ToSql]) -> Result<u64, Error>
-    {
+    fn execute(&self, query: &str, params: &[&dyn ToSql]) -> Result<u64, Error> {
         self.execute(query, params)
     }
-    fn query(&self, query: &str, params: &[&dyn ToSql]) -> Result<Vec<Row>, Error>
-    {
+    fn query(&self, query: &str, params: &[&dyn ToSql]) -> Result<Vec<Row>, Error> {
         self.query(query, params)
     }
     fn prepare(&self, query: &str) -> Result<Statement, Error> {

--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -1,12 +1,13 @@
 use fallible_iterator::FallibleIterator;
 use futures::Future;
+use std::cell::RefCell;
 use std::io::Read;
 use tokio_postgres::types::{ToSql, Type};
 use tokio_postgres::{Error, Row, SimpleQueryMessage};
 
 use crate::{
-    Client, CopyOutReader, Portal, QueryIter, QueryPortalIter, SimpleQueryIter, Statement,
-    ToStatement,
+    Client, CopyOutReader, GenericClient, Portal, QueryIter, QueryPortalIter, SimpleQueryIter,
+    Statement, ToStatement,
 };
 
 /// A representation of a PostgreSQL database transaction.
@@ -14,36 +15,43 @@ use crate::{
 /// Transactions will implicitly roll back by default when dropped. Use the `commit` method to commit the changes made
 /// in the transaction. Transactions can be nested, with inner transactions implemented via safepoints.
 pub struct Transaction<'a> {
-    client: &'a mut Client,
+    client: &'a Client,
+    state: RefCell<TransactionState>,
+}
+
+struct TransactionState {
     depth: u32,
     done: bool,
 }
 
 impl<'a> Drop for Transaction<'a> {
     fn drop(&mut self) {
-        if !self.done {
+        if !self.state.borrow().done {
             let _ = self.rollback_inner();
         }
     }
 }
 
 impl<'a> Transaction<'a> {
-    pub(crate) fn new(client: &'a mut Client) -> Transaction<'a> {
+    pub(crate) fn new(client: &'a Client) -> Transaction<'a> {
         Transaction {
             client,
-            depth: 0,
-            done: false,
+            state: RefCell::new(TransactionState {
+                depth: 0,
+                done: false,
+            }),
         }
     }
 
     /// Consumes the transaction, committing all changes made within it.
-    pub fn commit(mut self) -> Result<(), Error> {
-        self.done = true;
-        if self.depth == 0 {
+    pub fn commit(self) -> Result<(), Error> {
+        let mut state = self.state.borrow_mut();
+        state.done = true;
+        if state.depth == 0 {
             self.client.simple_query("COMMIT")?;
         } else {
             self.client
-                .simple_query(&format!("RELEASE sp{}", self.depth))?;
+                .simple_query(&format!("RELEASE sp{}", &state.depth))?;
         }
         Ok(())
     }
@@ -51,33 +59,34 @@ impl<'a> Transaction<'a> {
     /// Rolls the transaction back, discarding all changes made within it.
     ///
     /// This is equivalent to `Transaction`'s `Drop` implementation, but provides any error encountered to the caller.
-    pub fn rollback(mut self) -> Result<(), Error> {
-        self.done = true;
+    pub fn rollback(self) -> Result<(), Error> {
+        self.state.borrow_mut().done = true;
         self.rollback_inner()
     }
 
-    fn rollback_inner(&mut self) -> Result<(), Error> {
-        if self.depth == 0 {
+    fn rollback_inner(&self) -> Result<(), Error> {
+        let state = self.state.borrow_mut();
+        if state.depth == 0 {
             self.client.simple_query("ROLLBACK")?;
         } else {
             self.client
-                .simple_query(&format!("ROLLBACK TO sp{}", self.depth))?;
+                .simple_query(&format!("ROLLBACK TO sp{}", &state.depth))?;
         }
         Ok(())
     }
 
     /// Like `Client::prepare`.
-    pub fn prepare(&mut self, query: &str) -> Result<Statement, Error> {
+    pub fn prepare(&self, query: &str) -> Result<Statement, Error> {
         self.client.prepare(query)
     }
 
     /// Like `Client::prepare_typed`.
-    pub fn prepare_typed(&mut self, query: &str, types: &[Type]) -> Result<Statement, Error> {
+    pub fn prepare_typed(&self, query: &str, types: &[Type]) -> Result<Statement, Error> {
         self.client.prepare_typed(query, types)
     }
 
     /// Like `Client::execute`.
-    pub fn execute<T>(&mut self, query: &T, params: &[&dyn ToSql]) -> Result<u64, Error>
+    pub fn execute<T>(&self, query: &T, params: &[&dyn ToSql]) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement,
     {
@@ -85,7 +94,7 @@ impl<'a> Transaction<'a> {
     }
 
     /// Like `Client::query`.
-    pub fn query<T>(&mut self, query: &T, params: &[&dyn ToSql]) -> Result<Vec<Row>, Error>
+    pub fn query<T>(&self, query: &T, params: &[&dyn ToSql]) -> Result<Vec<Row>, Error>
     where
         T: ?Sized + ToStatement,
     {
@@ -93,11 +102,7 @@ impl<'a> Transaction<'a> {
     }
 
     /// Like `Client::query_iter`.
-    pub fn query_iter<T>(
-        &mut self,
-        query: &T,
-        params: &[&dyn ToSql],
-    ) -> Result<QueryIter<'_>, Error>
+    pub fn query_iter<T>(&self, query: &T, params: &[&dyn ToSql]) -> Result<QueryIter<'_>, Error>
     where
         T: ?Sized + ToStatement,
     {
@@ -114,41 +119,36 @@ impl<'a> Transaction<'a> {
     /// # Panics
     ///
     /// Panics if the number of parameters provided does not match the number expected.
-    pub fn bind<T>(&mut self, query: &T, params: &[&dyn ToSql]) -> Result<Portal, Error>
+    pub fn bind<T>(&self, query: &T, params: &[&dyn ToSql]) -> Result<Portal, Error>
     where
         T: ?Sized + ToStatement,
     {
-        let statement = query.__statement(&mut self.client)?;
-        self.client.get_mut().bind(&statement, params).wait()
+        let statement = query.__statement(&self.client)?;
+        self.client.get_ref().bind(&statement, params).wait()
     }
 
     /// Continues execution of a portal, returning the next set of rows.
     ///
     /// Unlike `query`, portals can be incrementally evaluated by limiting the number of rows returned in each call to
     /// `query_portal`. If the requested number is negative or 0, all remaining rows will be returned.
-    pub fn query_portal(&mut self, portal: &Portal, max_rows: i32) -> Result<Vec<Row>, Error> {
+    pub fn query_portal(&self, portal: &Portal, max_rows: i32) -> Result<Vec<Row>, Error> {
         self.query_portal_iter(portal, max_rows)?.collect()
     }
 
     /// Like `query_portal`, except that it returns a fallible iterator over the resulting rows rather than buffering
     /// the entire response in memory.
     pub fn query_portal_iter(
-        &mut self,
+        &self,
         portal: &Portal,
         max_rows: i32,
     ) -> Result<QueryPortalIter<'_>, Error> {
         Ok(QueryPortalIter::new(
-            self.client.get_mut().query_portal(&portal, max_rows),
+            self.client.get_ref().query_portal(&portal, max_rows),
         ))
     }
 
     /// Like `Client::copy_in`.
-    pub fn copy_in<T, R>(
-        &mut self,
-        query: &T,
-        params: &[&dyn ToSql],
-        reader: R,
-    ) -> Result<u64, Error>
+    pub fn copy_in<T, R>(&self, query: &T, params: &[&dyn ToSql], reader: R) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement,
         R: Read,
@@ -157,11 +157,7 @@ impl<'a> Transaction<'a> {
     }
 
     /// Like `Client::copy_out`.
-    pub fn copy_out<T>(
-        &mut self,
-        query: &T,
-        params: &[&dyn ToSql],
-    ) -> Result<CopyOutReader<'_>, Error>
+    pub fn copy_out<T>(&self, query: &T, params: &[&dyn ToSql]) -> Result<CopyOutReader<'_>, Error>
     where
         T: ?Sized + ToStatement,
     {
@@ -169,24 +165,44 @@ impl<'a> Transaction<'a> {
     }
 
     /// Like `Client::simple_query`.
-    pub fn simple_query(&mut self, query: &str) -> Result<Vec<SimpleQueryMessage>, Error> {
+    pub fn simple_query(&self, query: &str) -> Result<Vec<SimpleQueryMessage>, Error> {
         self.client.simple_query(query)
     }
 
     /// Like `Client::simple_query_iter`.
-    pub fn simple_query_iter(&mut self, query: &str) -> Result<SimpleQueryIter<'_>, Error> {
+    pub fn simple_query_iter(&self, query: &str) -> Result<SimpleQueryIter<'_>, Error> {
         self.client.simple_query_iter(query)
     }
 
     /// Like `Client::transaction`.
-    pub fn transaction(&mut self) -> Result<Transaction<'_>, Error> {
-        let depth = self.depth + 1;
+    pub fn transaction(&self) -> Result<Transaction<'_>, Error> {
+        let depth = self.state.borrow().depth + 1;
         self.client
             .simple_query(&format!("SAVEPOINT sp{}", depth))?;
         Ok(Transaction {
             client: self.client,
-            depth,
-            done: false,
+            state: RefCell::new(TransactionState { depth, done: false }),
         })
+    }
+}
+
+impl<'a> GenericClient for Transaction<'a> {
+    fn execute<T>(&self, query: &T, params: &[&dyn ToSql]) -> Result<u64, Error>
+    where
+        T: ?Sized + ToStatement,
+    {
+        self.execute(query, params)
+    }
+    fn query<T>(&self, query: &T, params: &[&dyn ToSql]) -> Result<Vec<Row>, Error>
+    where
+        T: ?Sized + ToStatement,
+    {
+        self.query(query, params)
+    }
+    fn prepare(&self, query: &str) -> Result<Statement, Error> {
+        self.prepare(query)
+    }
+    fn transaction(&self) -> Result<Transaction<'_>, Error> {
+        self.transaction()
     }
 }

--- a/tokio-postgres-native-tls/src/test.rs
+++ b/tokio-postgres-native-tls/src/test.rs
@@ -20,7 +20,7 @@ where
     let handshake = TcpStream::connect(&"127.0.0.1:5433".parse().unwrap())
         .map_err(|e| panic!("{}", e))
         .and_then(|s| builder.connect_raw(s, tls));
-    let (mut client, connection) = runtime.block_on(handshake).unwrap();
+    let (client, connection) = runtime.block_on(handshake).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 
@@ -96,7 +96,7 @@ fn runtime() {
         "host=localhost port=5433 user=postgres sslmode=require",
         connector,
     );
-    let (mut client, connection) = runtime.block_on(connect).unwrap();
+    let (client, connection) = runtime.block_on(connect).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 

--- a/tokio-postgres-openssl/src/test.rs
+++ b/tokio-postgres-openssl/src/test.rs
@@ -18,7 +18,7 @@ where
     let handshake = TcpStream::connect(&"127.0.0.1:5433".parse().unwrap())
         .map_err(|e| panic!("{}", e))
         .and_then(|s| builder.connect_raw(s, tls));
-    let (mut client, connection) = runtime.block_on(handshake).unwrap();
+    let (client, connection) = runtime.block_on(handshake).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 
@@ -81,7 +81,7 @@ fn runtime() {
         "host=localhost port=5433 user=postgres sslmode=require",
         connector,
     );
-    let (mut client, connection) = runtime.block_on(connect).unwrap();
+    let (client, connection) = runtime.block_on(connect).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -177,7 +177,7 @@ impl Client {
     ///
     /// Prepared statements can be executed repeatedly, and may contain query parameters (indicated by `$1`, `$2`, etc),
     /// which are set when executed. Prepared statements can only be used with the connection that created them.
-    pub fn prepare(&mut self, query: &str) -> impls::Prepare {
+    pub fn prepare(&self, query: &str) -> impls::Prepare {
         self.prepare_typed(query, &[])
     }
 
@@ -185,7 +185,7 @@ impl Client {
     ///
     /// The list of types may be smaller than the number of parameters - the types of the remaining parameters will be
     /// inferred. For example, `client.prepare_typed(query, &[])` is equivalent to `client.prepare(query)`.
-    pub fn prepare_typed(&mut self, query: &str, param_types: &[Type]) -> impls::Prepare {
+    pub fn prepare_typed(&self, query: &str, param_types: &[Type]) -> impls::Prepare {
         impls::Prepare(self.0.prepare(next_statement(), query, param_types))
     }
 
@@ -196,7 +196,7 @@ impl Client {
     /// # Panics
     ///
     /// Panics if the number of parameters provided does not match the number expected.
-    pub fn execute(&mut self, statement: &Statement, params: &[&dyn ToSql]) -> impls::Execute {
+    pub fn execute(&self, statement: &Statement, params: &[&dyn ToSql]) -> impls::Execute {
         impls::Execute(self.0.execute(&statement.0, params))
     }
 
@@ -205,7 +205,7 @@ impl Client {
     /// # Panics
     ///
     /// Panics if the number of parameters provided does not match the number expected.
-    pub fn query(&mut self, statement: &Statement, params: &[&dyn ToSql]) -> impls::Query {
+    pub fn query(&self, statement: &Statement, params: &[&dyn ToSql]) -> impls::Query {
         impls::Query(self.0.query(&statement.0, params))
     }
 
@@ -217,7 +217,7 @@ impl Client {
     /// # Panics
     ///
     /// Panics if the number of parameters provided does not match the number expected.
-    pub fn bind(&mut self, statement: &Statement, params: &[&dyn ToSql]) -> impls::Bind {
+    pub fn bind(&self, statement: &Statement, params: &[&dyn ToSql]) -> impls::Bind {
         impls::Bind(self.0.bind(&statement.0, next_portal(), params))
     }
 
@@ -225,7 +225,7 @@ impl Client {
     ///
     /// Unlike `query`, portals can be incrementally evaluated by limiting the number of rows returned in each call to
     /// query_portal. If the requested number is negative or 0, all rows will be returned.
-    pub fn query_portal(&mut self, portal: &Portal, max_rows: i32) -> impls::QueryPortal {
+    pub fn query_portal(&self, portal: &Portal, max_rows: i32) -> impls::QueryPortal {
         impls::QueryPortal(self.0.query_portal(&portal.0, max_rows))
     }
 
@@ -234,7 +234,7 @@ impl Client {
     /// The data in the provided stream is passed along to the server verbatim; it is the caller's responsibility to
     /// ensure it uses the proper format.
     pub fn copy_in<S>(
-        &mut self,
+        &self,
         statement: &Statement,
         params: &[&dyn ToSql],
         stream: S,
@@ -250,7 +250,7 @@ impl Client {
     }
 
     /// Executes a `COPY TO STDOUT` statement, returning a stream of the resulting data.
-    pub fn copy_out(&mut self, statement: &Statement, params: &[&dyn ToSql]) -> impls::CopyOut {
+    pub fn copy_out(&self, statement: &Statement, params: &[&dyn ToSql]) -> impls::CopyOut {
         impls::CopyOut(self.0.copy_out(&statement.0, params))
     }
 
@@ -267,7 +267,7 @@ impl Client {
     /// Prepared statements should be use for any query which contains user-specified data, as they provided the
     /// functionality to safely imbed that data in the request. Do not form statements via string concatenation and pass
     /// them to this method!
-    pub fn simple_query(&mut self, query: &str) -> impls::SimpleQuery {
+    pub fn simple_query(&self, query: &str) -> impls::SimpleQuery {
         impls::SimpleQuery(self.0.simple_query(query))
     }
 
@@ -289,7 +289,7 @@ impl Client {
     ///
     /// Unlike the other futures created by a client, this future is *not* atomic with respect to other requests. If you
     /// attempt to execute it concurrently with other futures created by the same connection, they will interleave!
-    pub fn build_transaction(&mut self) -> TransactionBuilder {
+    pub fn build_transaction(&self) -> TransactionBuilder {
         TransactionBuilder(self.0.clone())
     }
 
@@ -300,7 +300,7 @@ impl Client {
     ///
     /// Requires the `runtime` Cargo feature (enabled by default).
     #[cfg(feature = "runtime")]
-    pub fn cancel_query<T>(&mut self, make_tls_mode: T) -> impls::CancelQuery<T>
+    pub fn cancel_query<T>(&self, make_tls_mode: T) -> impls::CancelQuery<T>
     where
         T: MakeTlsConnect<Socket>,
     {
@@ -309,7 +309,7 @@ impl Client {
 
     /// Like `cancel_query`, but uses a stream which is already connected to the server rather than opening a new
     /// connection itself.
-    pub fn cancel_query_raw<S, T>(&mut self, stream: S, tls_mode: T) -> impls::CancelQueryRaw<S, T>
+    pub fn cancel_query_raw<S, T>(&self, stream: S, tls_mode: T) -> impls::CancelQueryRaw<S, T>
     where
         S: AsyncRead + AsyncWrite,
         T: TlsConnect<S>,
@@ -330,7 +330,7 @@ impl Client {
     /// example, this can be used by a connection pool to ensure that all work done by one checkout is done before
     /// making the client available for a new request. Otherwise, any non-completed work from the first request could
     /// interleave with the second.
-    pub fn poll_idle(&mut self) -> Poll<(), Error> {
+    pub fn poll_idle(&self) -> Poll<(), Error> {
         self.0.poll_idle()
     }
 }

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -36,7 +36,7 @@ fn smoke_test(s: &str) {
     let mut runtime = Runtime::new().unwrap();
 
     let handshake = connect(s);
-    let (mut client, connection) = runtime.block_on(handshake).unwrap();
+    let (client, connection) = runtime.block_on(handshake).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -139,7 +139,7 @@ fn pipelined_prepare() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -157,7 +157,7 @@ fn insert_select() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -193,7 +193,7 @@ fn query_portal() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -237,7 +237,7 @@ fn cancel_query_raw() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -271,7 +271,7 @@ fn custom_enum() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -309,7 +309,7 @@ fn custom_domain() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -336,7 +336,7 @@ fn custom_array() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -359,7 +359,7 @@ fn custom_composite() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -400,7 +400,7 @@ fn custom_range() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -430,7 +430,7 @@ fn custom_simple() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -447,7 +447,7 @@ fn notifications() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, mut connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, mut connection) = runtime.block_on(connect("user=postgres")).unwrap();
 
     let (tx, rx) = mpsc::unbounded();
     let connection = future::poll_fn(move || {
@@ -491,7 +491,7 @@ fn transaction_commit() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -532,7 +532,7 @@ fn transaction_abort() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -574,7 +574,7 @@ fn copy_in() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -621,7 +621,7 @@ fn copy_in_error() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -664,7 +664,7 @@ fn copy_out() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -697,7 +697,7 @@ fn transaction_builder_around_moved_client() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -715,7 +715,7 @@ fn transaction_builder_around_moved_client() {
                 .prepare("INSERT INTO transaction_foo (name) VALUES ($1), ($2)")
                 .map(|statement| (client, statement))
         })
-        .and_then(|(mut client, statement)| {
+        .and_then(|(client, statement)| {
             client
                 .query(&statement, &[&"jim", &"joe"])
                 .collect()
@@ -723,7 +723,7 @@ fn transaction_builder_around_moved_client() {
         });
 
     let transaction = transaction_builder.build(work);
-    let mut client = runtime.block_on(transaction).unwrap();
+    let client = runtime.block_on(transaction).unwrap();
 
     let data = runtime
         .block_on(
@@ -743,7 +743,7 @@ fn simple_query() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -821,7 +821,7 @@ fn poll_idle_running() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 
@@ -872,7 +872,7 @@ fn poll_idle_new() {
     let _ = env_logger::try_init();
     let mut runtime = Runtime::new().unwrap();
 
-    let (mut client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
+    let (client, connection) = runtime.block_on(connect("user=postgres")).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.handle().spawn(connection).unwrap();
 

--- a/tokio-postgres/tests/test/runtime.rs
+++ b/tokio-postgres/tests/test/runtime.rs
@@ -8,7 +8,7 @@ use tokio_postgres::NoTls;
 fn smoke_test(s: &str) {
     let mut runtime = Runtime::new().unwrap();
     let connect = tokio_postgres::connect(s, NoTls);
-    let (mut client, connection) = runtime.block_on(connect).unwrap();
+    let (client, connection) = runtime.block_on(connect).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 
@@ -76,7 +76,7 @@ fn cancel_query() {
     let mut runtime = Runtime::new().unwrap();
 
     let connect = tokio_postgres::connect("host=localhost port=5433 user=postgres", NoTls);
-    let (mut client, connection) = runtime.block_on(connect).unwrap();
+    let (client, connection) = runtime.block_on(connect).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 

--- a/tokio-postgres/tests/test/types/mod.rs
+++ b/tokio-postgres/tests/test/types/mod.rs
@@ -34,7 +34,7 @@ where
     let mut runtime = Runtime::new().unwrap();
 
     let handshake = connect("user=postgres");
-    let (mut client, connection) = runtime.block_on(handshake).unwrap();
+    let (client, connection) = runtime.block_on(handshake).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 
@@ -192,7 +192,7 @@ fn test_borrowed_text() {
     let mut runtime = Runtime::new().unwrap();
 
     let handshake = connect("user=postgres");
-    let (mut client, connection) = runtime.block_on(handshake).unwrap();
+    let (client, connection) = runtime.block_on(handshake).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 
@@ -209,7 +209,7 @@ fn test_bpchar_params() {
     let mut runtime = Runtime::new().unwrap();
 
     let handshake = connect("user=postgres");
-    let (mut client, connection) = runtime.block_on(handshake).unwrap();
+    let (client, connection) = runtime.block_on(handshake).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 
@@ -244,7 +244,7 @@ fn test_citext_params() {
     let mut runtime = Runtime::new().unwrap();
 
     let handshake = connect("user=postgres");
-    let (mut client, connection) = runtime.block_on(handshake).unwrap();
+    let (client, connection) = runtime.block_on(handshake).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 
@@ -292,7 +292,7 @@ fn test_borrowed_bytea() {
     let mut runtime = Runtime::new().unwrap();
 
     let handshake = connect("user=postgres");
-    let (mut client, connection) = runtime.block_on(handshake).unwrap();
+    let (client, connection) = runtime.block_on(handshake).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 
@@ -352,7 +352,7 @@ where
     let mut runtime = Runtime::new().unwrap();
 
     let handshake = connect("user=postgres");
-    let (mut client, connection) = runtime.block_on(handshake).unwrap();
+    let (client, connection) = runtime.block_on(handshake).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 
@@ -379,7 +379,7 @@ fn test_pg_database_datname() {
     let mut runtime = Runtime::new().unwrap();
 
     let handshake = connect("user=postgres");
-    let (mut client, connection) = runtime.block_on(handshake).unwrap();
+    let (client, connection) = runtime.block_on(handshake).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 
@@ -395,7 +395,7 @@ fn test_slice() {
     let mut runtime = Runtime::new().unwrap();
 
     let handshake = connect("user=postgres");
-    let (mut client, connection) = runtime.block_on(handshake).unwrap();
+    let (client, connection) = runtime.block_on(handshake).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 
@@ -427,7 +427,7 @@ fn test_slice_wrong_type() {
     let mut runtime = Runtime::new().unwrap();
 
     let handshake = connect("user=postgres");
-    let (mut client, connection) = runtime.block_on(handshake).unwrap();
+    let (client, connection) = runtime.block_on(handshake).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 
@@ -455,7 +455,7 @@ fn test_slice_range() {
     let mut runtime = Runtime::new().unwrap();
 
     let handshake = connect("user=postgres");
-    let (mut client, connection) = runtime.block_on(handshake).unwrap();
+    let (client, connection) = runtime.block_on(handshake).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 
@@ -512,7 +512,7 @@ fn domain() {
     let mut runtime = Runtime::new().unwrap();
 
     let handshake = connect("user=postgres");
-    let (mut client, connection) = runtime.block_on(handshake).unwrap();
+    let (client, connection) = runtime.block_on(handshake).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 
@@ -543,7 +543,7 @@ fn composite() {
     let mut runtime = Runtime::new().unwrap();
 
     let handshake = connect("user=postgres");
-    let (mut client, connection) = runtime.block_on(handshake).unwrap();
+    let (client, connection) = runtime.block_on(handshake).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 
@@ -580,7 +580,7 @@ fn enum_() {
     let mut runtime = Runtime::new().unwrap();
 
     let handshake = connect("user=postgres");
-    let (mut client, connection) = runtime.block_on(handshake).unwrap();
+    let (client, connection) = runtime.block_on(handshake).unwrap();
     let connection = connection.map_err(|e| panic!("{}", e));
     runtime.spawn(connection);
 


### PR DESCRIPTION
I added a GenericClient trait over Client and Transaction, and replaced &mut with & to support the same style of trait as in previous versions.

I'm using GenericConnection in the old versions and I just wanted to try to add it back. I just named it GenericClient to match the new Client struct.

Thoughts?

Related issue:
#329 