### PR TITLE
derive Clone, PartialEq and Eq for postgres_types::Json

### DIFF
--- a/postgres-types/src/serde_json_1.rs
+++ b/postgres-types/src/serde_json_1.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 use std::io::Read;
 
 /// A wrapper type to allow arbitrary `Serialize`/`Deserialize` types to convert to Postgres JSON values.
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Json<T>(pub T);
 
 impl<'a, T> FromSql<'a> for Json<T>


### PR DESCRIPTION
It's a bit unwieldy using the `Json` type as a struct field without
this.  `Json` is 'just data', so I think it's usually appropriate to
consider instances to be cloneable and testable for equivalence.