### PR TITLE
Add a Row-like interface to any PostgreSQL composite type

### DIFF
--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -110,7 +110,7 @@ pub use crate::error::Error;
 pub use crate::generic_client::GenericClient;
 pub use crate::portal::Portal;
 pub use crate::query::RowStream;
-pub use crate::row::{Row, SimpleQueryRow};
+pub use crate::row::{CompositeType, Row, SimpleQueryRow};
 pub use crate::simple_query::SimpleQueryStream;
 #[cfg(feature = "runtime")]
 pub use crate::socket::Socket;

--- a/tokio-postgres/src/row.rs
+++ b/tokio-postgres/src/row.rs
@@ -2,10 +2,11 @@
 
 use crate::row::sealed::{AsName, Sealed};
 use crate::statement::Column;
-use crate::types::{FromSql, Type, WrongType};
+use crate::types::{Field, FromSql, Kind, Type, WrongType};
 use crate::{Error, Statement};
+use byteorder::{BigEndian, ByteOrder};
 use fallible_iterator::FallibleIterator;
-use postgres_protocol::message::backend::DataRowBody;
+use postgres_protocol::message::backend::{DataRowBody, DataRowRanges};
 use std::fmt;
 use std::ops::Range;
 use std::str;
@@ -28,6 +29,12 @@ impl AsName for Column {
 impl AsName for String {
     fn as_name(&self) -> &str {
         self
+    }
+}
+
+impl AsName for Field {
+    fn as_name(&self) -> &str {
+        self.name()
     }
 }
 
@@ -171,6 +178,134 @@ impl Row {
         }
 
         let buf = self.ranges[idx].clone().map(|r| &self.body.buffer()[r]);
+        FromSql::from_sql_nullable(ty, buf).map_err(|e| Error::from_sql(e, idx))
+    }
+}
+
+/// PostgreSQL composite type.
+/// Fields of a type can be accessed using `CompositeType::get` and `CompositeType::try_get` methods.
+pub struct CompositeType<'a> {
+    type_: Type,
+    body: &'a [u8],
+    ranges: Vec<Option<Range<usize>>>,
+}
+
+impl<'a> FromSql<'a> for CompositeType<'a> {
+    fn from_sql(
+        type_: &Type,
+        raw: &'a [u8],
+    ) -> Result<CompositeType<'a>, Box<dyn std::error::Error + Sync + Send>> {
+        match *type_.kind() {
+            Kind::Composite(_) => {
+                let composite_type = CompositeType::new(type_.clone(), raw)?;
+                return Ok(composite_type);
+            }
+            _ => return Err(format!("expected composite type, got {}", type_).into()),
+        }
+    }
+    fn accepts(ty: &Type) -> bool {
+        match *ty.kind() {
+            Kind::Composite(_) => true,
+            _ => false,
+        }
+    }
+}
+
+fn composite_type_fields(type_: &Type) -> &[Field] {
+    match type_.kind() {
+        Kind::Composite(ref fields) => fields,
+        _ => unreachable!(),
+    }
+}
+
+impl<'a> CompositeType<'a> {
+    pub(crate) fn new(
+        type_: Type,
+        body: &'a [u8],
+    ) -> Result<CompositeType<'a>, Box<dyn std::error::Error + Sync + Send>> {
+        let fields: &[Field] = composite_type_fields(&type_);
+        if body.len() < 4 {
+            let message = format!("invalid composite type body length: {}", body.len());
+            return Err(message.into());
+        }
+        let num_fields: i32 = BigEndian::read_i32(&body[0..4]);
+        if num_fields as usize != fields.len() {
+            let message = format!("invalid field count: {} vs {}", num_fields, fields.len());
+            return Err(message.into());
+        }
+        let ranges =
+            DataRowRanges::composite_type_ranges(&body[4..], body.len(), num_fields as u16)
+                .collect()
+                .map_err(Error::parse)?;
+
+        Ok(CompositeType {
+            type_,
+            body,
+            ranges,
+        })
+    }
+
+    /// Returns information about the fields of the composite type.
+    pub fn fields(&self) -> &[Field] {
+        composite_type_fields(&self.type_)
+    }
+
+    /// Determines if the composite contains no values.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the number of fields of the composite type.
+    pub fn len(&self) -> usize {
+        self.fields().len()
+    }
+
+    /// Deserializes a value from the composite type.
+    ///
+    /// The value can be specified either by its numeric index, or by its field name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is out of bounds or if the value cannot be converted to the specified type.
+    pub fn get<'b, I, T>(&'b self, idx: I) -> T
+    where
+        I: RowIndex + fmt::Display,
+        T: FromSql<'b>,
+    {
+        match self.get_inner(&idx) {
+            Ok(ok) => ok,
+            Err(err) => panic!("error retrieving column {}: {}", idx, err),
+        }
+    }
+
+    /// Like `CompositeType::get`, but returns a `Result` rather than panicking.
+    pub fn try_get<'b, I, T>(&'b self, idx: I) -> Result<T, Error>
+    where
+        I: RowIndex + fmt::Display,
+        T: FromSql<'b>,
+    {
+        self.get_inner(&idx)
+    }
+
+    fn get_inner<'b, I, T>(&'b self, idx: &I) -> Result<T, Error>
+    where
+        I: RowIndex + fmt::Display,
+        T: FromSql<'b>,
+    {
+        let idx = match idx.__idx(self.fields()) {
+            Some(idx) => idx,
+            None => return Err(Error::column(idx.to_string())),
+        };
+
+        let ty = self.fields()[idx].type_();
+        if !T::accepts(ty) {
+            return Err(Error::from_sql(
+                Box::new(WrongType::new::<T>(ty.clone())),
+                idx,
+            ));
+        }
+
+        let buf = self.ranges[idx].clone().map(|r| &self.body[r]);
         FromSql::from_sql_nullable(ty, buf).map_err(|e| Error::from_sql(e, idx))
     }
 }

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -13,7 +13,8 @@ use tokio_postgres::error::SqlState;
 use tokio_postgres::tls::{NoTls, NoTlsStream};
 use tokio_postgres::types::{Kind, Type};
 use tokio_postgres::{
-    AsyncMessage, Client, Config, Connection, Error, IsolationLevel, SimpleQueryMessage,
+    AsyncMessage, Client, CompositeType, Config, Connection, Error, IsolationLevel,
+    SimpleQueryMessage,
 };
 
 mod binary_copy;
