### PR TITLE
[WIP] Reimplement `Client::prepare` with std-futures

### DIFF
--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -1,10 +1,14 @@
+use crate::codec::FrontendMessage;
 use crate::connection::{Request, RequestMessages};
 use crate::error::Error;
 use crate::responses::{self, Responses};
 use crate::statement::Statement;
 use crate::types::Type;
-
+use fallible_iterator::FallibleIterator;
 use futures::channel::mpsc;
+use futures::StreamExt;
+use postgres_protocol::message::backend::Message;
+use postgres_protocol::message::frontend;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 fn next_statement() -> String {
@@ -50,8 +54,80 @@ impl Client {
         query: &str,
         param_types: &[Type],
     ) -> Result<Statement, Error> {
-        unimplemented!();
-        //self.sender.unbounded_send(PendingRequest)
+        let name = next_statement();
+        let pending = self.pending(|buf| {
+            frontend::parse(&name, query, param_types.iter().map(Type::oid), buf)
+                .map_err(Error::parse)?;
+            frontend::describe(b'S', &name, buf).map_err(Error::parse)?;
+            frontend::sync(buf);
+            Ok(())
+        });
+
+        let mut response = self.send(pending)?;
+
+        let message = response.next().await;
+
+        match message {
+            Some(Ok(Message::ParseComplete)) => (),
+            Some(Ok(Message::ErrorResponse(body))) => return Err(Error::db(body)),
+            Some(Err(e)) => return Err(e),
+            Some(_) => return Err(Error::unexpected_message()),
+            None => return Err(Error::closed()),
+        };
+
+        let message = response.next().await;
+
+        let parameters: Vec<_> = match message {
+            Some(Ok(Message::ParameterDescription(body))) => {
+                body.parameters().collect().map_err(Error::parse)?
+            }
+            Some(Err(e)) => return Err(e),
+            Some(_) => return Err(Error::unexpected_message()),
+            None => return Err(Error::closed()),
+        };
+
+        let message = response.next().await;
+
+        let columns = match message {
+            Some(Ok(Message::RowDescription(body))) => body
+                .fields()
+                .map(|f| Ok((f.name().to_string(), f.type_oid())))
+                .collect()
+                .map_err(Error::parse)?,
+            Some(Ok(Message::NoData)) => vec![],
+            Some(_) => return Err(Error::unexpected_message()),
+            None => return Err(Error::closed()),
+        };
+
+        let mut parameters = parameters.into_iter();
+        if let Some(oid) = parameters.next() {
+            // fetch params
+            unimplemented!("not yet finished");
+        }
+
+        let mut columns = columns.into_iter();
+        if let Some((name, oid)) = columns.next() {
+            // fetch columns
+            unimplemented!("not yet finished");
+        }
+
+        unimplemented!("not yet finished");
+
+        /*Ok(Statement::new(
+            name,
+            parameters,
+            columns,
+        ))*/
+    }
+
+    pub(crate) fn pending<F>(&self, messages: F) -> PendingRequest
+    where
+        F: FnOnce(&mut Vec<u8>) -> Result<(), Error>,
+    {
+        let mut buf = vec![];
+        PendingRequest(
+            messages(&mut buf).map(|()| RequestMessages::Single(FrontendMessage::Raw(buf))),
+        )
     }
 
     pub(crate) fn send(&self, request: PendingRequest) -> Result<Responses, Error> {

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -55,7 +55,7 @@ impl Client {
     }
 
     pub(crate) fn send(&self, request: PendingRequest) -> Result<Responses, Error> {
-        let (messages) = request.0?;
+        let messages = request.0?;
 
         let (sender, receiver) = responses::channel();
         self.sender

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -3,9 +3,9 @@ use crate::error::Error;
 use crate::responses::{self, Responses};
 use crate::statement::Statement;
 use crate::types::Type;
+use crate::connection::RequestMessages;
 
 use futures::channel::mpsc;
-
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 fn next_statement() -> String {
@@ -13,8 +13,6 @@ fn next_statement() -> String {
     format!("s{}", ID.fetch_add(1, Ordering::SeqCst))
 }
 
-// #TODO Refactor me
-use crate::connection::RequestMessages;
 pub struct PendingRequest(Result<RequestMessages, Error>);
 
 pub struct Client {

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -1,5 +1,21 @@
 use crate::connection::Request;
+use crate::error::Error;
+use crate::responses::{self, Responses};
+use crate::statement::Statement;
+use crate::types::Type;
+
 use futures::channel::mpsc;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn next_statement() -> String {
+    static ID: AtomicUsize = AtomicUsize::new(0);
+    format!("s{}", ID.fetch_add(1, Ordering::SeqCst))
+}
+
+// #TODO Refactor me
+use crate::connection::RequestMessages;
+pub struct PendingRequest(Result<RequestMessages, Error>);
 
 pub struct Client {
     sender: mpsc::UnboundedSender<Request>,
@@ -18,5 +34,36 @@ impl Client {
             process_id,
             secret_key,
         }
+    }
+
+    /// Creates a new prepared statement.
+    ///
+    /// Prepared statements can be executed repeatedly, and may contain query parameters (indicated by `$1`, `$2`, etc),
+    /// which are set when executed. Prepared statements can only be used with the connection that created them.
+    pub async fn prepare(&self, query: &str) -> Result<Statement, Error> {
+        self.prepare_typed(query, &[]).await
+    }
+
+    /// Like `prepare`, but allows the types of query parameters to be explicitly specified.
+    ///
+    /// The list of types may be smaller than the number of parameters - the types of the remaining parameters will be
+    /// inferred. For example, `client.prepare_typed(query, &[])` is equivalent to `client.prepare(query)`.
+    pub async fn prepare_typed(
+        &self,
+        query: &str,
+        param_types: &[Type],
+    ) -> Result<Statement, Error> {
+        unimplemented!();
+        //self.sender.unbounded_send(PendingRequest)
+    }
+
+    pub(crate) fn send(&self, request: PendingRequest) -> Result<Responses, Error> {
+        let (messages) = request.0?;
+
+        let (sender, receiver) = responses::channel();
+        self.sender
+            .unbounded_send(Request { messages, sender })
+            .map(|_| receiver)
+            .map_err(|_| Error::closed())
     }
 }

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -1,9 +1,8 @@
-use crate::connection::Request;
+use crate::connection::{Request, RequestMessages};
 use crate::error::Error;
 use crate::responses::{self, Responses};
 use crate::statement::Statement;
 use crate::types::Type;
-use crate::connection::RequestMessages;
 
 use futures::channel::mpsc;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/tokio-postgres/src/column.rs
+++ b/tokio-postgres/src/column.rs
@@ -1,0 +1,24 @@
+use crate::types::Type;
+
+/// Information about a column of a Postgres query.
+#[derive(Debug)]
+pub struct Column {
+    name: String,
+    type_: Type,
+}
+
+impl Column {
+    pub(crate) fn new(name: String, type_: Type) -> Column {
+        Column { name, type_ }
+    }
+
+    /// Returns the name of the column.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the type of the column.
+    pub fn type_(&self) -> &Type {
+        &self.type_
+    }
+}

--- a/tokio-postgres/src/connection.rs
+++ b/tokio-postgres/src/connection.rs
@@ -42,11 +42,7 @@ pub struct Request {
     pub sender: mpsc::Sender<BackendMessages>,
 }
 
-pub struct Connection<S, T>
-where
-    S: AsyncRead + AsyncWrite + Unpin,
-    T: AsyncRead + AsyncWrite + Unpin,
-{
+pub struct Connection<S, T> {
     stream: Framed<MaybeTlsStream<S, T>, PostgresCodec>,
     parameters: HashMap<String, String>,
     receiver: mpsc::UnboundedReceiver<Request>,
@@ -87,6 +83,18 @@ where
         }
 
         self.stream.poll_next_unpin(cx)
+    }
+
+    fn poll_read(&mut self) -> Result<Option<AsyncMessage>, Error> {
+        unimplemented!()
+    }
+
+    fn poll_write(&mut self) -> Result<bool, Error> {
+        unimplemented!()
+    }
+
+    fn poll_request(&self) -> Poll<Option<Result<BackendMessage, Error>>> {
+        unimplemented!()
     }
 
     pub fn poll_message(&self, cx: &mut Context<'_>) -> Poll<Result<Option<AsyncMessage>, Error>> {

--- a/tokio-postgres/src/connection.rs
+++ b/tokio-postgres/src/connection.rs
@@ -1,12 +1,9 @@
 use crate::codec::{BackendMessage, BackendMessages, FrontendMessage, PostgresCodec};
-use crate::error::DbError;
-use crate::error::Error;
+use crate::error::{DbError, Error};
 use crate::maybe_tls_stream::MaybeTlsStream;
 use futures::channel::mpsc;
-use futures::ready;
 use futures::task::Context;
-use futures::Future;
-use futures::Poll;
+use futures::{ready, Future, Poll};
 use std::collections::HashMap;
 use std::io;
 use std::pin::Pin;

--- a/tokio-postgres/src/connection.rs
+++ b/tokio-postgres/src/connection.rs
@@ -1,8 +1,40 @@
-use crate::codec::{BackendMessages, FrontendMessage, PostgresCodec};
+use crate::codec::{BackendMessage, BackendMessages, FrontendMessage, PostgresCodec};
+use crate::error::DbError;
+use crate::error::Error;
 use crate::maybe_tls_stream::MaybeTlsStream;
 use futures::channel::mpsc;
+use futures::ready;
+use futures::task::Context;
+use futures::Future;
+use futures::Poll;
 use std::collections::HashMap;
+use std::io;
+use std::pin::Pin;
 use tokio::codec::Framed;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+/// An asynchronous notification.
+#[derive(Clone, Debug)]
+pub struct Notification {
+    process_id: i32,
+    channel: String,
+    payload: String,
+}
+
+/// An asynchronous message from the server.
+#[allow(clippy::large_enum_variant)]
+pub enum AsyncMessage {
+    /// A notice.
+    ///
+    /// Notices use the same format as errors, but aren't "errors" per-se.
+    Notice(DbError),
+    /// A notification.
+    ///
+    /// Connections can subscribe to notifications with the `LISTEN` command.
+    Notification(Notification),
+    #[doc(hidden)]
+    __NonExhaustive,
+}
 
 pub enum RequestMessages {
     Single(FrontendMessage),
@@ -17,6 +49,8 @@ pub struct Connection<S, T> {
     stream: Framed<MaybeTlsStream<S, T>, PostgresCodec>,
     parameters: HashMap<String, String>,
     receiver: mpsc::UnboundedReceiver<Request>,
+
+    pending_response: Option<BackendMessage>,
 }
 
 impl<S, T> Connection<S, T> {
@@ -29,6 +63,43 @@ impl<S, T> Connection<S, T> {
             stream,
             parameters,
             receiver,
+
+            pending_response: None,
         }
+    }
+}
+
+impl<S, T> Connection<S, T>
+where
+    S: AsyncRead + AsyncWrite,
+{
+    // #TODO
+    // Original source:
+    // https://github.com/sfackler/rust-postgres/blob/master/tokio-postgres/src/proto/connection.rs#L87
+
+    fn poll_response(&self, cx: &mut Context) -> Poll<Result<Option<BackendMessage>, io::Error>> {
+        /*if let Some(message) = self.pending_response.take() {
+            trace!("retrying pending response");
+            return Ok(Async::Ready(Some(message)));
+        }
+
+        self.stream.poll_next(cx)*/
+        unimplemented!()
+    }
+
+    pub fn poll_message(&self, cx: &mut Context) -> Poll<Result<Option<AsyncMessage>, Error>> {
+        unimplemented!()
+    }
+}
+
+impl<S, T> Future for Connection<S, T>
+where
+    S: AsyncRead + AsyncWrite,
+{
+    type Output = Result<(), Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Error>> {
+        while let Ok(Some(_)) = ready!(self.poll_message(cx)) {}
+        Poll::Ready(Ok(()))
     }
 }

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -119,6 +119,7 @@ pub use error::Error;
 
 mod client;
 mod codec;
+pub mod column;
 pub mod config;
 mod connect;
 mod connect_raw;
@@ -126,5 +127,7 @@ mod connect_tls;
 mod connection;
 pub mod error;
 mod maybe_tls_stream;
+mod responses;
+pub mod statement;
 pub mod tls;
 pub mod types;

--- a/tokio-postgres/src/responses.rs
+++ b/tokio-postgres/src/responses.rs
@@ -1,0 +1,42 @@
+use fallible_iterator::FallibleIterator;
+use futures::channel::mpsc;
+use futures::{ready, task::Context, Poll, Stream, StreamExt};
+use postgres_protocol::message::backend;
+use std::pin::Pin;
+
+use crate::codec::{BackendMessage, BackendMessages, FrontendMessage};
+use crate::Error;
+
+pub fn channel() -> (mpsc::Sender<BackendMessages>, Responses) {
+    let (sender, receiver) = mpsc::channel(1);
+
+    (
+        sender,
+        Responses {
+            receiver,
+            cur: BackendMessages::empty(),
+        },
+    )
+}
+
+pub struct Responses {
+    receiver: mpsc::Receiver<BackendMessages>,
+    cur: BackendMessages,
+}
+
+impl Stream for Responses {
+    type Item = Result<backend::Message, Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        loop {
+            if let Some(message) = self.cur.next().map_err(Error::parse)? {
+                return Poll::Ready(Some(Ok(message)));
+            }
+
+            match ready!(self.receiver.poll_next_unpin(cx)) {
+                Some(messages) => self.cur = messages,
+                None => return Poll::Ready(None),
+            }
+        }
+    }
+}

--- a/tokio-postgres/src/responses.rs
+++ b/tokio-postgres/src/responses.rs
@@ -4,7 +4,7 @@ use futures::{ready, task::Context, Poll, Stream, StreamExt};
 use postgres_protocol::message::backend;
 use std::pin::Pin;
 
-use crate::codec::{BackendMessage, BackendMessages, FrontendMessage};
+use crate::codec::BackendMessages;
 use crate::Error;
 
 pub fn channel() -> (mpsc::Sender<BackendMessages>, Responses) {
@@ -27,7 +27,7 @@ pub struct Responses {
 impl Stream for Responses {
     type Item = Result<backend::Message, Error>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
             if let Some(message) = self.cur.next().map_err(Error::parse)? {
                 return Poll::Ready(Some(Ok(message)));

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -1,0 +1,54 @@
+use std::sync::Arc;
+
+//use crate::proto::client::WeakClient;
+use crate::column::Column;
+use crate::types::Type;
+
+pub struct StatementInner {
+    //client: WeakClient,
+    name: String,
+    params: Vec<Type>,
+    columns: Vec<Column>,
+}
+
+impl Drop for StatementInner {
+    fn drop(&mut self) {
+        /*if let Some(client) = self.client.upgrade() {
+            client.close_statement(&self.name);
+        }*/
+    }
+}
+
+/// A prepared statement.
+///
+/// Prepared statements can only be used with the connection that created them.
+#[derive(Clone)]
+pub struct Statement(Arc<StatementInner>);
+
+impl Statement {
+    pub(crate) fn new(
+        //client: WeakClient,
+        name: String,
+        params: Vec<Type>,
+        columns: Vec<Column>,
+    ) -> Statement {
+        Statement(Arc::new(StatementInner {
+            //client,
+            name,
+            params,
+            columns,
+        }))
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.0.name
+    }
+
+    pub fn params(&self) -> &[Type] {
+        &self.0.params
+    }
+
+    pub fn columns(&self) -> &[Column] {
+        &self.0.columns
+    }
+}


### PR DESCRIPTION
A work in progress pull request of what I've been able to work on so far with regards to the std-future refactoring effort. I'm PR'ing this as is in order to avoid duplicate work.

I would have liked to be able to finish `Client::prepare` and pass the test I've refactored but I'm blocked mostly on the somewhat large re-implementation effort of `Connection`.