### PR TITLE
Send response messages in blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ members = [
     "tokio-postgres-native-tls",
     "tokio-postgres-openssl",
 ]
+
+[profile.release]
+debug = 2

--- a/tokio-postgres/src/proto/codec.rs
+++ b/tokio-postgres/src/proto/codec.rs
@@ -1,4 +1,5 @@
 use bytes::{Buf, BytesMut};
+use fallible_iterator::FallibleIterator;
 use postgres_protocol::message::backend;
 use postgres_protocol::message::frontend::CopyData;
 use std::io;
@@ -7,6 +8,31 @@ use tokio_codec::{Decoder, Encoder};
 pub enum FrontendMessage {
     Raw(Vec<u8>),
     CopyData(CopyData<Box<dyn Buf + Send>>),
+}
+
+pub enum BackendMessage {
+    Normal {
+        messages: BackendMessages,
+        request_complete: bool,
+    },
+    Async(backend::Message),
+}
+
+pub struct BackendMessages(BytesMut);
+
+impl BackendMessages {
+    pub fn empty() -> BackendMessages {
+        BackendMessages(BytesMut::new())
+    }
+}
+
+impl FallibleIterator for BackendMessages {
+    type Item = backend::Message;
+    type Error = io::Error;
+
+    fn next(&mut self) -> io::Result<Option<backend::Message>> {
+        backend::Message::parse(&mut self.0)
+    }
 }
 
 pub struct PostgresCodec;
@@ -26,10 +52,48 @@ impl Encoder for PostgresCodec {
 }
 
 impl Decoder for PostgresCodec {
-    type Item = backend::Message;
+    type Item = BackendMessage;
     type Error = io::Error;
 
-    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<backend::Message>, io::Error> {
-        backend::Message::parse(src)
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<BackendMessage>, io::Error> {
+        let mut idx = 0;
+        let mut request_complete = false;
+
+        while let Some(header) = backend::Header::parse(&src[idx..])? {
+            let len = header.len() as usize + 1;
+            if src[idx..].len() < len {
+                break;
+            }
+
+            match header.tag() {
+                backend::NOTICE_RESPONSE_TAG
+                | backend::NOTIFICATION_RESPONSE_TAG
+                | backend::PARAMETER_STATUS_TAG => {
+                    if idx == 0 {
+                        let message = backend::Message::parse(src)?.unwrap();
+                        return Ok(Some(BackendMessage::Async(message)));
+                    } else {
+                        break;
+                    }
+                }
+                _ => {}
+            }
+
+            idx += len;
+
+            if header.tag() == backend::READY_FOR_QUERY_TAG {
+                request_complete = true;
+                break;
+            }
+        }
+
+        if idx == 0 {
+            Ok(None)
+        } else {
+            Ok(Some(BackendMessage::Normal {
+                messages: BackendMessages(src.split_to(idx)),
+                request_complete,
+            }))
+        }
     }
 }

--- a/tokio-postgres/src/proto/mod.rs
+++ b/tokio-postgres/src/proto/mod.rs
@@ -1,13 +1,3 @@
-macro_rules! try_ready_receive {
-    ($e:expr) => {
-        match $e {
-            Ok(::futures::Async::Ready(v)) => v,
-            Ok(::futures::Async::NotReady) => return Ok(::futures::Async::NotReady),
-            Err(()) => unreachable!("mpsc::Receiver doesn't return errors"),
-        }
-    };
-}
-
 macro_rules! try_ready_closed {
     ($e:expr) => {
         match $e {
@@ -40,6 +30,7 @@ mod maybe_tls_stream;
 mod portal;
 mod prepare;
 mod query;
+mod responses;
 mod simple_query;
 mod statement;
 mod tls;

--- a/tokio-postgres/src/proto/query.rs
+++ b/tokio-postgres/src/proto/query.rs
@@ -1,10 +1,10 @@
-use futures::sync::mpsc;
 use futures::{Async, Poll, Stream};
 use postgres_protocol::message::backend::Message;
 use std::mem;
 
 use crate::proto::client::{Client, PendingRequest};
 use crate::proto::portal::Portal;
+use crate::proto::responses::Responses;
 use crate::proto::statement::Statement;
 use crate::{Error, Row};
 
@@ -31,7 +31,7 @@ enum State<T> {
         statement: T,
     },
     ReadingResponse {
-        receiver: mpsc::Receiver<Message>,
+        receiver: Responses,
         statement: T,
     },
     Done,
@@ -73,7 +73,7 @@ where
                             };
                             break Ok(Async::NotReady);
                         }
-                        Err(()) => unreachable!("mpsc::Receiver doesn't return errors"),
+                        Err(e) => return Err(e),
                     };
 
                     match message {

--- a/tokio-postgres/src/proto/responses.rs
+++ b/tokio-postgres/src/proto/responses.rs
@@ -1,0 +1,42 @@
+use fallible_iterator::FallibleIterator;
+use futures::sync::mpsc;
+use futures::{try_ready, Async, Poll, Stream};
+use postgres_protocol::message::backend;
+
+use crate::proto::codec::BackendMessages;
+use crate::Error;
+
+pub fn channel() -> (mpsc::Sender<BackendMessages>, Responses) {
+    let (sender, receiver) = mpsc::channel(1);
+
+    (
+        sender,
+        Responses {
+            receiver,
+            cur: BackendMessages::empty(),
+        },
+    )
+}
+
+pub struct Responses {
+    receiver: mpsc::Receiver<BackendMessages>,
+    cur: BackendMessages,
+}
+
+impl Stream for Responses {
+    type Item = backend::Message;
+    type Error = Error;
+
+    fn poll(&mut self) -> Poll<Option<backend::Message>, Error> {
+        loop {
+            if let Some(message) = self.cur.next().map_err(Error::parse)? {
+                return Ok(Async::Ready(Some(message)));
+            }
+
+            match try_ready!(self.receiver.poll().map_err(|()| Error::closed())) {
+                Some(messages) => self.cur = messages,
+                None => return Ok(Async::Ready(None)),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Our codec implementation originally just parsed single messages out of
the stream buffer. However, if a query returns a bunch of rows, we're
spending a ton of time shipping those individual messages from the
connection back to the Query stream. Instead, collect blocks of unparsed
messages that are as large as possible and send those back.

This cuts the processing time of the following query in half, from ~10
seconds to ~5:
`SELECT s.n, 'name' || s.n FROM generate_series(0, 9999999) AS s(n)`

At this point, almost all of the remainder of the time is spent parsing
the rows.

cc #450