### PR TITLE
Re-add savepoint method to Transaction

### DIFF
--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -173,9 +173,20 @@ impl<'a> Transaction<'a> {
         CancelToken::new(self.transaction.cancel_token())
     }
 
-    /// Like `Client::transaction`.
+    /// Like `Client::transaction`, but creates a nested transaction via a savepoint.
     pub fn transaction(&mut self) -> Result<Transaction<'_>, Error> {
         let transaction = self.connection.block_on(self.transaction.transaction())?;
+        Ok(Transaction {
+            connection: self.connection.as_ref(),
+            transaction,
+        })
+    }
+    /// Like `Client::transaction`, but creates a nested transaction via a savepoint with the specified name.
+    pub fn savepoint<I>(&mut self, name: I) -> Result<Transaction<'_>, Error>
+    where
+        I: Into<String>,
+    {
+        let transaction = self.connection.block_on(self.transaction.savepoint(name))?;
         Ok(Transaction {
             connection: self.connection.as_ref(),
             transaction,


### PR DESCRIPTION
Revives #184.

The rewrite for async/await and Tokio accidentally lost functionality
that allowed users to assign specific names to savepoints when using
nested transactions. This functionality had originally been added
in #184 and had been updated in #374.

This commit revives this functionality using a similar scheme to the
one that existed before. This should allow CockroachDB users to update
to the next patch release of version `0.17`.