### PR TITLE
Adding in generic connection trait back to the lib

### DIFF
--- a/postgres/src/client.rs
+++ b/postgres/src/client.rs
@@ -1,4 +1,7 @@
-use crate::{Config, CopyInWriter, CopyOutReader, GenericConnection, RowIter, Statement, ToStatement, Transaction};
+use crate::{
+    Config, CopyInWriter, CopyOutReader, GenericConnection, RowIter, Statement, ToStatement,
+    Transaction,
+};
 use std::ops::{Deref, DerefMut};
 use tokio::runtime::Runtime;
 use tokio_postgres::tls::{MakeTlsConnect, TlsConnect};

--- a/postgres/src/client.rs
+++ b/postgres/src/client.rs
@@ -1,4 +1,4 @@
-use crate::{Config, CopyInWriter, CopyOutReader, RowIter, Statement, ToStatement, Transaction};
+use crate::{Config, CopyInWriter, CopyOutReader, GenericConnection, RowIter, Statement, ToStatement, Transaction};
 use std::ops::{Deref, DerefMut};
 use tokio::runtime::Runtime;
 use tokio_postgres::tls::{MakeTlsConnect, TlsConnect};
@@ -448,5 +448,20 @@ impl Client {
     /// If this returns `true`, the client is no longer usable.
     pub fn is_closed(&self) -> bool {
         self.client.is_closed()
+    }
+}
+
+impl GenericConnection for Client {
+    fn execute(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error> {
+        self.execute(query, params)
+    }
+    fn query(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error> {
+        self.query(query, params)
+    }
+    fn prepare(&mut self, query: &str) -> Result<Statement, Error> {
+        self.prepare(query)
+    }
+    fn transaction(&mut self) -> Result<Transaction<'_>, Error> {
+        self.transaction()
     }
 }

--- a/postgres/src/client.rs
+++ b/postgres/src/client.rs
@@ -458,7 +458,10 @@ impl GenericConnection for Client {
     fn execute(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error> {
         self.execute(query, params)
     }
-    fn query(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error> {
+    fn query<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
+    where
+        T: ?Sized + ToStatement,
+    {
         self.query(query, params)
     }
     fn prepare(&mut self, query: &str) -> Result<Statement, Error> {

--- a/postgres/src/client.rs
+++ b/postgres/src/client.rs
@@ -455,7 +455,10 @@ impl Client {
 }
 
 impl GenericConnection for Client {
-    fn execute(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error> {
+    fn execute<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
+    where
+        T: ?Sized + ToStatement,
+    {
         self.execute(query, params)
     }
     fn query<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>

--- a/postgres/src/generic_connection.rs
+++ b/postgres/src/generic_connection.rs
@@ -1,4 +1,4 @@
-use crate::{Statement, Transaction};
+use crate::{Statement, ToStatement, Transaction};
 use tokio_postgres::types::ToSql;
 use tokio_postgres::{Error, Row};
 
@@ -8,7 +8,9 @@ pub trait GenericConnection {
     fn execute(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>;
 
     /// Like `Client::query`.
-    fn query(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>;
+    fn query<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
+    where
+        T: ?Sized + ToStatement;
 
     /// Like `Client::prepare`.
     fn prepare(&mut self, query: &str) -> Result<Statement, Error>;

--- a/postgres/src/generic_connection.rs
+++ b/postgres/src/generic_connection.rs
@@ -1,0 +1,18 @@
+use crate::{Statement, Transaction};
+use tokio_postgres::types::{ToSql};
+use tokio_postgres::{Error, Row};
+
+/// A trait allowing abstraction over connections and transactions
+pub trait GenericConnection {
+  /// Like `Client::execute`.
+  fn execute(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>;
+
+  /// Like `Client::query`.
+  fn query(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>;
+
+  /// Like `Client::prepare`.
+  fn prepare(&mut self, query: &str) -> Result<Statement, Error>;
+
+  /// Like `Client::transaction`.
+  fn transaction(&mut self) -> Result<Transaction<'_>, Error>;
+}

--- a/postgres/src/generic_connection.rs
+++ b/postgres/src/generic_connection.rs
@@ -5,7 +5,9 @@ use tokio_postgres::{Error, Row};
 /// A trait allowing abstraction over connections and transactions
 pub trait GenericConnection {
     /// Like `Client::execute`.
-    fn execute(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>;
+    fn execute<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
+    where
+        T: ?Sized + ToStatement;
 
     /// Like `Client::query`.
     fn query<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>

--- a/postgres/src/generic_connection.rs
+++ b/postgres/src/generic_connection.rs
@@ -1,18 +1,18 @@
 use crate::{Statement, Transaction};
-use tokio_postgres::types::{ToSql};
+use tokio_postgres::types::ToSql;
 use tokio_postgres::{Error, Row};
 
 /// A trait allowing abstraction over connections and transactions
 pub trait GenericConnection {
-  /// Like `Client::execute`.
-  fn execute(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>;
+    /// Like `Client::execute`.
+    fn execute(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>;
 
-  /// Like `Client::query`.
-  fn query(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>;
+    /// Like `Client::query`.
+    fn query(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>;
 
-  /// Like `Client::prepare`.
-  fn prepare(&mut self, query: &str) -> Result<Statement, Error>;
+    /// Like `Client::prepare`.
+    fn prepare(&mut self, query: &str) -> Result<Statement, Error>;
 
-  /// Like `Client::transaction`.
-  fn transaction(&mut self) -> Result<Transaction<'_>, Error>;
+    /// Like `Client::transaction`.
+    fn transaction(&mut self) -> Result<Transaction<'_>, Error>;
 }

--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -60,6 +60,7 @@ pub use crate::copy_in_writer::CopyInWriter;
 pub use crate::copy_out_reader::CopyOutReader;
 #[doc(no_inline)]
 pub use crate::error::Error;
+pub use crate::generic_connection::GenericConnection;
 #[doc(no_inline)]
 pub use crate::row::{Row, SimpleQueryRow};
 pub use crate::row_iter::RowIter;
@@ -72,6 +73,7 @@ mod client;
 pub mod config;
 mod copy_in_writer;
 mod copy_out_reader;
+mod generic_connection;
 mod lazy_pin;
 mod row_iter;
 mod transaction;

--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -1,4 +1,6 @@
-use crate::{CopyInWriter, CopyOutReader, GenericConnection, Portal, RowIter, Rt, Statement, ToStatement};
+use crate::{
+    CopyInWriter, CopyOutReader, GenericConnection, Portal, RowIter, Rt, Statement, ToStatement,
+};
 use tokio::runtime::Runtime;
 use tokio_postgres::types::{ToSql, Type};
 use tokio_postgres::{Error, Row, SimpleQueryMessage};

--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -184,7 +184,10 @@ impl<'a> GenericConnection for Transaction<'a> {
     fn execute(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error> {
         self.execute(query, params)
     }
-    fn query(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error> {
+    fn query<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
+    where
+        T: ?Sized + ToStatement,
+    {
         self.query(query, params)
     }
     fn prepare(&mut self, query: &str) -> Result<Statement, Error> {

--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -181,7 +181,10 @@ impl<'a> Transaction<'a> {
 }
 
 impl<'a> GenericConnection for Transaction<'a> {
-    fn execute(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error> {
+    fn execute<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
+    where
+        T: ?Sized + ToStatement,
+    {
         self.execute(query, params)
     }
     fn query<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>

--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -1,4 +1,4 @@
-use crate::{CopyInWriter, CopyOutReader, Portal, RowIter, Rt, Statement, ToStatement};
+use crate::{CopyInWriter, CopyOutReader, GenericConnection, Portal, RowIter, Rt, Statement, ToStatement};
 use tokio::runtime::Runtime;
 use tokio_postgres::types::{ToSql, Type};
 use tokio_postgres::{Error, Row, SimpleQueryMessage};
@@ -175,5 +175,20 @@ impl<'a> Transaction<'a> {
             runtime: self.runtime,
             transaction,
         })
+    }
+}
+
+impl<'a> GenericConnection for Transaction<'a> {
+    fn execute(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error> {
+        self.execute(query, params)
+    }
+    fn query(&mut self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error> {
+        self.query(query, params)
+    }
+    fn prepare(&mut self, query: &str) -> Result<Statement, Error> {
+        self.prepare(query)
+    }
+    fn transaction(&mut self) -> Result<Transaction<'_>, Error> {
+        self.transaction()
     }
 }


### PR DESCRIPTION
I am trying to add back in the generic connection trait that existed for connections and traits in version 0.15.2 but was not put back in when this lib was rebuilt. This work is based on an existing closed PR: https://github.com/sfackler/rust-postgres/pull/433. I wasn't exactly sure where to put the generic connection so I added it in a new file but it could easily be moved to the lib.rs or even client.rs. I also used the old name of GenericConnection instead of GenericClient used in the old PR. All available feedback is requested.