### PR TITLE
Immutable borrow of `Client` in transactions

### DIFF
--- a/tokio-postgres/src/to_statement.rs
+++ b/tokio-postgres/src/to_statement.rs
@@ -2,7 +2,7 @@ use crate::to_statement::private::{Sealed, ToStatementType};
 use crate::Statement;
 
 mod private {
-    use crate::{Client, Error, Statement};
+    use crate::{GenericClient, Error, Statement};
 
     pub trait Sealed {}
 
@@ -12,7 +12,7 @@ mod private {
     }
 
     impl<'a> ToStatementType<'a> {
-        pub async fn into_statement(self, client: &Client) -> Result<Statement, Error> {
+        pub async fn into_statement<C: GenericClient>(self, client: &C) -> Result<Statement, Error> {
             match self {
                 ToStatementType::Statement(s) => Ok(s.clone()),
                 ToStatementType::Query(s) => client.prepare(s).await,

--- a/tokio-postgres/src/transaction_builder.rs
+++ b/tokio-postgres/src/transaction_builder.rs
@@ -108,6 +108,6 @@ impl<'a> TransactionBuilder<'a> {
 
         self.client.batch_execute(&query).await?;
 
-        Ok(Transaction::new(self.client))
+        Transaction::new(self.client)
     }
 }

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -320,7 +320,7 @@ async fn cancel_query_raw() {
 
 #[tokio::test]
 async fn transaction_commit() {
-    let mut client = connect("user=postgres").await;
+    let client = connect("user=postgres").await;
 
     client
         .batch_execute(
@@ -348,7 +348,7 @@ async fn transaction_commit() {
 
 #[tokio::test]
 async fn transaction_rollback() {
-    let mut client = connect("user=postgres").await;
+    let client = connect("user=postgres").await;
 
     client
         .batch_execute(
@@ -375,7 +375,7 @@ async fn transaction_rollback() {
 
 #[tokio::test]
 async fn transaction_rollback_drop() {
-    let mut client = connect("user=postgres").await;
+    let client = connect("user=postgres").await;
 
     client
         .batch_execute(
@@ -643,7 +643,7 @@ async fn notifications() {
 
 #[tokio::test]
 async fn query_portal() {
-    let mut client = connect("user=postgres").await;
+    let client = connect("user=postgres").await;
 
     client
         .batch_execute(
@@ -708,7 +708,7 @@ async fn check_send() {
 
     let f = connect("user=postgres");
     is_send(&f);
-    let mut client = f.await;
+    let client = f.await;
 
     let f = client.prepare("SELECT $1::TEXT");
     is_send(&f);


### PR DESCRIPTION
This (fairly large) PR changes the implementation of transactions in order to avoid taking mutable borrows.

The idea is to introduce a new kind of message from the frontend, namely `connection::RequestMessages::Transaction(…)` containing just a channel receiver. When receiving this message, the backend stores that receiver, and then takes its messages from that receiver only, until the sender is dropped.

This guarantees that only messages from that transaction are sent between `BEGIN` and `COMMIT`/`ROLLBACK`, which was achieved before by having the `Transaction` type take a mutable borrow on the `Client`. However, that previous solution is not convenient when multiple Tokio tasks share a reference to the client (which I think is a pretty common case in a web server), since mutexes could result in a deadlock in that case (as the task that can unlock the mutex is on the same thread as the waiting task), and refcells in a panic.