### PR TITLE
Add support for money type

### DIFF
--- a/postgres-protocol/src/types/mod.rs
+++ b/postgres-protocol/src/types/mod.rs
@@ -441,6 +441,22 @@ pub fn uuid_from_sql(buf: &[u8]) -> Result<[u8; 16], StdBox<dyn Error + Sync + S
     Ok(out)
 }
 
+/// Serializes a `Money` value.
+#[inline]
+pub fn money_to_sql(v: i64, buf: &mut BytesMut) {
+    buf.put_i64(v);
+}
+
+/// Deserializes a `Money` value.
+#[inline]
+pub fn money_from_sql(mut buf: &[u8]) -> Result<i64, StdBox<dyn Error + Sync + Send>> {
+    let v = buf.read_i64::<BigEndian>()?;
+    if !buf.is_empty() {
+        return Err("invalid buffer size".into());
+    }
+    Ok(v)
+}
+
 /// Serializes an array value.
 #[inline]
 pub fn array_to_sql<T, I, J, F>(

--- a/postgres-types/Cargo.toml
+++ b/postgres-types/Cargo.toml
@@ -16,6 +16,7 @@ with-bit-vec-0_6 = ["bit-vec-06"]
 with-chrono-0_4 = ["chrono-04"]
 with-eui48-0_4 = ["eui48-04"]
 with-geo-types-0_4 = ["geo-types-04"]
+with-money-0_1 = ["money-01"]
 with-serde_json-1 = ["serde-1", "serde_json-1"]
 with-uuid-0_8 = ["uuid-08"]
 with-time-0_2 = ["time-02"]
@@ -30,6 +31,7 @@ bit-vec-06 = { version = "0.6", package = "bit-vec", optional = true }
 chrono-04 = { version = "0.4", package = "chrono", optional = true }
 eui48-04 = { version = "0.4", package = "eui48", optional = true }
 geo-types-04 = { version = "0.4", package = "geo-types", optional = true }
+money-01 = { version = "0.2", package = "postgres_money", optional = true }
 serde-1 = { version = "1.0", package = "serde", optional = true }
 serde_json-1 = { version = "1.0", package = "serde_json", optional = true }
 uuid-08 = { version = "0.8", package = "uuid", optional = true }

--- a/postgres-types/Cargo.toml
+++ b/postgres-types/Cargo.toml
@@ -16,7 +16,7 @@ with-bit-vec-0_6 = ["bit-vec-06"]
 with-chrono-0_4 = ["chrono-04"]
 with-eui48-0_4 = ["eui48-04"]
 with-geo-types-0_4 = ["geo-types-04"]
-with-money-0_1 = ["money-01"]
+with-money-0_2 = ["money-02"]
 with-serde_json-1 = ["serde-1", "serde_json-1"]
 with-uuid-0_8 = ["uuid-08"]
 with-time-0_2 = ["time-02"]
@@ -31,7 +31,7 @@ bit-vec-06 = { version = "0.6", package = "bit-vec", optional = true }
 chrono-04 = { version = "0.4", package = "chrono", optional = true }
 eui48-04 = { version = "0.4", package = "eui48", optional = true }
 geo-types-04 = { version = "0.4", package = "geo-types", optional = true }
-money-01 = { version = "0.2", package = "postgres_money", optional = true }
+money-02 = { version = "0.2", package = "postgres_money", optional = true }
 serde-1 = { version = "1.0", package = "serde", optional = true }
 serde_json-1 = { version = "1.0", package = "serde_json", optional = true }
 uuid-08 = { version = "0.8", package = "uuid", optional = true }

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -196,8 +196,8 @@ mod chrono_04;
 mod eui48_04;
 #[cfg(feature = "with-geo-types-0_4")]
 mod geo_types_04;
-#[cfg(feature = "with-money-0_1")]
-mod money_01;
+#[cfg(feature = "with-money-0_2")]
+mod money_02;
 #[cfg(feature = "with-serde_json-1")]
 mod serde_json_1;
 #[cfg(feature = "with-time-0_2")]

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -196,6 +196,8 @@ mod chrono_04;
 mod eui48_04;
 #[cfg(feature = "with-geo-types-0_4")]
 mod geo_types_04;
+#[cfg(feature = "with-money-0_1")]
+mod money_01;
 #[cfg(feature = "with-serde_json-1")]
 mod serde_json_1;
 #[cfg(feature = "with-time-0_2")]

--- a/postgres-types/src/money_01.rs
+++ b/postgres-types/src/money_01.rs
@@ -1,0 +1,25 @@
+use bytes::BytesMut;
+use std::error::Error;
+use postgres_protocol::types;
+use money_01::Money;
+
+use crate::{FromSql, IsNull, ToSql, Type};
+
+impl<'a> FromSql<'a> for Money {
+    fn from_sql(_: &Type, raw: &[u8]) -> Result<Money, Box<dyn Error + Sync + Send>> {
+        let inner = types::money_from_sql(raw)?;
+        Ok(Money::from(inner))
+    }
+
+    accepts!(MONEY);
+}
+
+impl ToSql for Money {
+    fn to_sql(&self, _: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        types::money_to_sql(self.inner(), w);
+        Ok(IsNull::No)
+    }
+
+    accepts!(MONEY);
+    to_sql_checked!();
+}

--- a/postgres-types/src/money_02.rs
+++ b/postgres-types/src/money_02.rs
@@ -1,7 +1,7 @@
 use bytes::BytesMut;
-use std::error::Error;
+use money_02::Money;
 use postgres_protocol::types;
-use money_01::Money;
+use std::error::Error;
 
 use crate::{FromSql, IsNull, ToSql, Type};
 

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -31,7 +31,7 @@ with-bit-vec-0_6 = ["postgres-types/with-bit-vec-0_6"]
 with-chrono-0_4 = ["postgres-types/with-chrono-0_4"]
 with-eui48-0_4 = ["postgres-types/with-eui48-0_4"]
 with-geo-types-0_4 = ["postgres-types/with-geo-types-0_4"]
-with-money-0_1 = ["postgres-types/with-money-0_1"]
+with-money-0_2 = ["postgres-types/with-money-0_2"]
 with-serde_json-1 = ["postgres-types/with-serde_json-1"]
 with-uuid-0_8 = ["postgres-types/with-uuid-0_8"]
 with-time-0_2 = ["postgres-types/with-time-0_2"]
@@ -61,7 +61,7 @@ bit-vec-06 = { version = "0.6", package = "bit-vec" }
 chrono-04 = { version = "0.4", package = "chrono" }
 eui48-04 = { version = "0.4", package = "eui48" }
 geo-types-04 = { version = "0.4", package = "geo-types" }
-money-01 = { version = "0.2", package = "postgres_money" }
+money-02 = { version = "0.2", package = "postgres_money" }
 serde-1 = { version = "1.0", package = "serde" }
 serde_json-1 = { version = "1.0", package = "serde_json" }
 uuid-08 = { version = "0.8", package = "uuid" }

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -31,6 +31,7 @@ with-bit-vec-0_6 = ["postgres-types/with-bit-vec-0_6"]
 with-chrono-0_4 = ["postgres-types/with-chrono-0_4"]
 with-eui48-0_4 = ["postgres-types/with-eui48-0_4"]
 with-geo-types-0_4 = ["postgres-types/with-geo-types-0_4"]
+with-money-0_1 = ["postgres-types/with-money-0_1"]
 with-serde_json-1 = ["postgres-types/with-serde_json-1"]
 with-uuid-0_8 = ["postgres-types/with-uuid-0_8"]
 with-time-0_2 = ["postgres-types/with-time-0_2"]
@@ -60,6 +61,7 @@ bit-vec-06 = { version = "0.6", package = "bit-vec" }
 chrono-04 = { version = "0.4", package = "chrono" }
 eui48-04 = { version = "0.4", package = "eui48" }
 geo-types-04 = { version = "0.4", package = "geo-types" }
+money-01 = { version = "0.2", package = "postgres_money" }
 serde-1 = { version = "1.0", package = "serde" }
 serde_json-1 = { version = "1.0", package = "serde_json" }
 uuid-08 = { version = "0.8", package = "uuid" }


### PR DESCRIPTION
Closes #598 

Implements `ToSql` and `FromSql` for the [`postgres_money::Money`](https://docs.rs/postgres_money/0.2.0/postgres_money/struct.Money.html) struct, behind the feature `with-money-0_2`.

