### PR TITLE
Add Hash implementation to Type

### DIFF
--- a/codegen/src/type_gen.rs
+++ b/codegen/src/type_gen.rs
@@ -266,7 +266,7 @@ use std::sync::Arc;
 
 use crate::{{Type, Oid, Kind}};
 
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Hash)]
 pub struct Other {{
     pub name: String,
     pub oid: Oid,
@@ -282,7 +282,7 @@ fn make_enum(w: &mut BufWriter<File>, types: &BTreeMap<u32, Type>) {
     write!(
         w,
         "
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub enum Inner {{"
     )
     .unwrap();

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -209,7 +209,7 @@ mod special;
 mod type_gen;
 
 /// A Postgres type.
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub struct Type(Inner);
 
 impl fmt::Display for Type {
@@ -264,7 +264,7 @@ impl Type {
 }
 
 /// Represents the kind of a Postgres type.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Kind {
     /// A simple type like `VARCHAR` or `INTEGER`.
     Simple,
@@ -285,7 +285,7 @@ pub enum Kind {
 }
 
 /// Information about a field of a composite type.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Field {
     name: String,
     type_: Type,

--- a/postgres-types/src/type_gen.rs
+++ b/postgres-types/src/type_gen.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::{Kind, Oid, Type};
 
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Hash)]
 pub struct Other {
     pub name: String,
     pub oid: Oid,
@@ -11,7 +11,7 @@ pub struct Other {
     pub schema: String,
 }
 
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub enum Inner {
     Bool,
     Bytea,


### PR DESCRIPTION
In order to provide proper caching of statements I need to be able to hash both the `query` and the `parameter_types`. That's why I added `Hash` to the `#[derive(...)]` of `Type` and all other structs it depends on.