### PR TITLE
deps: upgrade to tokio v1.0 ecosystem

### DIFF
--- a/postgres-native-tls/Cargo.toml
+++ b/postgres-native-tls/Cargo.toml
@@ -18,10 +18,10 @@ runtime = ["tokio-postgres/runtime"]
 [dependencies]
 futures = "0.3"
 native-tls = "0.2"
-tokio = "0.3"
-tokio-native-tls = "0.2"
+tokio = "1.0"
+tokio-native-tls = "0.3"
 tokio-postgres = { version = "0.6.0", path = "../tokio-postgres", default-features = false }
 
 [dev-dependencies]
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "1.0", features = ["full"] }
 postgres = { version = "0.18.0", path = "../postgres" }

--- a/postgres-openssl/Cargo.toml
+++ b/postgres-openssl/Cargo.toml
@@ -18,10 +18,10 @@ runtime = ["tokio-postgres/runtime"]
 [dependencies]
 futures = "0.3"
 openssl = "0.10"
-tokio = "0.3"
-tokio-openssl = "0.5"
+tokio = "1.0"
+tokio-openssl = "0.6"
 tokio-postgres = { version = "0.6.0", path = "../tokio-postgres", default-features = false }
 
 [dev-dependencies]
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "1.0", features = ["full"] }
 postgres = { version = "0.18.0", path = "../postgres" }

--- a/postgres-protocol/Cargo.toml
+++ b/postgres-protocol/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 [dependencies]
 base64 = "0.13"
 byteorder = "1.0"
-bytes = "0.5"
+bytes = "1.0"
 fallible-iterator = "0.2"
 hmac = "0.10"
 md5 = "0.7"

--- a/postgres-types/Cargo.toml
+++ b/postgres-types/Cargo.toml
@@ -22,7 +22,7 @@ with-uuid-0_8 = ["uuid-08"]
 with-time-0_2 = ["time-02"]
 
 [dependencies]
-bytes = "0.5"
+bytes = "1.0"
 fallible-iterator = "0.2"
 postgres-protocol = { version = "0.5.0", path = "../postgres-protocol" }
 postgres-derive = { version = "0.4.0", optional = true, path = "../postgres-derive" }

--- a/postgres-types/src/serde_json_1.rs
+++ b/postgres-types/src/serde_json_1.rs
@@ -1,5 +1,4 @@
 use crate::{FromSql, IsNull, ToSql, Type};
-use bytes::buf::BufMutExt;
 use bytes::{BufMut, BytesMut};
 use serde_1::{Deserialize, Serialize};
 use serde_json_1::Value;

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -31,12 +31,12 @@ with-uuid-0_8 = ["tokio-postgres/with-uuid-0_8"]
 with-time-0_2 = ["tokio-postgres/with-time-0_2"]
 
 [dependencies]
-bytes = "0.5"
+bytes = "1.0"
 fallible-iterator = "0.2"
 futures = "0.3"
 tokio-postgres = { version = "0.6.0", path = "../tokio-postgres" }
 
-tokio = { version = "0.3", features = ["rt", "time"] }
+tokio = { version = "1.0", features = ["rt", "time"] }
 log = "0.4"
 
 [dev-dependencies]

--- a/postgres/src/copy_out_reader.rs
+++ b/postgres/src/copy_out_reader.rs
@@ -46,7 +46,7 @@ impl BufRead for CopyOutReader<'_> {
             };
         }
 
-        Ok(self.cur.bytes())
+        Ok(&self.cur)
     }
 
     fn consume(&mut self, amt: usize) {

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -38,7 +38,7 @@ with-time-0_2 = ["postgres-types/with-time-0_2"]
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 byteorder = "1.0"
 fallible-iterator = "0.2"
 futures = "0.3"
@@ -50,11 +50,11 @@ phf = "0.8"
 postgres-protocol = { version = "0.5.0", path = "../postgres-protocol" }
 postgres-types = { version = "0.1.2", path = "../postgres-types" }
 socket2 = "0.3"
-tokio = { version = "0.3", features = ["io-util"] }
-tokio-util = { version = "0.4", features = ["codec"] }
+tokio = { version = "1.0", features = ["io-util"] }
+tokio-util = { version = "0.6", features = ["codec"] }
 
 [dev-dependencies]
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "1.0", features = ["full"] }
 env_logger = "0.8"
 criterion = "0.3"
 

--- a/tokio-postgres/src/binary_copy.rs
+++ b/tokio-postgres/src/binary_copy.rs
@@ -153,7 +153,7 @@ impl Stream for BinaryCopyOutStream {
             Some(header) => header.has_oids,
             None => {
                 check_remaining(&chunk, HEADER_LEN)?;
-                if &chunk.bytes()[..MAGIC.len()] != MAGIC {
+                if !chunk.chunk().starts_with(MAGIC) {
                     return Poll::Ready(Some(Err(Error::parse(io::Error::new(
                         io::ErrorKind::InvalidData,
                         "invalid magic value",

--- a/tokio-postgres/src/copy_in.rs
+++ b/tokio-postgres/src/copy_in.rs
@@ -2,7 +2,6 @@ use crate::client::{InnerClient, Responses};
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
 use crate::{query, slice_iter, Error, Statement};
-use bytes::buf::BufExt;
 use bytes::{Buf, BufMut, BytesMut};
 use futures::channel::mpsc;
 use futures::future;


### PR DESCRIPTION
@sfackler this is still waiting on releases of both tokio-openssl and tokio-native-tls that include the Tokio v1.0 bump, but I got tests for tokio-postgres and postgres passing, so figured I'd put this up.