@@ -761,4 +762,56 @@ async fn query_opt() {
         .await
         .err()
         .unwrap();
+}
+
+#[tokio::test]
+async fn composite_type() {
+    let client = connect("user=postgres").await;
+
+    client
+        .batch_execute(
+            "
+                CREATE TYPE pg_temp.message AS (
+                    id INTEGER,
+                    content TEXT,
+                    link TEXT
+                );
+                CREATE TYPE pg_temp.person AS (
+                    id INTEGER,
+                    name TEXT,
+                    messages message[],
+                    email TEXT
+                );
+
+            ",
+        )
+        .await
+        .unwrap();
+
+    let row = client
+        .query_one(
+            "select (123,'alice',ARRAY[(1,'message1',NULL)::message,(2,'message2',NULL)::message],NULL)::person",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let person: CompositeType<'_> = row.get(0);
+
+    assert_eq!(person.get::<_, Option<i32>>("id"), Some(123));
+    assert_eq!(person.get::<_, Option<&str>>("name"), Some("alice"));
+    assert_eq!(person.get::<_, Option<&str>>("email"), None);
+
+    let messages: Vec<CompositeType<'_>> = person.get("messages");
+
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0].get::<_, Option<i32>>("id"), Some(1));
+    assert_eq!(
+        messages[0].get::<_, Option<&str>>("content"),
+        Some("message1")
+    );
+    assert_eq!(messages[0].get::<_, Option<&str>>("link"), None);
+    assert_eq!(messages[1].get::<_, Option<i32>>(0), Some(2));
+    assert_eq!(messages[1].get::<_, Option<&str>>(1), Some("message2"));
+    assert_eq!(messages[1].get::<_, Option<&str>>(2), None);
 }


### PR DESCRIPTION
It can be useful to be able to get fields of a composite type without the need to derive `FromSql` for a structure (https://github.com/sfackler/rust-postgres/issues/366).

This PR adds a new type `CompositeType` that implements `FromSql` and has the same methods as `Row`.

Example:


```sql
create table users (
  id               serial primary key,
  name             text
);
create table posts (
  id               serial primary key,
  author_id        integer not null references users(id),
  title            text,
  content          text
);
```
```rust
let query = "SELECT users.*,ARRAY_REMOVE(ARRAY_AGG(posts),NULL) as posts FROM users LEFT JOIN posts ON posts.author_id = users.id GROUP BY users.id";
let stmt = client.prepare(query).await?;
let rows: Vec<Row> = client.query(&stmt, &[]).await?;
for user_with_posts in rows {
    let user_name = user_with_posts.get::<_,&str>("name");
    // ...
    let user_posts = user_with_posts.get::<_,Vec<CompositeType>>("posts");
    for post in user_posts {
        let post_title = post.get::<_,&str>("title");
        let post_content = post.get::<_,&str>("content");
        // ...
    }
}
```
 

The binary format of a composite type is different from the format of a `DataRow` (there is an OID before each length/value pair), so I added a type parameter to `DataRowRanges` to make `FallibleIterator` for ranges usable for both cases:
https://github.com/alexwl/rust-postgres/blob/aa4b5547e3bf13e112ae90dd919b0ac70d67ebaa/postgres-protocol/src/message/backend.rs#L550-L574
