### PR TITLE
Change connection initialization timezone to UTC

### DIFF
--- a/tokio-postgres/src/connect_raw.rs
+++ b/tokio-postgres/src/connect_raw.rs
@@ -109,7 +109,7 @@ where
     S: AsyncRead + AsyncWrite + Unpin,
     T: AsyncRead + AsyncWrite + Unpin,
 {
-    let mut params = vec![("client_encoding", "UTF8"), ("timezone", "GMT")];
+    let mut params = vec![("client_encoding", "UTF8"), ("timezone", "UTC")];
     if let Some(user) = &config.user {
         params.push(("user", &**user));
     }


### PR DESCRIPTION
Although CockroachDB supports the postgres wire protocol, it doesn't appear to support using the `GMT` timezone (at least not on Windows). However, cockroach does accept `UTC`. This PR provides a way to configure the timezone connection property.

I've left the default as `GMT` but I think `UTC` is probably a better option. The native client defaults to unspecified:

> timezone (string)
> Sets the time zone for displaying and interpreting time stamps. If not explicitly set, the server initializes this variable to the time zone specified by its system environment. See Section 8.5.3 for more information.

https://www.postgresql.org/docs/9.1/runtime-config-client.html