### PR TITLE
Add methods that take iterators of parameters

### DIFF
--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -197,6 +197,17 @@ impl Client {
     ///
     /// Panics if the number of parameters provided does not match the number expected.
     pub fn execute(&mut self, statement: &Statement, params: &[&dyn ToSql]) -> impls::Execute {
+        self.execute_iter(statement, params.iter().cloned())
+    }
+
+    /// Like [`execute`], but takes an iterator of parameters rather than a slice.
+    ///
+    /// [`execute`]: #method.execute
+    pub fn execute_iter<'a, I>(&mut self, statement: &Statement, params: I) -> impls::Execute
+    where
+        I: IntoIterator<Item = &'a dyn ToSql>,
+        I::IntoIter: ExactSizeIterator,
+    {
         impls::Execute(self.0.execute(&statement.0, params))
     }
 
@@ -206,6 +217,17 @@ impl Client {
     ///
     /// Panics if the number of parameters provided does not match the number expected.
     pub fn query(&mut self, statement: &Statement, params: &[&dyn ToSql]) -> impls::Query {
+        self.query_iter(statement, params.iter().cloned())
+    }
+
+    /// Like [`query`], but takes an iterator of parameters rather than a slice.
+    ///
+    /// [`query`]: #method.query
+    pub fn query_iter<'a, I>(&mut self, statement: &Statement, params: I) -> impls::Query
+    where
+        I: IntoIterator<Item = &'a dyn ToSql>,
+        I::IntoIter: ExactSizeIterator,
+    {
         impls::Query(self.0.query(&statement.0, params))
     }
 
@@ -214,10 +236,22 @@ impl Client {
     /// Portals only last for the duration of the transaction in which they are created - in particular, a portal
     /// created outside of a transaction is immediately destroyed. Portals can only be used on the connection that
     /// created them.
+    ///
     /// # Panics
     ///
     /// Panics if the number of parameters provided does not match the number expected.
     pub fn bind(&mut self, statement: &Statement, params: &[&dyn ToSql]) -> impls::Bind {
+        self.bind_iter(statement, params.iter().cloned())
+    }
+
+    /// Like [`bind`], but takes an iterator of parameters rather than a slice.
+    ///
+    /// [`bind`]: #method.bind
+    pub fn bind_iter<'a, I>(&mut self, statement: &Statement, params: I) -> impls::Bind
+    where
+        I: IntoIterator<Item = &'a dyn ToSql>,
+        I::IntoIter: ExactSizeIterator,
+    {
         impls::Bind(self.0.bind(&statement.0, next_portal(), params))
     }
 
@@ -233,6 +267,10 @@ impl Client {
     ///
     /// The data in the provided stream is passed along to the server verbatim; it is the caller's responsibility to
     /// ensure it uses the proper format.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of parameters provided does not match the number expected.
     pub fn copy_in<S>(
         &mut self,
         statement: &Statement,
@@ -246,11 +284,47 @@ impl Client {
         // FIXME error type?
         S::Error: Into<Box<dyn StdError + Sync + Send>>,
     {
+        self.copy_in_iter(statement, params.iter().cloned(), stream)
+    }
+
+    /// Like [`copy_in`], except that it takes an iterator of parameters rather than a slice.
+    ///
+    /// [`copy_in`]: #method.copy_in
+    pub fn copy_in_iter<'a, I, S>(
+        &mut self,
+        statement: &Statement,
+        params: I,
+        stream: S,
+    ) -> impls::CopyIn<S>
+    where
+        I: IntoIterator<Item = &'a dyn ToSql>,
+        I::IntoIter: ExactSizeIterator,
+        S: Stream,
+        S::Item: IntoBuf,
+        <S::Item as IntoBuf>::Buf: 'static + Send,
+        // FIXME error type?
+        S::Error: Into<Box<dyn StdError + Sync + Send>>,
+    {
         impls::CopyIn(self.0.copy_in(&statement.0, params, stream))
     }
 
     /// Executes a `COPY TO STDOUT` statement, returning a stream of the resulting data.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of parameters provided does not match the number expected.
     pub fn copy_out(&mut self, statement: &Statement, params: &[&dyn ToSql]) -> impls::CopyOut {
+        self.copy_out_iter(statement, params.iter().cloned())
+    }
+
+    /// Like [`copy_out`], except that it takes an iterator of parameters rather than a slice.
+    ///
+    /// [`copy_out`]: #method.copy_out
+    pub fn copy_out_iter<'a, I>(&mut self, statement: &Statement, params: I) -> impls::CopyOut
+    where
+        I: IntoIterator<Item = &'a dyn ToSql>,
+        I::IntoIter: ExactSizeIterator,
+    {
         impls::CopyOut(self.0.copy_out(&statement.0, params))
     }
 

--- a/tokio-postgres/src/proto/typeinfo_composite.rs
+++ b/tokio-postgres/src/proto/typeinfo_composite.rs
@@ -11,7 +11,7 @@ use crate::proto::prepare::PrepareFuture;
 use crate::proto::query::QueryStream;
 use crate::proto::statement::Statement;
 use crate::proto::typeinfo::TypeinfoFuture;
-use crate::types::{Field, Oid};
+use crate::types::{Field, Oid, ToSql};
 
 const TYPEINFO_COMPOSITE_QUERY: &str = "
 SELECT attname, atttypid
@@ -59,7 +59,10 @@ impl PollTypeinfoComposite for TypeinfoComposite {
 
         match state.client.typeinfo_composite_query() {
             Some(statement) => transition!(QueryingCompositeFields {
-                future: state.client.query(&statement, &[&state.oid]).collect(),
+                future: state
+                    .client
+                    .query(&statement, [&state.oid as &dyn ToSql].iter().cloned())
+                    .collect(),
                 client: state.client,
             }),
             None => transition!(PreparingTypeinfoComposite {
@@ -82,7 +85,10 @@ impl PollTypeinfoComposite for TypeinfoComposite {
 
         state.client.set_typeinfo_composite_query(&statement);
         transition!(QueryingCompositeFields {
-            future: state.client.query(&statement, &[&state.oid]).collect(),
+            future: state
+                .client
+                .query(&statement, [&state.oid as &dyn ToSql].iter().cloned())
+                .collect(),
             client: state.client,
         })
     }

--- a/tokio-postgres/src/proto/typeinfo_enum.rs
+++ b/tokio-postgres/src/proto/typeinfo_enum.rs
@@ -8,7 +8,7 @@ use crate::proto::client::Client;
 use crate::proto::prepare::PrepareFuture;
 use crate::proto::query::QueryStream;
 use crate::proto::statement::Statement;
-use crate::types::Oid;
+use crate::types::{Oid, ToSql};
 
 const TYPEINFO_ENUM_QUERY: &str = "
 SELECT enumlabel
@@ -58,7 +58,10 @@ impl PollTypeinfoEnum for TypeinfoEnum {
 
         match state.client.typeinfo_enum_query() {
             Some(statement) => transition!(QueryingEnumVariants {
-                future: state.client.query(&statement, &[&state.oid]).collect(),
+                future: state
+                    .client
+                    .query(&statement, [&state.oid as &dyn ToSql].iter().cloned())
+                    .collect(),
                 client: state.client,
             }),
             None => transition!(PreparingTypeinfoEnum {
@@ -98,7 +101,10 @@ impl PollTypeinfoEnum for TypeinfoEnum {
 
         state.client.set_typeinfo_enum_query(&statement);
         transition!(QueryingEnumVariants {
-            future: state.client.query(&statement, &[&state.oid]).collect(),
+            future: state
+                .client
+                .query(&statement, [&state.oid as &dyn ToSql].iter().cloned())
+                .collect(),
             client: state.client,
         })
     }
@@ -111,7 +117,10 @@ impl PollTypeinfoEnum for TypeinfoEnum {
 
         state.client.set_typeinfo_enum_query(&statement);
         transition!(QueryingEnumVariants {
-            future: state.client.query(&statement, &[&state.oid]).collect(),
+            future: state
+                .client
+                .query(&statement, [&state.oid as &dyn ToSql].iter().cloned())
+                .collect(),
             client: state.client,
         })
     }


### PR DESCRIPTION
The existing methods which take slices of parameters work well when
directly passing a temporary slice (e.g. `c.query(s, &[&15, &"hi"])`,
but becomes limiting in other contexts like when programmatically
building up a query. We now offer methods which take iterators, which
are significantly more flexible for these kinds of use cases.

Because of the weird object safety of `ToSql`, we can't be generic over
`Iterator<Item = impl ToSql>`, but instead have to specifically work
with `Iterator<Item = &dyn ToSql>`. This may require a `.map()` or two
but should still work fine.

Closes #265