### PR TITLE
Add support for time-0.2 types

### DIFF
--- a/postgres-types/Cargo.toml
+++ b/postgres-types/Cargo.toml
@@ -18,6 +18,7 @@ with-eui48-0_4 = ["eui48-04"]
 with-geo-types-0_4 = ["geo-types-04"]
 with-serde_json-1 = ["serde-1", "serde_json-1"]
 with-uuid-0_8 = ["uuid-08"]
+with-time-0_2 = ["time-02"]
 
 [dependencies]
 bytes = "0.5"
@@ -32,3 +33,4 @@ geo-types-04 = { version = "0.4", package = "geo-types", optional = true }
 serde-1 = { version = "1.0", package = "serde", optional = true }
 serde_json-1 = { version = "1.0", package = "serde_json", optional = true }
 uuid-08 = { version = "0.8", package = "uuid", optional = true }
+time-02 = { version = "0.2", package = "time", optional = true }

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -398,7 +398,7 @@ impl WrongType {
 /// | `chrono::NaiveDate`             | DATE                                |
 /// | `chrono::NaiveTime`             | TIME                                |
 /// | `time::PrimitiveDateTime`       | TIMESTAMP                           |
-/// | `time::OffsetDateTime`          | TIMESTAMP, TIMESTAMP WITH TIME ZONE |
+/// | `time::OffsetDateTime`          | TIMESTAMP WITH TIME ZONE            |
 /// | `time::Date`                    | DATE                                |
 /// | `time::Time`                    | TIME                                |
 /// | `eui48::MacAddress`             | MACADDR                             |
@@ -661,7 +661,7 @@ pub enum IsNull {
 /// | `chrono::NaiveDate`             | DATE                                |
 /// | `chrono::NaiveTime`             | TIME                                |
 /// | `time::PrimitiveDateTime`       | TIMESTAMP                           |
-/// | `time::OffsetDateTime`          | TIMESTAMP, TIMESTAMP WITH TIME ZONE |
+/// | `time::OffsetDateTime`          | TIMESTAMP WITH TIME ZONE            |
 /// | `time::Date`                    | DATE                                |
 /// | `time::Time`                    | TIME                                |
 /// | `eui48::MacAddress`             | MACADDR                             |

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -198,8 +198,14 @@ mod eui48_04;
 mod geo_types_04;
 #[cfg(feature = "with-serde_json-1")]
 mod serde_json_1;
+#[cfg(feature = "with-time-0_2")]
+mod time_02;
 #[cfg(feature = "with-uuid-0_8")]
 mod uuid_08;
+
+// The time::{date, time} macros produce compile errors if the crate package is renamed.
+#[cfg(feature = "with-time-0_2")]
+extern crate time_02 as time;
 
 #[doc(hidden)]
 pub mod private;
@@ -391,6 +397,10 @@ impl WrongType {
 /// | `chrono::DateTime<FixedOffset>` | TIMESTAMP WITH TIME ZONE            |
 /// | `chrono::NaiveDate`             | DATE                                |
 /// | `chrono::NaiveTime`             | TIME                                |
+/// | `time::PrimitiveDateTime`       | TIMESTAMP                           |
+/// | `time::OffsetDateTime`          | TIMESTAMP, TIMESTAMP WITH TIME ZONE |
+/// | `time::Date`                    | DATE                                |
+/// | `time::Time`                    | TIME                                |
 /// | `eui48::MacAddress`             | MACADDR                             |
 /// | `geo_types::Point<f64>`         | POINT                               |
 /// | `geo_types::Rect<f64>`          | BOX                                 |
@@ -650,6 +660,10 @@ pub enum IsNull {
 /// | `chrono::DateTime<FixedOffset>` | TIMESTAMP WITH TIME ZONE            |
 /// | `chrono::NaiveDate`             | DATE                                |
 /// | `chrono::NaiveTime`             | TIME                                |
+/// | `time::PrimitiveDateTime`       | TIMESTAMP                           |
+/// | `time::OffsetDateTime`          | TIMESTAMP, TIMESTAMP WITH TIME ZONE |
+/// | `time::Date`                    | DATE                                |
+/// | `time::Time`                    | TIME                                |
 /// | `eui48::MacAddress`             | MACADDR                             |
 /// | `geo_types::Point<f64>`         | POINT                               |
 /// | `geo_types::Rect<f64>`          | BOX                                 |

--- a/postgres-types/src/time_02.rs
+++ b/postgres-types/src/time_02.rs
@@ -40,7 +40,7 @@ impl<'a> FromSql<'a> for OffsetDateTime {
         Ok(primitive.assume_utc())
     }
 
-    accepts!(TIMESTAMP, TIMESTAMPTZ);
+    accepts!(TIMESTAMPTZ);
 }
 
 impl ToSql for OffsetDateTime {
@@ -56,7 +56,7 @@ impl ToSql for OffsetDateTime {
         primitive.to_sql(type_, w)
     }
 
-    accepts!(TIMESTAMP, TIMESTAMPTZ);
+    accepts!(TIMESTAMPTZ);
     to_sql_checked!();
 }
 

--- a/postgres-types/src/time_02.rs
+++ b/postgres-types/src/time_02.rs
@@ -1,0 +1,109 @@
+use bytes::BytesMut;
+use postgres_protocol::types;
+use std::convert::TryFrom;
+use std::error::Error;
+use time_02::{date, time, Date, Duration, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
+
+use crate::{FromSql, IsNull, ToSql, Type};
+
+#[rustfmt::skip]
+const fn base() -> PrimitiveDateTime {
+    PrimitiveDateTime::new(date!(2000-01-01), time!(00:00:00))
+}
+
+impl<'a> FromSql<'a> for PrimitiveDateTime {
+    fn from_sql(_: &Type, raw: &[u8]) -> Result<PrimitiveDateTime, Box<dyn Error + Sync + Send>> {
+        let t = types::timestamp_from_sql(raw)?;
+        Ok(base() + Duration::microseconds(t))
+    }
+
+    accepts!(TIMESTAMP);
+}
+
+impl ToSql for PrimitiveDateTime {
+    fn to_sql(&self, _: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        let time = match i64::try_from((*self - base()).whole_microseconds()) {
+            Ok(time) => time,
+            Err(_) => return Err("value too large to transmit".into()),
+        };
+        types::timestamp_to_sql(time, w);
+        Ok(IsNull::No)
+    }
+
+    accepts!(TIMESTAMP);
+    to_sql_checked!();
+}
+
+impl<'a> FromSql<'a> for OffsetDateTime {
+    fn from_sql(type_: &Type, raw: &[u8]) -> Result<OffsetDateTime, Box<dyn Error + Sync + Send>> {
+        let primitive = PrimitiveDateTime::from_sql(type_, raw)?;
+        Ok(primitive.assume_utc())
+    }
+
+    accepts!(TIMESTAMP, TIMESTAMPTZ);
+}
+
+impl ToSql for OffsetDateTime {
+    fn to_sql(
+        &self,
+        type_: &Type,
+        w: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        let utc_datetime = self.to_offset(UtcOffset::UTC);
+        let date = utc_datetime.date();
+        let time = utc_datetime.time();
+        let primitive = PrimitiveDateTime::new(date, time);
+        primitive.to_sql(type_, w)
+    }
+
+    accepts!(TIMESTAMP, TIMESTAMPTZ);
+    to_sql_checked!();
+}
+
+impl<'a> FromSql<'a> for Date {
+    fn from_sql(_: &Type, raw: &[u8]) -> Result<Date, Box<dyn Error + Sync + Send>> {
+        let jd = types::date_from_sql(raw)?;
+        Ok(base().date() + Duration::days(i64::from(jd)))
+    }
+
+    accepts!(DATE);
+}
+
+impl ToSql for Date {
+    fn to_sql(&self, _: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        let jd = (*self - base().date()).whole_days();
+        if jd > i64::from(i32::max_value()) || jd < i64::from(i32::min_value()) {
+            return Err("value too large to transmit".into());
+        }
+
+        types::date_to_sql(jd as i32, w);
+        Ok(IsNull::No)
+    }
+
+    accepts!(DATE);
+    to_sql_checked!();
+}
+
+impl<'a> FromSql<'a> for Time {
+    fn from_sql(_: &Type, raw: &[u8]) -> Result<Time, Box<dyn Error + Sync + Send>> {
+        let usec = types::time_from_sql(raw)?;
+        Ok(time!(00:00:00) + Duration::microseconds(usec))
+    }
+
+    accepts!(TIME);
+}
+
+impl ToSql for Time {
+    fn to_sql(&self, _: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        let delta = *self - time!(00:00:00);
+        let time = match i64::try_from(delta.whole_microseconds()) {
+            Ok(time) => time,
+            Err(_) => return Err("value too large to transmit".into()),
+        };
+        types::time_to_sql(time, w);
+        Ok(IsNull::No)
+    }
+
+    accepts!(TIME);
+    to_sql_checked!();
+}

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -27,6 +27,7 @@ with-eui48-0_4 = ["tokio-postgres/with-eui48-0_4"]
 with-geo-types-0_4 = ["tokio-postgres/with-geo-types-0_4"]
 with-serde_json-1 = ["tokio-postgres/with-serde_json-1"]
 with-uuid-0_8 = ["tokio-postgres/with-uuid-0_8"]
+with-time-0_2 = ["tokio-postgres/with-time-0_2"]
 
 [dependencies]
 bytes = "0.5"

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -63,4 +63,5 @@ geo-types-04 = { version = "0.4", package = "geo-types" }
 serde-1 = { version = "1.0", package = "serde" }
 serde_json-1 = { version = "1.0", package = "serde_json" }
 uuid-08 = { version = "0.8", package = "uuid" }
+time-02 = { version = "0.2", package = "time" }
 

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -33,6 +33,7 @@ with-eui48-0_4 = ["postgres-types/with-eui48-0_4"]
 with-geo-types-0_4 = ["postgres-types/with-geo-types-0_4"]
 with-serde_json-1 = ["postgres-types/with-serde_json-1"]
 with-uuid-0_8 = ["postgres-types/with-uuid-0_8"]
+with-time-0_2 = ["postgres-types/with-time-0_2"]
 
 [dependencies]
 async-trait = "0.1"

--- a/tokio-postgres/tests/test/types/mod.rs
+++ b/tokio-postgres/tests/test/types/mod.rs
@@ -22,6 +22,8 @@ mod eui48_04;
 mod geo_010;
 #[cfg(feature = "with-serde_json-1")]
 mod serde_json_1;
+#[cfg(feature = "with-time-0_2")]
+mod time_02;
 #[cfg(feature = "with-uuid-0_8")]
 mod uuid_08;
 

--- a/tokio-postgres/tests/test/types/time_02.rs
+++ b/tokio-postgres/tests/test/types/time_02.rs
@@ -1,0 +1,147 @@
+use time_02::{OffsetDateTime, PrimitiveDateTime};
+use tokio_postgres::types::{Date, Timestamp};
+
+use crate::types::test_type;
+
+#[tokio::test]
+async fn test_naive_date_time_params() {
+    fn make_check(time: &str) -> (Option<PrimitiveDateTime>, &str) {
+        (
+            Some(PrimitiveDateTime::parse(time, "'%Y-%m-%d %H:%M:%S.%f'").unwrap()),
+            time,
+        )
+    }
+    test_type(
+        "TIMESTAMP",
+        &[
+            make_check("'1970-01-01 00:00:00.010000000'"),
+            make_check("'1965-09-25 11:19:33.100314000'"),
+            make_check("'2010-02-09 23:11:45.120200000'"),
+            (None, "NULL"),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_with_special_naive_date_time_params() {
+    fn make_check(time: &str) -> (Timestamp<PrimitiveDateTime>, &str) {
+        (
+            Timestamp::Value(PrimitiveDateTime::parse(time, "'%Y-%m-%d %H:%M:%S.%f'").unwrap()),
+            time,
+        )
+    }
+    test_type(
+        "TIMESTAMP",
+        &[
+            make_check("'1970-01-01 00:00:00.010000000'"),
+            make_check("'1965-09-25 11:19:33.100314000'"),
+            make_check("'2010-02-09 23:11:45.120200000'"),
+            (Timestamp::PosInfinity, "'infinity'"),
+            (Timestamp::NegInfinity, "'-infinity'"),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_date_time_params() {
+    fn make_check(time: &str) -> (Option<OffsetDateTime>, &str) {
+        (
+            Some(OffsetDateTime::parse(time, "'%Y-%m-%d %H:%M:%S.%f'").unwrap()),
+            time,
+        )
+    }
+    test_type(
+        "TIMESTAMP WITH TIME ZONE",
+        &[
+            make_check("'1970-01-01 00:00:00.010000000'"),
+            make_check("'1965-09-25 11:19:33.100314000'"),
+            make_check("'2010-02-09 23:11:45.120200000'"),
+            (None, "NULL"),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_with_special_date_time_params() {
+    fn make_check(time: &str) -> (Timestamp<OffsetDateTime>, &str) {
+        (
+            Timestamp::Value(OffsetDateTime::parse(time, "'%Y-%m-%d %H:%M:%S.%f'").unwrap()),
+            time,
+        )
+    }
+    test_type(
+        "TIMESTAMP WITH TIME ZONE",
+        &[
+            make_check("'1970-01-01 00:00:00.010000000'"),
+            make_check("'1965-09-25 11:19:33.100314000'"),
+            make_check("'2010-02-09 23:11:45.120200000'"),
+            (Timestamp::PosInfinity, "'infinity'"),
+            (Timestamp::NegInfinity, "'-infinity'"),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_date_params() {
+    fn make_check(time: &str) -> (Option<time_02::Date>, &str) {
+        (
+            Some(time_02::Date::parse(time, "'%Y-%m-%d'").unwrap()),
+            time,
+        )
+    }
+    test_type(
+        "DATE",
+        &[
+            make_check("'1970-01-01'"),
+            make_check("'1965-09-25'"),
+            make_check("'2010-02-09'"),
+            (None, "NULL"),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_with_special_date_params() {
+    fn make_check(date: &str) -> (Date<time_02::Date>, &str) {
+        (
+            Date::Value(time_02::Date::parse(date, "'%Y-%m-%d'").unwrap()),
+            date,
+        )
+    }
+    test_type(
+        "DATE",
+        &[
+            make_check("'1970-01-01'"),
+            make_check("'1965-09-25'"),
+            make_check("'2010-02-09'"),
+            (Date::PosInfinity, "'infinity'"),
+            (Date::NegInfinity, "'-infinity'"),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_time_params() {
+    fn make_check(time: &str) -> (Option<time_02::Time>, &str) {
+        (
+            Some(time_02::Time::parse(time, "'%H:%M:%S.%f'").unwrap()),
+            time,
+        )
+    }
+    test_type(
+        "TIME",
+        &[
+            make_check("'00:00:00.010000000'"),
+            make_check("'11:19:33.100314000'"),
+            make_check("'23:11:45.120200000'"),
+            (None, "NULL"),
+        ],
+    )
+    .await;
+}

--- a/tokio-postgres/tests/test/types/time_02.rs
+++ b/tokio-postgres/tests/test/types/time_02.rs
@@ -3,20 +3,23 @@ use tokio_postgres::types::{Date, Timestamp};
 
 use crate::types::test_type;
 
+// time 0.2 does not [yet?] support parsing fractional seconds
+// https://github.com/time-rs/time/issues/226
+
 #[tokio::test]
-async fn test_naive_date_time_params() {
+async fn test_primitive_date_time_params() {
     fn make_check(time: &str) -> (Option<PrimitiveDateTime>, &str) {
         (
-            Some(PrimitiveDateTime::parse(time, "'%Y-%m-%d %H:%M:%S.%f'").unwrap()),
+            Some(PrimitiveDateTime::parse(time, "'%Y-%m-%d %H:%M:%S'").unwrap()),
             time,
         )
     }
     test_type(
         "TIMESTAMP",
         &[
-            make_check("'1970-01-01 00:00:00.010000000'"),
-            make_check("'1965-09-25 11:19:33.100314000'"),
-            make_check("'2010-02-09 23:11:45.120200000'"),
+            make_check("'1970-01-01 00:00:00'"), // .010000000
+            make_check("'1965-09-25 11:19:33'"), // .100314000
+            make_check("'2010-02-09 23:11:45'"), // .120200000
             (None, "NULL"),
         ],
     )
@@ -24,19 +27,19 @@ async fn test_naive_date_time_params() {
 }
 
 #[tokio::test]
-async fn test_with_special_naive_date_time_params() {
+async fn test_with_special_primitive_date_time_params() {
     fn make_check(time: &str) -> (Timestamp<PrimitiveDateTime>, &str) {
         (
-            Timestamp::Value(PrimitiveDateTime::parse(time, "'%Y-%m-%d %H:%M:%S.%f'").unwrap()),
+            Timestamp::Value(PrimitiveDateTime::parse(time, "'%Y-%m-%d %H:%M:%S'").unwrap()),
             time,
         )
     }
     test_type(
         "TIMESTAMP",
         &[
-            make_check("'1970-01-01 00:00:00.010000000'"),
-            make_check("'1965-09-25 11:19:33.100314000'"),
-            make_check("'2010-02-09 23:11:45.120200000'"),
+            make_check("'1970-01-01 00:00:00'"), // .010000000
+            make_check("'1965-09-25 11:19:33'"), // .100314000
+            make_check("'2010-02-09 23:11:45'"), // .120200000
             (Timestamp::PosInfinity, "'infinity'"),
             (Timestamp::NegInfinity, "'-infinity'"),
         ],
@@ -45,19 +48,19 @@ async fn test_with_special_naive_date_time_params() {
 }
 
 #[tokio::test]
-async fn test_date_time_params() {
+async fn test_offset_date_time_params() {
     fn make_check(time: &str) -> (Option<OffsetDateTime>, &str) {
         (
-            Some(OffsetDateTime::parse(time, "'%Y-%m-%d %H:%M:%S.%f'").unwrap()),
+            Some(OffsetDateTime::parse(time, "'%Y-%m-%d %H:%M:%S %z'").unwrap()),
             time,
         )
     }
     test_type(
         "TIMESTAMP WITH TIME ZONE",
         &[
-            make_check("'1970-01-01 00:00:00.010000000'"),
-            make_check("'1965-09-25 11:19:33.100314000'"),
-            make_check("'2010-02-09 23:11:45.120200000'"),
+            make_check("'1970-01-01 00:00:00 +0000'"), // .010000000
+            make_check("'1965-09-25 11:19:33 +0000'"), // .100314000
+            make_check("'2010-02-09 23:11:45 +0000'"), // .120200000
             (None, "NULL"),
         ],
     )
@@ -65,19 +68,19 @@ async fn test_date_time_params() {
 }
 
 #[tokio::test]
-async fn test_with_special_date_time_params() {
+async fn test_with_special_offset_date_time_params() {
     fn make_check(time: &str) -> (Timestamp<OffsetDateTime>, &str) {
         (
-            Timestamp::Value(OffsetDateTime::parse(time, "'%Y-%m-%d %H:%M:%S.%f'").unwrap()),
+            Timestamp::Value(OffsetDateTime::parse(time, "'%Y-%m-%d %H:%M:%S %z'").unwrap()),
             time,
         )
     }
     test_type(
         "TIMESTAMP WITH TIME ZONE",
         &[
-            make_check("'1970-01-01 00:00:00.010000000'"),
-            make_check("'1965-09-25 11:19:33.100314000'"),
-            make_check("'2010-02-09 23:11:45.120200000'"),
+            make_check("'1970-01-01 00:00:00 +0000'"), // .010000000
+            make_check("'1965-09-25 11:19:33 +0000'"), // .100314000
+            make_check("'2010-02-09 23:11:45 +0000'"), // .120200000
             (Timestamp::PosInfinity, "'infinity'"),
             (Timestamp::NegInfinity, "'-infinity'"),
         ],
@@ -130,16 +133,16 @@ async fn test_with_special_date_params() {
 async fn test_time_params() {
     fn make_check(time: &str) -> (Option<time_02::Time>, &str) {
         (
-            Some(time_02::Time::parse(time, "'%H:%M:%S.%f'").unwrap()),
+            Some(time_02::Time::parse(time, "'%H:%M:%S'").unwrap()),
             time,
         )
     }
     test_type(
         "TIME",
         &[
-            make_check("'00:00:00.010000000'"),
-            make_check("'11:19:33.100314000'"),
-            make_check("'23:11:45.120200000'"),
+            make_check("'00:00:00'"), // .010000000
+            make_check("'11:19:33'"), // .100314000
+            make_check("'23:11:45'"), // .120200000
             (None, "NULL"),
         ],
     )


### PR DESCRIPTION
This is essentially ported from the `chrono` implementation. 