### PR TITLE
Add parameter and column formatting to query_raw()

### DIFF
--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -770,16 +770,12 @@ pub trait ToSql: fmt::Debug {
         ty: &Type,
         out: &mut BytesMut,
     ) -> Result<IsNull, Box<dyn Error + Sync + Send>>;
-
-    /// Specifies the message format of the value
-    fn format(&self) -> Format {
-        Format::Binary
-    }
 }
 
 /// Supported Postgres message format types
 ///
 /// Using Text format in a message assumes a Postgres `SERVER_ENCODING` of `UTF8`
+#[derive(Copy, Clone, Debug)]
 pub enum Format {
     /// Text format (UTF-8)
     Text,
@@ -788,12 +784,18 @@ pub enum Format {
 }
 
 /// Convert from `Format` to the Postgres integer representation of those formats
-impl From<Format> for i16 {
-    fn from(format: Format) -> Self {
+impl From<&Format> for i16 {
+    fn from(format: &Format) -> Self {
         match format {
             Format::Text => 0,
             Format::Binary => 1,
         }
+    }
+}
+
+impl From<Format> for i16 {
+    fn from(format: Format) -> Self {
+        Self::from(&format)
     }
 }
 

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -190,6 +190,7 @@ where
     if !T::accepts(ty) {
         return Err(Box::new(WrongType::new::<T>(ty.clone())));
     }
+
     v.to_sql(ty, out)
 }
 
@@ -741,11 +742,11 @@ pub enum IsNull {
 /// an index offset of 1. **Note:** the impl for arrays only exist when the
 /// Cargo feature `array-impls` is enabled.
 pub trait ToSql: fmt::Debug {
-    /// Converts the value of `self` into the binary format of the specified
+    /// Converts the value of `self` into the `Format` of the specified
     /// Postgres `Type`, appending it to `out`.
     ///
     /// The caller of this method is responsible for ensuring that this type
-    /// is compatible with the Postgres `Type`.
+    /// is compatible with the Postgres `Type` and `Format`.
     ///
     /// The return value indicates if this value should be represented as
     /// `NULL`. If this is the case, implementations **must not** write
@@ -769,6 +770,31 @@ pub trait ToSql: fmt::Debug {
         ty: &Type,
         out: &mut BytesMut,
     ) -> Result<IsNull, Box<dyn Error + Sync + Send>>;
+
+    /// Specifies the message format of the value
+    fn format(&self) -> Format {
+        Format::Binary
+    }
+}
+
+/// Supported Postgres message format types
+///
+/// Using Text format in a message assumes a Postgres `SERVER_ENCODING` of `UTF8`
+pub enum Format {
+    /// Text format (UTF-8)
+    Text,
+    /// Compact, typed binary format
+    Binary,
+}
+
+/// Convert from `Format` to the Postgres integer representation of those formats
+impl From<Format> for i16 {
+    fn from(format: Format) -> Self {
+        match format {
+            Format::Text => 0,
+            Format::Binary => 1,
+        }
+    }
 }
 
 impl<'a, T> ToSql for &'a T

--- a/tokio-postgres/src/bind.rs
+++ b/tokio-postgres/src/bind.rs
@@ -1,7 +1,7 @@
 use crate::client::InnerClient;
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
-use crate::types::BorrowToSql;
+use crate::types::{BorrowToSql, Format};
 use crate::{query, Error, Portal, Statement};
 use postgres_protocol::message::backend::Message;
 use postgres_protocol::message::frontend;
@@ -10,19 +10,30 @@ use std::sync::Arc;
 
 static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 
-pub async fn bind<P, I>(
+pub async fn bind<P, I, J, K>(
     client: &Arc<InnerClient>,
     statement: Statement,
     params: I,
+    param_formats: J,
+    column_formats: K,
 ) -> Result<Portal, Error>
 where
     P: BorrowToSql,
     I: IntoIterator<Item = P>,
     I::IntoIter: ExactSizeIterator,
+    J: IntoIterator<Item = Format>,
+    K: IntoIterator<Item = Format>,
 {
     let name = format!("p{}", NEXT_ID.fetch_add(1, Ordering::SeqCst));
     let buf = client.with_buf(|buf| {
-        query::encode_bind(&statement, params, &name, buf)?;
+        query::encode_bind(
+            &statement,
+            params,
+            param_formats,
+            column_formats,
+            &name,
+            buf,
+        )?;
         frontend::sync(buf);
         Ok(buf.split().freeze())
     })?;

--- a/tokio-postgres/src/copy_in.rs
+++ b/tokio-postgres/src/copy_in.rs
@@ -1,6 +1,7 @@
 use crate::client::{InnerClient, Responses};
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
+use crate::types::Format;
 use crate::{query, slice_iter, Error, Statement};
 use bytes::{Buf, BufMut, BytesMut};
 use futures::channel::mpsc;
@@ -201,7 +202,13 @@ where
 {
     debug!("executing copy in statement {}", statement.name());
 
-    let buf = query::encode(client, &statement, slice_iter(&[]))?;
+    let buf = query::encode(
+        client,
+        &statement,
+        slice_iter(&[]),
+        Some(Format::Binary),
+        Some(Format::Binary),
+    )?;
 
     let (mut sender, receiver) = mpsc::channel(1);
     let receiver = CopyInReceiver::new(receiver);

--- a/tokio-postgres/src/copy_out.rs
+++ b/tokio-postgres/src/copy_out.rs
@@ -1,6 +1,7 @@
 use crate::client::{InnerClient, Responses};
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
+use crate::types::Format;
 use crate::{query, slice_iter, Error, Statement};
 use bytes::Bytes;
 use futures::{ready, Stream};
@@ -14,7 +15,13 @@ use std::task::{Context, Poll};
 pub async fn copy_out(client: &InnerClient, statement: Statement) -> Result<CopyOutStream, Error> {
     debug!("executing copy out statement {}", statement.name());
 
-    let buf = query::encode(client, &statement, slice_iter(&[]))?;
+    let buf = query::encode(
+        client,
+        &statement,
+        slice_iter(&[]),
+        Some(Format::Binary),
+        Some(Format::Binary),
+    )?;
     let responses = start(client, buf).await?;
     Ok(CopyOutStream {
         responses,


### PR DESCRIPTION
## Summary

This PR would close #746 ~by adding a `format(&self)` method to `ToSql`, defaulting to `Format::Binary` for backwards compatibility and ease-of-use~ by adding `param_formats` and `column_formats` to the `query_raw()` method. 

## Notes

~This implementation allocates [two new vectors](https://github.com/sfackler/rust-postgres/compare/master...NAlexPear:parameter-formats?expand=1#diff-75a8b28bb1837403d9e313e5fb5111a321fd4f223e9c150a0bc028313db7fb66R168), which might not be acceptable. Running benchmarks showed no consistent real-world performance differences on my machine, but YMMV. It would be possible to avoid those allocations if `encode_bind` could take an `IntoIterator<Item = &P>` instead of `P`, I think, but that would certainly be a lot more work to get changed.~