### PR TITLE
better api for passing parameters to `*_raw` methods

### DIFF
--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -951,3 +951,21 @@ fn downcast(len: usize) -> Result<i32, Box<dyn Error + Sync + Send>> {
         Ok(len as i32)
     }
 }
+
+/// A helper trait to be able create a parameters iterator from `&dyn ToSql` or `T: ToSql`
+pub trait BorrowToSql {
+    /// Get a reference to a `ToSql` trait object
+    fn borrow_to_sql(&self) -> &dyn ToSql;
+}
+
+impl BorrowToSql for &dyn ToSql {
+    fn borrow_to_sql(&self) -> &dyn ToSql {
+        *self
+    }
+}
+
+impl<T: ToSql> BorrowToSql for T {
+    fn borrow_to_sql(&self) -> &dyn ToSql {
+        self
+    }
+}

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -960,7 +960,7 @@ mod sealed {
 /// A helper trait used internally by Rust-Postgres
 /// to be able create a parameters iterator from `&dyn ToSql` or `T: ToSql`.
 ///
-/// /// This cannot be implemented outside of this crate.
+/// This cannot be implemented outside of this crate.
 pub trait BorrowToSql: sealed::Sealed {
     /// Get a reference to a `ToSql` trait object
     fn borrow_to_sql(&self) -> &dyn ToSql;

--- a/postgres/src/binary_copy.rs
+++ b/postgres/src/binary_copy.rs
@@ -1,7 +1,7 @@
 //! Utilities for working with the PostgreSQL binary copy format.
 
 use crate::connection::ConnectionRef;
-use crate::types::{ToSql, Type};
+use crate::types::{BorrowToSql, ToSql, Type};
 use crate::{CopyInWriter, CopyOutReader, Error};
 use fallible_iterator::FallibleIterator;
 use futures::StreamExt;
@@ -46,9 +46,10 @@ impl<'a> BinaryCopyInWriter<'a> {
     /// # Panics
     ///
     /// Panics if the number of values provided does not match the number expected.
-    pub fn write_raw<'b, I>(&mut self, values: I) -> Result<(), Error>
+    pub fn write_raw<P, I>(&mut self, values: I) -> Result<(), Error>
     where
-        I: IntoIterator<Item = &'b dyn ToSql>,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
         self.connection

--- a/postgres/src/client.rs
+++ b/postgres/src/client.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use std::task::Poll;
 use tokio_postgres::tls::{MakeTlsConnect, TlsConnect};
-use tokio_postgres::types::{ToSql, Type};
+use tokio_postgres::types::{BorrowToSql, ToSql, Type};
 use tokio_postgres::{Error, Row, SimpleQueryMessage, Socket};
 
 /// A synchronous PostgreSQL client.
@@ -227,7 +227,7 @@ impl Client {
     /// let mut client = Client::connect("host=localhost user=postgres", NoTls)?;
     ///
     /// let baz = true;
-    /// let mut it = client.query_raw("SELECT foo FROM bar WHERE baz = $1", iter::once(&baz as _))?;
+    /// let mut it = client.query_raw("SELECT foo FROM bar WHERE baz = $1", iter::once(baz))?;
     ///
     /// while let Some(row) = it.next()? {
     ///     let foo: i32 = row.get("foo");
@@ -263,10 +263,11 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn query_raw<'a, T, I>(&mut self, query: &T, params: I) -> Result<RowIter<'_>, Error>
+    pub fn query_raw<T, P, I>(&mut self, query: &T, params: I) -> Result<RowIter<'_>, Error>
     where
         T: ?Sized + ToStatement,
-        I: IntoIterator<Item = &'a dyn ToSql>,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
         let stream = self

--- a/postgres/src/client.rs
+++ b/postgres/src/client.rs
@@ -253,7 +253,7 @@ impl Client {
     /// ];
     /// let mut it = client.query_raw(
     ///     "SELECT foo FROM bar WHERE biz = $1 AND baz = $2",
-    ///     params.iter().map(|p| p as &dyn ToSql),
+    ///     params,
     /// )?;
     ///
     /// while let Some(row) = it.next()? {

--- a/postgres/src/generic_client.rs
+++ b/postgres/src/generic_client.rs
@@ -1,4 +1,4 @@
-use crate::types::{ToSql, Type};
+use crate::types::{BorrowToSql, ToSql, Type};
 use crate::{
     Client, CopyInWriter, CopyOutReader, Error, Row, RowIter, SimpleQueryMessage, Statement,
     ToStatement, Transaction,
@@ -37,10 +37,11 @@ pub trait GenericClient: private::Sealed {
         T: ?Sized + ToStatement;
 
     /// Like `Client::query_raw`.
-    fn query_raw<'a, T, I>(&mut self, query: &T, params: I) -> Result<RowIter<'_>, Error>
+    fn query_raw<T, P, I>(&mut self, query: &T, params: I) -> Result<RowIter<'_>, Error>
     where
         T: ?Sized + ToStatement,
-        I: IntoIterator<Item = &'a dyn ToSql>,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator;
 
     /// Like `Client::prepare`.
@@ -104,10 +105,11 @@ impl GenericClient for Client {
         self.query_opt(query, params)
     }
 
-    fn query_raw<'a, T, I>(&mut self, query: &T, params: I) -> Result<RowIter<'_>, Error>
+    fn query_raw<T, P, I>(&mut self, query: &T, params: I) -> Result<RowIter<'_>, Error>
     where
         T: ?Sized + ToStatement,
-        I: IntoIterator<Item = &'a dyn ToSql>,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
         self.query_raw(query, params)
@@ -183,10 +185,11 @@ impl GenericClient for Transaction<'_> {
         self.query_opt(query, params)
     }
 
-    fn query_raw<'a, T, I>(&mut self, query: &T, params: I) -> Result<RowIter<'_>, Error>
+    fn query_raw<T, P, I>(&mut self, query: &T, params: I) -> Result<RowIter<'_>, Error>
     where
         T: ?Sized + ToStatement,
-        I: IntoIterator<Item = &'a dyn ToSql>,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
         self.query_raw(query, params)

--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -1,6 +1,6 @@
 use crate::connection::ConnectionRef;
 use crate::{CancelToken, CopyInWriter, CopyOutReader, Portal, RowIter, Statement, ToStatement};
-use tokio_postgres::types::{ToSql, Type};
+use tokio_postgres::types::{BorrowToSql, ToSql, Type};
 use tokio_postgres::{Error, Row, SimpleQueryMessage};
 
 /// A representation of a PostgreSQL database transaction.
@@ -102,10 +102,11 @@ impl<'a> Transaction<'a> {
     }
 
     /// Like `Client::query_raw`.
-    pub fn query_raw<'b, T, I>(&mut self, query: &T, params: I) -> Result<RowIter<'_>, Error>
+    pub fn query_raw<T, P, I>(&mut self, query: &T, params: I) -> Result<RowIter<'_>, Error>
     where
         T: ?Sized + ToStatement,
-        I: IntoIterator<Item = &'b dyn ToSql>,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
         let stream = self

--- a/tokio-postgres/src/bind.rs
+++ b/tokio-postgres/src/bind.rs
@@ -1,7 +1,7 @@
 use crate::client::InnerClient;
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
-use crate::types::ToSql;
+use crate::types::BorrowToSql;
 use crate::{query, Error, Portal, Statement};
 use postgres_protocol::message::backend::Message;
 use postgres_protocol::message::frontend;
@@ -10,13 +10,14 @@ use std::sync::Arc;
 
 static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 
-pub async fn bind<'a, I>(
+pub async fn bind<P, I>(
     client: &Arc<InnerClient>,
     statement: Statement,
     params: I,
 ) -> Result<Portal, Error>
 where
-    I: IntoIterator<Item = &'a dyn ToSql>,
+    P: BorrowToSql,
+    I: IntoIterator<Item = P>,
     I::IntoIter: ExactSizeIterator,
 {
     let name = format!("p{}", NEXT_ID.fetch_add(1, Ordering::SeqCst));

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -318,9 +318,6 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// If you have a type like `Vec<T>` where `T: ToSql` Rust will not know how to use it as params. To get around
-    /// this the type must explicitly be converted to `&dyn ToSql`.
-    ///
     /// ```no_run
     /// # async fn async_main(client: &tokio_postgres::Client) -> Result<(), tokio_postgres::Error> {
     /// use tokio_postgres::types::ToSql;
@@ -332,7 +329,7 @@ impl Client {
     /// ];
     /// let mut it = client.query_raw(
     ///     "SELECT foo FROM bar WHERE biz = $1 AND baz = $2",
-    ///     params.iter().map(|p| p as &dyn ToSql),
+    ///     params,
     /// ).await?;
     ///
     /// pin_mut!(it);

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -20,6 +20,7 @@ use futures::channel::mpsc;
 use futures::{future, pin_mut, ready, StreamExt, TryStreamExt};
 use parking_lot::Mutex;
 use postgres_protocol::message::backend::Message;
+use postgres_types::BorrowToSql;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
@@ -342,10 +343,11 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn query_raw<'a, T, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
+    pub async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
         T: ?Sized + ToStatement,
-        I: IntoIterator<Item = &'a dyn ToSql>,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
         let statement = statement.__convert().into_statement(self).await?;
@@ -391,10 +393,11 @@ impl Client {
     /// Panics if the number of parameters provided does not match the number expected.
     ///
     /// [`execute`]: #method.execute
-    pub async fn execute_raw<'a, T, I>(&self, statement: &T, params: I) -> Result<u64, Error>
+    pub async fn execute_raw<T, P, I>(&self, statement: &T, params: I) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement,
-        I: IntoIterator<Item = &'a dyn ToSql>,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
         let statement = statement.__convert().into_statement(self).await?;

--- a/tokio-postgres/src/generic_client.rs
+++ b/tokio-postgres/src/generic_client.rs
@@ -1,5 +1,5 @@
 use crate::query::RowStream;
-use crate::types::{ToSql, Type};
+use crate::types::{BorrowToSql, ToSql, Type};
 use crate::{Client, Error, Row, Statement, ToStatement, Transaction};
 use async_trait::async_trait;
 
@@ -18,10 +18,11 @@ pub trait GenericClient: private::Sealed {
         T: ?Sized + ToStatement + Sync + Send;
 
     /// Like `Client::execute_raw`.
-    async fn execute_raw<'b, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
+    async fn execute_raw<P, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
-        I: IntoIterator<Item = &'b dyn ToSql> + Sync + Send,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P> + Sync + Send,
         I::IntoIter: ExactSizeIterator;
 
     /// Like `Client::query`.
@@ -48,10 +49,11 @@ pub trait GenericClient: private::Sealed {
         T: ?Sized + ToStatement + Sync + Send;
 
     /// Like `Client::query_raw`.
-    async fn query_raw<'b, T, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
+    async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
-        I: IntoIterator<Item = &'b dyn ToSql> + Sync + Send,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P> + Sync + Send,
         I::IntoIter: ExactSizeIterator;
 
     /// Like `Client::prepare`.
@@ -79,10 +81,11 @@ impl GenericClient for Client {
         self.execute(query, params).await
     }
 
-    async fn execute_raw<'b, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
+    async fn execute_raw<P, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
-        I: IntoIterator<Item = &'b dyn ToSql> + Sync + Send,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P> + Sync + Send,
         I::IntoIter: ExactSizeIterator,
     {
         self.execute_raw(statement, params).await
@@ -117,10 +120,11 @@ impl GenericClient for Client {
         self.query_opt(statement, params).await
     }
 
-    async fn query_raw<'b, T, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
+    async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
-        I: IntoIterator<Item = &'b dyn ToSql> + Sync + Send,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P> + Sync + Send,
         I::IntoIter: ExactSizeIterator,
     {
         self.query_raw(statement, params).await
@@ -155,10 +159,11 @@ impl GenericClient for Transaction<'_> {
         self.execute(query, params).await
     }
 
-    async fn execute_raw<'b, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
+    async fn execute_raw<P, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
-        I: IntoIterator<Item = &'b dyn ToSql> + Sync + Send,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P> + Sync + Send,
         I::IntoIter: ExactSizeIterator,
     {
         self.execute_raw(statement, params).await
@@ -193,10 +198,11 @@ impl GenericClient for Transaction<'_> {
         self.query_opt(statement, params).await
     }
 
-    async fn query_raw<'b, T, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
+    async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
-        I: IntoIterator<Item = &'b dyn ToSql> + Sync + Send,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P> + Sync + Send,
         I::IntoIter: ExactSizeIterator,
     {
         self.query_raw(statement, params).await

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -5,7 +5,7 @@ use crate::query::RowStream;
 #[cfg(feature = "runtime")]
 use crate::tls::MakeTlsConnect;
 use crate::tls::TlsConnect;
-use crate::types::{ToSql, Type};
+use crate::types::{BorrowToSql, ToSql, Type};
 #[cfg(feature = "runtime")]
 use crate::Socket;
 use crate::{
@@ -139,10 +139,11 @@ impl<'a> Transaction<'a> {
     }
 
     /// Like `Client::query_raw`.
-    pub async fn query_raw<'b, T, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
+    pub async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
         T: ?Sized + ToStatement,
-        I: IntoIterator<Item = &'b dyn ToSql>,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
         self.client.query_raw(statement, params).await
@@ -161,10 +162,11 @@ impl<'a> Transaction<'a> {
     }
 
     /// Like `Client::execute_iter`.
-    pub async fn execute_raw<'b, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
+    pub async fn execute_raw<P, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement,
-        I: IntoIterator<Item = &'b dyn ToSql>,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
         self.client.execute_raw(statement, params).await
@@ -192,10 +194,11 @@ impl<'a> Transaction<'a> {
     /// A maximally flexible version of [`bind`].
     ///
     /// [`bind`]: #method.bind
-    pub async fn bind_raw<'b, T, I>(&self, statement: &T, params: I) -> Result<Portal, Error>
+    pub async fn bind_raw<P, T, I>(&self, statement: &T, params: I) -> Result<Portal, Error>
     where
         T: ?Sized + ToStatement,
-        I: IntoIterator<Item = &'b dyn ToSql>,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
         let statement = statement.__convert().into_statement(&self.client).await?;


### PR DESCRIPTION
This enables passing iterators of `&dyn ToSql` or `T: ToSql` as the `params` argument to `*_raw` methods.

Adds the a helper trait `BorrowToSql` that is only implemented for both `&dyn ToSql` and `T: ToSql`. This trait shouldn't be implemented by users.

Maybe there's a better name for the trait, I chose it because I works as `Borrow<dyn ToSql>` if that was possible.

Fixes #683 