### PR TITLE
Disable chrono's "oldtime" feature to drop time v0.1

### DIFF
--- a/postgres-types/Cargo.toml
+++ b/postgres-types/Cargo.toml
@@ -28,7 +28,7 @@ postgres-protocol = { version = "0.5.0", path = "../postgres-protocol" }
 postgres-derive = { version = "0.4.0", optional = true, path = "../postgres-derive" }
 
 bit-vec-06 = { version = "0.6", package = "bit-vec", optional = true }
-chrono-04 = { version = "0.4", package = "chrono", optional = true }
+chrono-04 = { version = "0.4.16", package = "chrono", default-features = false, features = ["clock"], optional = true }
 eui48-04 = { version = "0.4", package = "eui48", optional = true }
 geo-types-04 = { version = "0.4", package = "geo-types", optional = true }
 geo-types-06 = { version = "0.6", package = "geo-types", optional = true }

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -58,7 +58,7 @@ env_logger = "0.7"
 criterion = "0.3"
 
 bit-vec-06 = { version = "0.6", package = "bit-vec" }
-chrono-04 = { version = "0.4", package = "chrono" }
+chrono-04 = { version = "0.4", package = "chrono", default-features = false }
 eui48-04 = { version = "0.4", package = "eui48" }
 geo-types-04 = { version = "0.4", package = "geo-types" }
 geo-types-06 = { version = "0.6", package = "geo-types" }


### PR DESCRIPTION
The latest version of chrono, v0.4.16, permits removing its dependency
on the long-deprecated time v0.1 crate by disabling the "oldtime"
feature.

For backwards compatibility, chrono is leaving the "oldtime" feature on
by default, so disabling the "oldtime" feature requires disabling all
default features and then re-enabling the one default feature ("clock")
that rust-postgres needs.

Note that this change does not cause any backwards-compatibility
problems for users of rust-postgres. The "oldtime" feature controls only
whether `time_v01::Duration` and `chrono::Duration` are the same type
and does not affect any of the APIs used by rust-postgres.