### PR TITLE
Add missing methods to GenericClient

### DIFF
--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -506,6 +506,7 @@ impl Client {
 
 #[async_trait]
 impl GenericClient for Client {
+    /// Like `Client::execute`.
     async fn execute<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
@@ -513,6 +514,17 @@ impl GenericClient for Client {
         self.execute(query, params).await
     }
 
+    /// Like `Client::execute_raw`.
+    async fn execute_raw<'b, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
+    where
+        T: ?Sized + ToStatement + Sync + Send,
+        I: IntoIterator<Item = &'b dyn ToSql> + Sync + Send,
+        I::IntoIter: ExactSizeIterator,
+    {
+        self.execute_raw(statement, params).await
+    }
+
+    /// Like `Client::query`.
     async fn query<T>(
         &mut self,
         query: &T,
@@ -524,10 +536,55 @@ impl GenericClient for Client {
         self.query(query, params).await
     }
 
+    /// Like `Client::query_one`.
+    async fn query_one<T>(
+        &self,
+        statement: &T,
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Row, Error>
+    where
+        T: ?Sized + ToStatement + Sync + Send,
+    {
+        self.query_one(statement, params).await
+    }
+
+    /// Like `Client::query_opt`.
+    async fn query_opt<T>(
+        &self,
+        statement: &T,
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Option<Row>, Error>
+    where
+        T: ?Sized + ToStatement + Sync + Send,
+    {
+        self.query_opt(statement, params).await
+    }
+
+    /// Like `Client::query_raw`.
+    async fn query_raw<'b, T, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
+    where
+        T: ?Sized + ToStatement + Sync + Send,
+        I: IntoIterator<Item = &'b dyn ToSql> + Sync + Send,
+        I::IntoIter: ExactSizeIterator,
+    {
+        self.query_raw(statement, params).await
+    }
+
+    /// Like `Client::prepare`.
     async fn prepare(&mut self, query: &str) -> Result<Statement, Error> {
         self.prepare(query).await
     }
 
+    /// Like `Client::prepare_typed`.
+    async fn prepare_typed(
+        &self,
+        query: &str,
+        parameter_types: &[Type],
+    ) -> Result<Statement, Error> {
+        self.prepare_typed(query, parameter_types).await
+    }
+
+    /// Like `Client::transaction`.
     async fn transaction(&mut self) -> Result<Transaction<'_>, Error> {
         self.transaction().await
     }

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -507,7 +507,7 @@ impl Client {
 #[async_trait]
 impl GenericClient for Client {
     /// Like `Client::execute`.
-    async fn execute<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
+    async fn execute<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
     {
@@ -525,11 +525,7 @@ impl GenericClient for Client {
     }
 
     /// Like `Client::query`.
-    async fn query<T>(
-        &mut self,
-        query: &T,
-        params: &[&(dyn ToSql + Sync)],
-    ) -> Result<Vec<Row>, Error>
+    async fn query<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
     {
@@ -571,7 +567,7 @@ impl GenericClient for Client {
     }
 
     /// Like `Client::prepare`.
-    async fn prepare(&mut self, query: &str) -> Result<Statement, Error> {
+    async fn prepare(&self, query: &str) -> Result<Statement, Error> {
         self.prepare(query).await
     }
 

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -506,7 +506,6 @@ impl Client {
 
 #[async_trait]
 impl GenericClient for Client {
-    /// Like `Client::execute`.
     async fn execute<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
@@ -514,7 +513,6 @@ impl GenericClient for Client {
         self.execute(query, params).await
     }
 
-    /// Like `Client::execute_raw`.
     async fn execute_raw<'b, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
@@ -524,7 +522,6 @@ impl GenericClient for Client {
         self.execute_raw(statement, params).await
     }
 
-    /// Like `Client::query`.
     async fn query<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
@@ -532,7 +529,6 @@ impl GenericClient for Client {
         self.query(query, params).await
     }
 
-    /// Like `Client::query_one`.
     async fn query_one<T>(
         &self,
         statement: &T,
@@ -544,7 +540,6 @@ impl GenericClient for Client {
         self.query_one(statement, params).await
     }
 
-    /// Like `Client::query_opt`.
     async fn query_opt<T>(
         &self,
         statement: &T,
@@ -556,7 +551,6 @@ impl GenericClient for Client {
         self.query_opt(statement, params).await
     }
 
-    /// Like `Client::query_raw`.
     async fn query_raw<'b, T, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
@@ -566,12 +560,10 @@ impl GenericClient for Client {
         self.query_raw(statement, params).await
     }
 
-    /// Like `Client::prepare`.
     async fn prepare(&self, query: &str) -> Result<Statement, Error> {
         self.prepare(query).await
     }
 
-    /// Like `Client::prepare_typed`.
     async fn prepare_typed(
         &self,
         query: &str,
@@ -580,7 +572,6 @@ impl GenericClient for Client {
         self.prepare_typed(query, parameter_types).await
     }
 
-    /// Like `Client::transaction`.
     async fn transaction(&mut self) -> Result<Transaction<'_>, Error> {
         self.transaction().await
     }

--- a/tokio-postgres/src/generic_client.rs
+++ b/tokio-postgres/src/generic_client.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 #[async_trait]
 pub trait GenericClient {
     /// Like `Client::execute`.
-    async fn execute<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
+    async fn execute<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement + Sync + Send;
 
@@ -19,11 +19,7 @@ pub trait GenericClient {
         I::IntoIter: ExactSizeIterator;
 
     /// Like `Client::query`.
-    async fn query<T>(
-        &mut self,
-        query: &T,
-        params: &[&(dyn ToSql + Sync)],
-    ) -> Result<Vec<Row>, Error>
+    async fn query<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
     where
         T: ?Sized + ToStatement + Sync + Send;
 
@@ -53,7 +49,7 @@ pub trait GenericClient {
         I::IntoIter: ExactSizeIterator;
 
     /// Like `Client::prepare`.
-    async fn prepare(&mut self, query: &str) -> Result<Statement, Error>;
+    async fn prepare(&self, query: &str) -> Result<Statement, Error>;
 
     /// Like `Client::prepare_typed`.
     async fn prepare_typed(

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -289,7 +289,6 @@ impl<'a> Transaction<'a> {
 
 #[async_trait]
 impl crate::GenericClient for Transaction<'_> {
-    /// Like `Transaction::execute`.
     async fn execute<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
@@ -297,7 +296,6 @@ impl crate::GenericClient for Transaction<'_> {
         self.execute(query, params).await
     }
 
-    /// Like `Transaction::execute_raw`.
     async fn execute_raw<'b, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
@@ -307,7 +305,6 @@ impl crate::GenericClient for Transaction<'_> {
         self.execute_raw(statement, params).await
     }
 
-    /// Like `Transaction::query`.
     async fn query<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
@@ -315,7 +312,6 @@ impl crate::GenericClient for Transaction<'_> {
         self.query(query, params).await
     }
 
-    /// Like `Transaction::query_one`.
     async fn query_one<T>(
         &self,
         statement: &T,
@@ -327,7 +323,6 @@ impl crate::GenericClient for Transaction<'_> {
         self.query_one(statement, params).await
     }
 
-    /// Like `Transaction::query_opt`.
     async fn query_opt<T>(
         &self,
         statement: &T,
@@ -339,7 +334,6 @@ impl crate::GenericClient for Transaction<'_> {
         self.query_opt(statement, params).await
     }
 
-    /// Like `Transaction::query_raw`.
     async fn query_raw<'b, T, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
@@ -349,12 +343,10 @@ impl crate::GenericClient for Transaction<'_> {
         self.query_raw(statement, params).await
     }
 
-    /// Like `Transaction::prepare`.
     async fn prepare(&self, query: &str) -> Result<Statement, Error> {
         self.prepare(query).await
     }
 
-    /// Like `Transaction::prepare_typed`.
     async fn prepare_typed(
         &self,
         query: &str,
@@ -363,7 +355,6 @@ impl crate::GenericClient for Transaction<'_> {
         self.prepare_typed(query, parameter_types).await
     }
 
-    /// Like `Transaction::transaction`.
     #[allow(clippy::needless_lifetimes)]
     async fn transaction<'a>(&'a mut self) -> Result<Transaction<'a>, Error> {
         self.transaction().await

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -290,7 +290,7 @@ impl<'a> Transaction<'a> {
 #[async_trait]
 impl crate::GenericClient for Transaction<'_> {
     /// Like `Transaction::execute`.
-    async fn execute<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
+    async fn execute<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
     {
@@ -308,11 +308,7 @@ impl crate::GenericClient for Transaction<'_> {
     }
 
     /// Like `Transaction::query`.
-    async fn query<T>(
-        &mut self,
-        query: &T,
-        params: &[&(dyn ToSql + Sync)],
-    ) -> Result<Vec<Row>, Error>
+    async fn query<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
     {
@@ -354,7 +350,7 @@ impl crate::GenericClient for Transaction<'_> {
     }
 
     /// Like `Transaction::prepare`.
-    async fn prepare(&mut self, query: &str) -> Result<Statement, Error> {
+    async fn prepare(&self, query: &str) -> Result<Statement, Error> {
         self.prepare(query).await
     }
 

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -289,6 +289,7 @@ impl<'a> Transaction<'a> {
 
 #[async_trait]
 impl crate::GenericClient for Transaction<'_> {
+    /// Like `Transaction::execute`.
     async fn execute<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
@@ -296,6 +297,17 @@ impl crate::GenericClient for Transaction<'_> {
         self.execute(query, params).await
     }
 
+    /// Like `Transaction::execute_raw`.
+    async fn execute_raw<'b, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
+    where
+        T: ?Sized + ToStatement + Sync + Send,
+        I: IntoIterator<Item = &'b dyn ToSql> + Sync + Send,
+        I::IntoIter: ExactSizeIterator,
+    {
+        self.execute_raw(statement, params).await
+    }
+
+    /// Like `Transaction::query`.
     async fn query<T>(
         &mut self,
         query: &T,
@@ -307,10 +319,55 @@ impl crate::GenericClient for Transaction<'_> {
         self.query(query, params).await
     }
 
+    /// Like `Transaction::query_one`.
+    async fn query_one<T>(
+        &self,
+        statement: &T,
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Row, Error>
+    where
+        T: ?Sized + ToStatement + Sync + Send,
+    {
+        self.query_one(statement, params).await
+    }
+
+    /// Like `Transaction::query_opt`.
+    async fn query_opt<T>(
+        &self,
+        statement: &T,
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Option<Row>, Error>
+    where
+        T: ?Sized + ToStatement + Sync + Send,
+    {
+        self.query_opt(statement, params).await
+    }
+
+    /// Like `Transaction::query_raw`.
+    async fn query_raw<'b, T, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
+    where
+        T: ?Sized + ToStatement + Sync + Send,
+        I: IntoIterator<Item = &'b dyn ToSql> + Sync + Send,
+        I::IntoIter: ExactSizeIterator,
+    {
+        self.query_raw(statement, params).await
+    }
+
+    /// Like `Transaction::prepare`.
     async fn prepare(&mut self, query: &str) -> Result<Statement, Error> {
         self.prepare(query).await
     }
 
+    /// Like `Transaction::prepare_typed`.
+    async fn prepare_typed(
+        &self,
+        query: &str,
+        parameter_types: &[Type],
+    ) -> Result<Statement, Error> {
+        self.prepare_typed(query, parameter_types).await
+    }
+
+    /// Like `Transaction::transaction`.
     #[allow(clippy::needless_lifetimes)]
     async fn transaction<'a>(&'a mut self) -> Result<Transaction<'a>, Error> {
         self.transaction().await


### PR DESCRIPTION
This adds `execute_raw`,  `query_one`, `query_opt`, `query_raw`, and `prepare_typed` to the generic trait introduced in #525.

Furthermore, in 1ea8b7b2d467b2da49c94de522dd6ec054b5d159 I attempted to fix the lifetimes (as `&mut` is only required for `transaction()`).

@sfackler I'm not sure if this is the way to go or if you want this in a separate PR, if so, please let me know.