### PR TITLE
add `client` method to `GenericClient`

### DIFF
--- a/tokio-postgres/src/generic_client.rs
+++ b/tokio-postgres/src/generic_client.rs
@@ -12,6 +12,9 @@ mod private {
 /// This trait is "sealed", and cannot be implemented outside of this crate.
 #[async_trait]
 pub trait GenericClient: private::Sealed {
+    /// Get a reference to the underlying `Client`
+    fn client(&self) -> &Client;
+
     /// Like `Client::execute`.
     async fn execute<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
@@ -74,6 +77,10 @@ impl private::Sealed for Client {}
 
 #[async_trait]
 impl GenericClient for Client {
+    fn client(&self) -> &Client {
+        self
+    }
+
     async fn execute<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,
@@ -152,6 +159,10 @@ impl private::Sealed for Transaction<'_> {}
 #[async_trait]
 #[allow(clippy::needless_lifetimes)]
 impl GenericClient for Transaction<'_> {
+    fn client(&self) -> &Client {
+        self.client()
+    }
+
     async fn execute<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement + Sync + Send,

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -64,6 +64,11 @@ impl<'a> Transaction<'a> {
         }
     }
 
+    /// Get a reference to the underlying `Client`
+    pub fn client(&self) -> &Client {
+        &self.client
+    }
+
     /// Consumes the transaction, committing all changes made within it.
     pub async fn commit(mut self) -> Result<(), Error> {
         self.done = true;


### PR DESCRIPTION
Closes #691

As I mentioned in the issue my reasoning is that methods that don't need to create transactions can take &Client and avoid having to deal with generics or Box<GenericClient> and the overhead of async_trait boxed futures. This way a method that takes &Client can be called when you have a impl GenericClient.
