### PR TITLE
Fix weird error when fetching user-defined type

### DIFF
--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -555,7 +555,7 @@ macro_rules! simple_from {
 }
 
 simple_from!(bool, bool_from_sql, BOOL);
-simple_from!(i8, char_from_sql, CHAR);
+simple_from!(i8, char_from_sql, CHAR, BPCHAR);
 simple_from!(i16, int2_from_sql, INT2);
 simple_from!(i32, int4_from_sql, INT4);
 simple_from!(u32, oid_from_sql, OID);


### PR DESCRIPTION
Closes #700 

This PR fixes error when database returns `BPCHAR` instead of `CHAR`.