### PR TITLE
Make prepare() return a Future that satisfies `Send`.

### DIFF
--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -126,8 +126,7 @@ async fn get_type(client: &Arc<InnerClient>, oid: Oid) -> Result<Type, Error> {
 
     let stmt = typeinfo_statement(client).await?;
 
-    let params: &[&dyn ToSql] = &[&oid];
-    let buf = query::encode(&stmt, params.iter().cloned());
+    let buf = query::encode(&stmt, (&[&oid as &dyn ToSql]).iter().cloned());
     let rows = query::query(client.clone(), stmt, buf);
     pin_mut!(rows);
 
@@ -174,7 +173,7 @@ async fn get_type(client: &Arc<InnerClient>, oid: Oid) -> Result<Type, Error> {
 fn get_type_rec<'a>(
     client: &'a Arc<InnerClient>,
     oid: Oid,
-) -> Pin<Box<dyn Future<Output = Result<Type, Error>> + 'a>> {
+) -> Pin<Box<dyn Future<Output = Result<Type, Error>> + Send + 'a>> {
     Box::pin(get_type(client, oid))
 }
 
@@ -198,8 +197,7 @@ async fn typeinfo_statement(client: &Arc<InnerClient>) -> Result<Statement, Erro
 async fn get_enum_variants(client: &Arc<InnerClient>, oid: Oid) -> Result<Vec<String>, Error> {
     let stmt = typeinfo_enum_statement(client).await?;
 
-    let params: &[&dyn ToSql] = &[&oid];
-    let buf = query::encode(&stmt, params.iter().cloned());
+    let buf = query::encode(&stmt, (&[&oid as &dyn ToSql]).iter().cloned());
     query::query(client.clone(), stmt, buf)
         .and_then(|row| future::ready(row.try_get(0)))
         .try_collect()
@@ -226,8 +224,7 @@ async fn typeinfo_enum_statement(client: &Arc<InnerClient>) -> Result<Statement,
 async fn get_composite_fields(client: &Arc<InnerClient>, oid: Oid) -> Result<Vec<Field>, Error> {
     let stmt = typeinfo_composite_statement(client).await?;
 
-    let params: &[&dyn ToSql] = &[&oid];
-    let buf = query::encode(&stmt, params.iter().cloned());
+    let buf = query::encode(&stmt, (&[&oid as &dyn ToSql]).iter().cloned());
     let rows = query::query(client.clone(), stmt, buf)
         .try_collect::<Vec<_>>()
         .await?;


### PR DESCRIPTION
Currently this code:
```rust
use futures::{FutureExt, TryStreamExt};
use tokio_postgres::{Error, NoTls};

async fn example() -> Result<(), Error> {
    let (mut client, connection) = tokio_postgres::connect("host=localhost user=postgres password=postgres", NoTls).await?;

    let connection = connection.map(|r| {
        if let Err(e) = r {
            eprintln!("connection error: {}", e);
        }
    });
    tokio::spawn(connection);

    let stmt = client.prepare("SELECT $1::TEXT").await?;

    let rows = client
        .query(&stmt, &[&"hello world"])
        .try_collect::<Vec<_>>()
        .await?;

    // Now we can check that we got back the same string we sent over.
    let value: &str = rows[0].get(0);

    assert_eq!(value, "hello world");

    Ok::<(), Error>(())
}

#[tokio::main]
async fn main() {
    example().boxed().await.unwrap()
}
```

Fails with the following error:
```
    Checking rocket-tokio-postgres v0.1.0 (/home/jeb/code/tokio-postgres-prepare-send)
error[E0277]: `dyn tokio_postgres::types::ToSql` cannot be shared between threads safely
  --> src/main.rs:31:15
   |
31 |     example().boxed().await.unwrap()
   |               ^^^^^ `dyn tokio_postgres::types::ToSql` cannot be shared between threads safely
   |
   = help: the trait `std::marker::Sync` is not implemented for `dyn tokio_postgres::types::ToSql`
   = note: required because of the requirements on the impl of `std::marker::Send` for `&dyn tokio_postgres::types::ToSql`
   = note: required because it appears within the type `[&dyn tokio_postgres::types::ToSql; 1]`
   = note: required because it appears within the type `for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10, 't11, 't12> {&'r std::sync::Arc<tokio_postgres::client::InnerClient>, u32, fn(std::result::Result<tokio_postgres::statement::Statement, tokio_postgres::error::Error>) -> std::result::Result<<std::result::Result<tokio_postgres::statement::Statement, tokio_postgres::error::Error> as std::ops::Try>::Ok, <std::result::Result<tokio_postgres::statement::Statement, tokio_postgres::error::Error> as std::ops::Try>::Error> {<std::result::Result<tokio_postgres::statement::Statement, tokio_postgres::error::Error> as std::ops::Try>::into_result}, impl core::future::future::Future, (), tokio_postgres::statement::Statement, [&'t0 (dyn tokio_postgres::types::ToSql + 't1); 1], &'t2 [&'t3 (dyn tokio_postgres::types::ToSql + 't4)], std::result::Result<std::vec::Vec<u8>, tokio_postgres::error::Error>, impl futures_core::stream::Stream, std::pin::Pin<&'t5 mut impl futures_core::stream::Stream>, fn(std::result::Result<std::option::Option<tokio_postgres::row::Row>, tokio_postgres::error::Error>) -> std::result::Result<<std::result::Result<std::option::Option<tokio_postgres::row::Row>, tokio_postgres::error::Error> as std::ops::Try>::Ok, <std::result::Result<std::option::Option<tokio_postgres::row::Row>, tokio_postgres::error::Error> as std::ops::Try>::Error> {<std::result::Result<std::option::Option<tokio_postgres::row::Row>, tokio_postgres::error::Error> as std::ops::Try>::into_result}, futures_util::try_stream::try_next::TryNext<'t6, std::pin::Pin<&'t7 mut impl futures_core::stream::Stream>>, tokio_postgres::row::Row, std::string::String, i8, std::option::Option<u32>, bool, fn(std::result::Result<std::vec::Vec<std::string::String>, tokio_postgres::error::Error>) -> std::result::Result<<std::result::Result<std::vec::Vec<std::string::String>, tokio_postgres::error::Error> as std::ops::Try>::Ok, <std::result::Result<std::vec::Vec<std::string::String>, tokio_postgres::error::Error> as std::ops::Try>::Error> {<std::result::Result<std::vec::Vec<std::string::String>, tokio_postgres::error::Error> as std::ops::Try>::into_result}, impl core::future::future::Future, fn(std::result::Result<tokio_postgres::types::Type, tokio_postgres::error::Error>) -> std::result::Result<<std::result::Result<tokio_postgres::types::Type, tokio_postgres::error::Error> as std::ops::Try>::Ok, <std::result::Result<tokio_postgres::types::Type, tokio_postgres::error::Error> as std::ops::Try>::Error> {<std::result::Result<tokio_postgres::types::Type, tokio_postgres::error::Error> as std::ops::Try>::into_result}, std::pin::Pin<std::boxed::Box<(dyn core::future::future::Future<Output = std::result::Result<tokio_postgres::types::Type, tokio_postgres::error::Error>> + 't9)>>, std::pin::Pin<std::boxed::Box<(dyn core::future::future::Future<Output = std::result::Result<tokio_postgres::types::Type, tokio_postgres::error::Error>> + 't10)>>, fn(std::result::Result<std::vec::Vec<tokio_postgres::types::Field>, tokio_postgres::error::Error>) -> std::result::Result<<std::result::Result<std::vec::Vec<tokio_postgres::types::Field>, tokio_postgres::error::Error> as std::ops::Try>::Ok, <std::result::Result<std::vec::Vec<tokio_postgres::types::Field>, tokio_postgres::error::Error> as std::ops::Try>::Error> {<std::result::Result<std::vec::Vec<tokio_postgres::types::Field>, tokio_postgres::error::Error> as std::ops::Try>::into_result}, impl core::future::future::Future, std::pin::Pin<std::boxed::Box<(dyn core::future::future::Future<Output = std::result::Result<tokio_postgres::types::Type, tokio_postgres::error::Error>> + 't12)>>}`
```
(clipped, the rest is at https://paste.rs/sB1)

The same example works as intended after this PR.

I understand why the change to `get_type_rec` was necessary, but I think the changes to `params` are necessary because of a bug in rustc - possibly rust-lang/rust#59087 or similar.