### PR TITLE
Expose async notifications in sync API

### DIFF
--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -51,8 +51,8 @@
 
 pub use fallible_iterator;
 pub use tokio_postgres::{
-    error, row, tls, types, Column, IsolationLevel, Portal, SimpleQueryMessage, Socket, Statement,
-    ToStatement,
+    error, row, tls, types, AsyncMessage, Column, IsolationLevel, Portal, SimpleQueryMessage,
+    Socket, Statement, ToStatement,
 };
 
 pub use crate::cancel_token::CancelToken;


### PR DESCRIPTION
@sfackler not sure if there are additional complexities here, but this callback is sufficient for my notification-receiving needs with the sync client. Consider this more of a proposal than a ready-to-merge PR!

----

Expose a Config::connect_with method in the sync API that allows the
user to provide a callback function that is invoked for every
asynchronous message or error received by the underlying connection.

Fix #404.