### PR TITLE
Fix clippy lint warnings regarding indirect structural matches

### DIFF
--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -106,7 +106,7 @@
 //! }
 //! ```
 #![doc(html_root_url = "https://docs.rs/postgres-types/0.1")]
-#![warn(clippy::all, rust_2018_idioms, missing_docs)]
+#![warn(clippy::all, future_incompatible, rust_2018_idioms, missing_docs)]
 
 use fallible_iterator::FallibleIterator;
 use postgres_protocol::types::{self, ArrayDimension};
@@ -144,8 +144,8 @@ const NSEC_PER_USEC: u64 = 1_000;
 macro_rules! accepts {
     ($($expected:ident),+) => (
         fn accepts(ty: &$crate::Type) -> bool {
-            match *ty {
-                $($crate::Type::$expected)|+ => true,
+            match ty {
+                $(typ if *typ == $crate::Type::$expected => true,)*
                 _ => false
             }
         }

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -536,8 +536,8 @@ impl<'a> FromSql<'a> for &'a str {
     }
 
     fn accepts(ty: &Type) -> bool {
-        match *ty {
-            Type::VARCHAR | Type::TEXT | Type::BPCHAR | Type::NAME | Type::UNKNOWN => true,
+        match ty {
+            typ if *typ == Type::VARCHAR || *typ == Type::TEXT || *typ == Type::BPCHAR || *typ == Type::NAME || *typ == Type::UNKNOWN => true,
             ref ty if ty.name() == "citext" => true,
             _ => false,
         }
@@ -830,8 +830,8 @@ impl<'a> ToSql for &'a str {
     }
 
     fn accepts(ty: &Type) -> bool {
-        match *ty {
-            Type::VARCHAR | Type::TEXT | Type::BPCHAR | Type::NAME | Type::UNKNOWN => true,
+        match ty {
+            typ if *typ == Type::VARCHAR || *typ == Type::TEXT || *typ == Type::BPCHAR || *typ == Type::NAME || *typ == Type::UNKNOWN => true,
             ref ty if ty.name() == "citext" => true,
             _ => false,
         }

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -537,7 +537,14 @@ impl<'a> FromSql<'a> for &'a str {
 
     fn accepts(ty: &Type) -> bool {
         match ty {
-            typ if *typ == Type::VARCHAR || *typ == Type::TEXT || *typ == Type::BPCHAR || *typ == Type::NAME || *typ == Type::UNKNOWN => true,
+            typ if *typ == Type::VARCHAR
+                || *typ == Type::TEXT
+                || *typ == Type::BPCHAR
+                || *typ == Type::NAME
+                || *typ == Type::UNKNOWN =>
+            {
+                true
+            }
             ref ty if ty.name() == "citext" => true,
             _ => false,
         }
@@ -831,7 +838,14 @@ impl<'a> ToSql for &'a str {
 
     fn accepts(ty: &Type) -> bool {
         match ty {
-            typ if *typ == Type::VARCHAR || *typ == Type::TEXT || *typ == Type::BPCHAR || *typ == Type::NAME || *typ == Type::UNKNOWN => true,
+            typ if *typ == Type::VARCHAR
+                || *typ == Type::TEXT
+                || *typ == Type::BPCHAR
+                || *typ == Type::NAME
+                || *typ == Type::UNKNOWN =>
+            {
+                true
+            }
             ref ty if ty.name() == "citext" => true,
             _ => false,
         }

--- a/postgres-types/src/special.rs
+++ b/postgres-types/src/special.rs
@@ -76,7 +76,9 @@ impl<'a, T: FromSql<'a>> FromSql<'a> for Timestamp<T> {
 
     fn accepts(ty: &Type) -> bool {
         match ty {
-            typ if (*typ == Type::TIMESTAMP || *typ == Type::TIMESTAMPTZ) && T::accepts(&ty) => true,
+            typ if (*typ == Type::TIMESTAMP || *typ == Type::TIMESTAMPTZ) && T::accepts(&ty) => {
+                true
+            }
             _ => false,
         }
     }
@@ -100,7 +102,9 @@ impl<T: ToSql> ToSql for Timestamp<T> {
 
     fn accepts(ty: &Type) -> bool {
         match ty {
-            typ if (*typ == Type::TIMESTAMP || *typ == Type::TIMESTAMPTZ) && T::accepts(&ty) => true,
+            typ if (*typ == Type::TIMESTAMP || *typ == Type::TIMESTAMPTZ) && T::accepts(&ty) => {
+                true
+            }
             _ => false,
         }
     }

--- a/postgres-types/src/special.rs
+++ b/postgres-types/src/special.rs
@@ -75,8 +75,8 @@ impl<'a, T: FromSql<'a>> FromSql<'a> for Timestamp<T> {
     }
 
     fn accepts(ty: &Type) -> bool {
-        match *ty {
-            Type::TIMESTAMP | Type::TIMESTAMPTZ if T::accepts(ty) => true,
+        match ty {
+            typ if (*typ == Type::TIMESTAMP || *typ == Type::TIMESTAMPTZ) && T::accepts(&ty) => true,
             _ => false,
         }
     }
@@ -99,8 +99,8 @@ impl<T: ToSql> ToSql for Timestamp<T> {
     }
 
     fn accepts(ty: &Type) -> bool {
-        match *ty {
-            Type::TIMESTAMP | Type::TIMESTAMPTZ if T::accepts(ty) => true,
+        match ty {
+            typ if (*typ == Type::TIMESTAMP || *typ == Type::TIMESTAMPTZ) && T::accepts(&ty) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
With `#[warn(future_incompatible)]`, one gets a warning in the `accepts!` macro due an indirect structural match (see https://github.com/rust-lang/rust/issues/62411).

E.g. today one gets:

```
warning: to use a constant of type `std::sync::Arc` in a pattern, `std::sync::Arc` must be annotated with `#[derive(PartialEq, Eq)]`
   --> postgres-types/src/lib.rs:148:19
    |
148 |                 $($crate::Type::$expected)|+ => true,
    |                   ^^^^^^^^^^^^^^^^^^^^^^^
...
944 |     accepts!(INET);
    |     --------------- in this macro invocation
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

This PR implements option number 2 in the fixes suggested in the above tracking issue, and enables the `future_incompatible` lint to ensure we conform.