### PR TITLE
Put unused type parameter back into use

### DIFF
--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -155,11 +155,7 @@ impl<'a> Transaction<'a> {
     }
 
     /// Like `Client::execute_iter`.
-    pub async fn execute_raw<'b, I, T>(
-        &self,
-        statement: &Statement,
-        params: I,
-    ) -> Result<u64, Error>
+    pub async fn execute_raw<'b, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement,
         I: IntoIterator<Item = &'b dyn ToSql>,


### PR DESCRIPTION
A simple fix to the transaction API. Not sure why there wasn't any warning from the compiler.