### PR TITLE
Remove Sync and Send requirements in GenericClient

### DIFF
--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -504,19 +504,19 @@ impl Client {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl GenericClient for Client {
     async fn execute<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement,
     {
         self.execute(query, params).await
     }
 
     async fn execute_raw<'b, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
-        I: IntoIterator<Item = &'b dyn ToSql> + Sync + Send,
+        T: ?Sized + ToStatement,
+        I: IntoIterator<Item = &'b dyn ToSql>,
         I::IntoIter: ExactSizeIterator,
     {
         self.execute_raw(statement, params).await
@@ -524,7 +524,7 @@ impl GenericClient for Client {
 
     async fn query<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement,
     {
         self.query(query, params).await
     }
@@ -535,7 +535,7 @@ impl GenericClient for Client {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Row, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement,
     {
         self.query_one(statement, params).await
     }
@@ -546,15 +546,15 @@ impl GenericClient for Client {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Option<Row>, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement,
     {
         self.query_opt(statement, params).await
     }
 
     async fn query_raw<'b, T, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
-        I: IntoIterator<Item = &'b dyn ToSql> + Sync + Send,
+        T: ?Sized + ToStatement,
+        I: IntoIterator<Item = &'b dyn ToSql>,
         I::IntoIter: ExactSizeIterator,
     {
         self.query_raw(statement, params).await

--- a/tokio-postgres/src/generic_client.rs
+++ b/tokio-postgres/src/generic_client.rs
@@ -4,24 +4,24 @@ use crate::{Error, Row, Statement, ToStatement, Transaction};
 use async_trait::async_trait;
 
 /// A trait allowing abstraction over connections and transactions.
-#[async_trait]
+#[async_trait(?Send)]
 pub trait GenericClient {
     /// Like `Client::execute`.
     async fn execute<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send;
+        T: ?Sized + ToStatement;
 
     /// Like `Client::execute_raw`.
     async fn execute_raw<'b, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
-        I: IntoIterator<Item = &'b dyn ToSql> + Sync + Send,
+        T: ?Sized + ToStatement,
+        I: IntoIterator<Item = &'b dyn ToSql>,
         I::IntoIter: ExactSizeIterator;
 
     /// Like `Client::query`.
     async fn query<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send;
+        T: ?Sized + ToStatement;
 
     /// Like `Client::query_one`.
     async fn query_one<T>(
@@ -30,7 +30,7 @@ pub trait GenericClient {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Row, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send;
+        T: ?Sized + ToStatement;
 
     /// Like `Client::query_opt`.
     async fn query_opt<T>(
@@ -39,13 +39,13 @@ pub trait GenericClient {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Option<Row>, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send;
+        T: ?Sized + ToStatement;
 
     /// Like `Client::query_raw`.
     async fn query_raw<'b, T, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
-        I: IntoIterator<Item = &'b dyn ToSql> + Sync + Send,
+        T: ?Sized + ToStatement,
+        I: IntoIterator<Item = &'b dyn ToSql>,
         I::IntoIter: ExactSizeIterator;
 
     /// Like `Client::prepare`.

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -287,19 +287,19 @@ impl<'a> Transaction<'a> {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl crate::GenericClient for Transaction<'_> {
     async fn execute<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement,
     {
         self.execute(query, params).await
     }
 
     async fn execute_raw<'b, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
-        I: IntoIterator<Item = &'b dyn ToSql> + Sync + Send,
+        T: ?Sized + ToStatement,
+        I: IntoIterator<Item = &'b dyn ToSql>,
         I::IntoIter: ExactSizeIterator,
     {
         self.execute_raw(statement, params).await
@@ -307,7 +307,7 @@ impl crate::GenericClient for Transaction<'_> {
 
     async fn query<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement,
     {
         self.query(query, params).await
     }
@@ -318,7 +318,7 @@ impl crate::GenericClient for Transaction<'_> {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Row, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement,
     {
         self.query_one(statement, params).await
     }
@@ -329,15 +329,15 @@ impl crate::GenericClient for Transaction<'_> {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Option<Row>, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement,
     {
         self.query_opt(statement, params).await
     }
 
     async fn query_raw<'b, T, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
-        I: IntoIterator<Item = &'b dyn ToSql> + Sync + Send,
+        T: ?Sized + ToStatement,
+        I: IntoIterator<Item = &'b dyn ToSql>,
         I::IntoIter: ExactSizeIterator,
     {
         self.query_raw(statement, params).await


### PR DESCRIPTION
I just found out that the `async_trait` macro supports leaving out the `Sync` and `Send` requirements 🙂, see https://github.com/dtolnay/async-trait#non-threadsafe-futures.