### PR TITLE
Add query_one to postgres::Transaction

### DIFF
--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -58,6 +58,14 @@ impl<'a> Transaction<'a> {
         executor::block_on(self.0.query(query, params))
     }
 
+    /// Like `Client::query_one`.
+    pub fn query_one<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Row, Error>
+    where
+        T: ?Sized + ToStatement,
+    {
+        executor::block_on(self.0.query_one(query, params))
+    }
+
     /// Like `Client::query_raw`.
     pub fn query_raw<'b, T, I>(
         &mut self,


### PR DESCRIPTION
I believe this was missed in 31855141d2eac62c0b3fff34a5825602c177693d.

Feel free to strip my authorship if more convenient, this is just a tested copy-paste.