### PR TITLE
Fix enum name check.

### DIFF
--- a/postgres-derive/src/tosql.rs
+++ b/postgres-derive/src/tosql.rs
@@ -10,8 +10,7 @@ use crate::overrides::Overrides;
 
 pub fn expand_derive_tosql(input: DeriveInput) -> Result<TokenStream, Error> {
     let overrides = Overrides::extract(&input.attrs)?;
-
-    let name = overrides.name.unwrap_or_else(|| input.ident.to_string());
+    let name = overrides.name.unwrap_or_else(|| input.ident.to_string().to_lowercase());
 
     let (accepts_body, to_sql_body) = match input.data {
         Data::Enum(ref data) => {


### PR DESCRIPTION
I think there is an issue with checking the name derived using `ToSql` on Enums and the case-insensitivity of the Postgres type names. I ran into issues when I derived `ToSql` and then tried to use `prepared_typed` to insert the Enum values. The types I used in `prepare_typed` were fetched from the server using the suggestion from #585. The original type definition used to create the type in Postgres had a casing that matched the Enum name in rust, but the type name returned from the query was lowercase. I know this can probably be fixed with `#[postgres(name="foo")]`, but I think it is better to handle this by default. This patch may not cover all possible scenarios that we want to match.   