### PR TITLE
Add Debug + Clone to structs in postgres-native-tls

### DIFF
--- a/postgres-native-tls/src/lib.rs
+++ b/postgres-native-tls/src/lib.rs
@@ -93,6 +93,7 @@ where
 }
 
 /// A `TlsConnect` implementation using the `native-tls` crate.
+#[derive(Debug, Clone)]
 pub struct TlsConnector {
     connector: tokio_tls::TlsConnector,
     domain: String,
@@ -129,6 +130,7 @@ where
 }
 
 /// The stream returned by `TlsConnector`.
+#[derive(Debug)]
 pub struct TlsStream<S>(tokio_tls::TlsStream<S>);
 
 impl<S> AsyncRead for TlsStream<S>


### PR DESCRIPTION
Straight-forward, I found these to be missing when combining the TLS implementation with a `bb8` connection pool, which requires the `TlsConnector` to be `Clone`.