### PR TITLE
Don't accidentally return early from CopyOutReader

### DIFF
--- a/postgres/src/copy_out_reader.rs
+++ b/postgres/src/copy_out_reader.rs
@@ -34,7 +34,7 @@ impl Read for CopyOutReader<'_> {
 
 impl BufRead for CopyOutReader<'_> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
-        if !self.cur.has_remaining() {
+        while !self.cur.has_remaining() {
             let mut stream = self.stream.pinned();
             match self
                 .connection
@@ -42,7 +42,7 @@ impl BufRead for CopyOutReader<'_> {
             {
                 Ok(Some(cur)) => self.cur = cur,
                 Err(e) => return Err(io::Error::new(io::ErrorKind::Other, e)),
-                Ok(None) => {}
+                Ok(None) => break,
             };
         }
 


### PR DESCRIPTION
The COPY OUT protocol allows sending CopyData packets that have no data.
The (synchronous) CopyOutReader needs to be careful not to return an
empty slice in this case, but instead request more data, since an empty
slice is taken to mean EOF.