### PR TITLE
Add support for libpq-compatible password files (`passfile=`).

### DIFF
--- a/postgres/src/config.rs
+++ b/postgres/src/config.rs
@@ -51,6 +51,9 @@ use tokio_postgres::{Error, Socket};
 /// * `target_session_attrs` - Specifies requirements of the session. If set to `read-write`, the client will check that
 ///     the `transaction_read_write` session parameter is set to `on`. This can be used to connect to the primary server
 ///     in a database cluster as opposed to the secondary read-only mirrors. Defaults to `all`.
+/// * `passfile` - Filesystem path of a file storing passwords. Each line should have fields
+///    `hostname:port:database:username:password`. Lines beginning with `#` are comments. `*` as a complete field
+///    matches anything. `password` takes precedence if both are set.
 ///
 /// ## Examples
 ///
@@ -307,6 +310,20 @@ impl Config {
     /// Gets the channel binding behavior.
     pub fn get_channel_binding(&self) -> ChannelBinding {
         self.config.get_channel_binding()
+    }
+
+    /// Sets the password file path.
+    pub fn passfile<T>(&mut self, passfile: T) -> &mut Config
+    where
+        T: AsRef<Path>,
+    {
+        self.config.passfile(passfile);
+        self
+    }
+
+    /// Gets the password file path, if one has been set with the `passfile` method.
+    pub fn get_passfile(&self) -> Option<&Path> {
+        self.config.get_passfile()
     }
 
     /// Sets the notice callback.

--- a/test/pgpass
+++ b/test/pgpass
@@ -1,0 +1,4 @@
+# Used by tokio-postgres/tests/test/passfile.rs
+localhost:5433:*:pass_user:password
+localhost:5433:*:md5_user:password
+localhost:5433:*:scram_user:password

--- a/test/pgpass_wrong
+++ b/test/pgpass_wrong
@@ -1,0 +1,3 @@
+# Used by tokio-postgres/tests/test/passfile.rs
+localhost:5433:*:pass_user:wrong password
+# No entry for md5_user or scram_user

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -25,7 +25,7 @@ circle-ci = { repository = "sfackler/rust-postgres" }
 
 [features]
 default = ["runtime"]
-runtime = ["tokio/net", "tokio/time"]
+runtime = ["tokio/net", "tokio/time", "tokio/fs"]
 
 with-bit-vec-0_6 = ["postgres-types/with-bit-vec-0_6"]
 with-chrono-0_4 = ["postgres-types/with-chrono-0_4"]

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -105,6 +105,9 @@ pub enum Host {
 /// * `channel_binding` - Controls usage of channel binding in the authentication process. If set to `disable`, channel
 ///     binding will not be used. If set to `prefer`, channel binding will be used if available, but not used otherwise.
 ///     If set to `require`, the authentication process will fail if channel binding is not used. Defaults to `prefer`.
+/// * `passfile` - Filesystem path of a file storing passwords. Each line should have fields
+///    `hostname:port:database:username:password`. Lines beginning with `#` are comments. `*` as a complete field
+///    matches anything. `password` takes precedence if both are set.
 ///
 /// ## Examples
 ///
@@ -159,6 +162,7 @@ pub struct Config {
     pub(crate) keepalives_idle: Duration,
     pub(crate) target_session_attrs: TargetSessionAttrs,
     pub(crate) channel_binding: ChannelBinding,
+    pub(crate) passfile: Option<PathBuf>,
 }
 
 impl Default for Config {
@@ -184,6 +188,7 @@ impl Config {
             keepalives_idle: Duration::from_secs(2 * 60 * 60),
             target_session_attrs: TargetSessionAttrs::Any,
             channel_binding: ChannelBinding::Prefer,
+            passfile: None,
         }
     }
 
@@ -387,6 +392,20 @@ impl Config {
         self.channel_binding
     }
 
+    /// Sets the password file path.
+    pub fn passfile<T>(&mut self, passfile: T) -> &mut Config
+    where
+        T: AsRef<Path>,
+    {
+        self.passfile = Some(passfile.as_ref().to_path_buf());
+        self
+    }
+
+    /// Gets the password file path, if one has been set with the `passfile` method.
+    pub fn get_passfile(&self) -> Option<&Path> {
+        self.passfile.as_deref()
+    }
+
     fn param(&mut self, key: &str, value: &str) -> Result<(), Error> {
         match key {
             "user" => {
@@ -475,6 +494,9 @@ impl Config {
                     }
                 };
                 self.channel_binding(channel_binding);
+            }
+            "passfile" => {
+                self.passfile(Path::new(value));
             }
             key => {
                 return Err(Error::config_parse(Box::new(UnknownOption(

--- a/tokio-postgres/src/connect.rs
+++ b/tokio-postgres/src/connect.rs
@@ -1,6 +1,6 @@
 use crate::client::SocketConfig;
 use crate::config::{Host, TargetSessionAttrs};
-use crate::connect_raw::connect_raw;
+use crate::connect_raw::connect_raw_with_password;
 use crate::connect_socket::connect_socket;
 use crate::tls::{MakeTlsConnect, TlsConnect};
 use crate::{Client, Config, Connection, Error, SimpleQueryMessage, Socket};
@@ -69,7 +69,8 @@ where
         config.keepalives_idle,
     )
     .await?;
-    let (mut client, mut connection) = connect_raw(socket, tls, config).await?;
+    let (mut client, mut connection) =
+        connect_raw_with_password(socket, tls, config, config.password.as_ref()).await?;
 
     if let TargetSessionAttrs::ReadWrite = config.target_session_attrs {
         let rows = client.simple_query_raw("SHOW transaction_read_only");

--- a/tokio-postgres/src/connect.rs
+++ b/tokio-postgres/src/connect.rs
@@ -63,11 +63,11 @@ where
     T: TlsConnect<Socket>,
 {
     let passfile_password;
-    let password = match (&config.password, &config.passfile) {
+    let password = match (config.password.as_deref(), &config.passfile) {
         (Some(password), _) => Some(password),
         (None, Some(passfile)) => {
             passfile_password = passfile::find_password(&passfile, &config, host, port).await;
-            passfile_password.as_ref()
+            passfile_password.as_deref()
         }
         (None, None) => None,
     };

--- a/tokio-postgres/src/connect.rs
+++ b/tokio-postgres/src/connect.rs
@@ -2,6 +2,7 @@ use crate::client::SocketConfig;
 use crate::config::{Host, TargetSessionAttrs};
 use crate::connect_raw::connect_raw_with_password;
 use crate::connect_socket::connect_socket;
+use crate::passfile;
 use crate::tls::{MakeTlsConnect, TlsConnect};
 use crate::{Client, Config, Connection, Error, SimpleQueryMessage, Socket};
 use futures::{future, pin_mut, Future, FutureExt, Stream};
@@ -61,6 +62,16 @@ async fn connect_once<T>(
 where
     T: TlsConnect<Socket>,
 {
+    let passfile_password;
+    let password = match (&config.password, &config.passfile) {
+        (Some(password), _) => Some(password),
+        (None, Some(passfile)) => {
+            passfile_password = passfile::find_password(&passfile, &config, host, port).await;
+            passfile_password.as_ref()
+        }
+        (None, None) => None,
+    };
+
     let socket = connect_socket(
         host,
         port,
@@ -70,7 +81,7 @@ where
     )
     .await?;
     let (mut client, mut connection) =
-        connect_raw_with_password(socket, tls, config, config.password.as_ref()).await?;
+        connect_raw_with_password(socket, tls, config, password).await?;
 
     if let TargetSessionAttrs::ReadWrite = config.target_session_attrs {
         let rows = client.simple_query_raw("SHOW transaction_read_only");

--- a/tokio-postgres/src/connect_raw.rs
+++ b/tokio-postgres/src/connect_raw.rs
@@ -78,10 +78,11 @@ where
     }
 }
 
-pub async fn connect_raw<S, T>(
+pub(crate) async fn connect_raw_with_password<S, T>(
     stream: S,
     tls: T,
     config: &Config,
+    password: Option<&Vec<u8>>,
 ) -> Result<(Client, Connection<S, T::Stream>), Error>
 where
     S: AsyncRead + AsyncWrite + Unpin,
@@ -96,7 +97,7 @@ where
     };
 
     startup(&mut stream, config).await?;
-    authenticate(&mut stream, config).await?;
+    authenticate(&mut stream, config, password).await?;
     let (process_id, secret_key, parameters) = read_info(&mut stream).await?;
 
     let (sender, receiver) = mpsc::unbounded();
@@ -104,6 +105,18 @@ where
     let connection = Connection::new(stream.inner, stream.delayed, parameters, receiver);
 
     Ok((client, connection))
+}
+
+pub async fn connect_raw<S, T>(
+    stream: S,
+    tls: T,
+    config: &Config,
+) -> Result<(Client, Connection<S, T::Stream>), Error>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+    T: TlsConnect<S>,
+{
+    connect_raw_with_password(stream, tls, config, config.password.as_ref()).await
 }
 
 async fn startup<S, T>(stream: &mut StartupStream<S, T>, config: &Config) -> Result<(), Error>
@@ -134,7 +147,11 @@ where
         .map_err(Error::io)
 }
 
-async fn authenticate<S, T>(stream: &mut StartupStream<S, T>, config: &Config) -> Result<(), Error>
+async fn authenticate<S, T>(
+    stream: &mut StartupStream<S, T>,
+    config: &Config,
+    password: Option<&Vec<u8>>,
+) -> Result<(), Error>
 where
     S: AsyncRead + AsyncWrite + Unpin,
     T: TlsStream + Unpin,
@@ -147,11 +164,7 @@ where
         Some(Message::AuthenticationCleartextPassword) => {
             can_skip_channel_binding(config)?;
 
-            let pass = config
-                .password
-                .as_ref()
-                .ok_or_else(|| Error::config("password missing".into()))?;
-
+            let pass = password.ok_or_else(|| Error::config("password missing".into()))?;
             authenticate_password(stream, pass).await?;
         }
         Some(Message::AuthenticationMd5Password(body)) => {
@@ -161,16 +174,13 @@ where
                 .user
                 .as_ref()
                 .ok_or_else(|| Error::config("user missing".into()))?;
-            let pass = config
-                .password
-                .as_ref()
-                .ok_or_else(|| Error::config("password missing".into()))?;
-
+            let pass = password.ok_or_else(|| Error::config("password missing".into()))?;
             let output = authentication::md5_hash(user.as_bytes(), pass, body.salt());
             authenticate_password(stream, output.as_bytes()).await?;
         }
         Some(Message::AuthenticationSasl(body)) => {
-            authenticate_sasl(stream, body, config).await?;
+            let pass = password.ok_or_else(|| Error::config("password missing".into()))?;
+            authenticate_sasl(stream, body, config, pass).await?;
         }
         Some(Message::AuthenticationKerberosV5)
         | Some(Message::AuthenticationScmCredential)
@@ -223,16 +233,12 @@ async fn authenticate_sasl<S, T>(
     stream: &mut StartupStream<S, T>,
     body: AuthenticationSaslBody,
     config: &Config,
+    password: &Vec<u8>,
 ) -> Result<(), Error>
 where
     S: AsyncRead + AsyncWrite + Unpin,
     T: TlsStream + Unpin,
 {
-    let password = config
-        .password
-        .as_ref()
-        .ok_or_else(|| Error::config("password missing".into()))?;
-
     let mut has_scram = false;
     let mut has_scram_plus = false;
     let mut mechanisms = body.mechanisms();

--- a/tokio-postgres/src/connect_raw.rs
+++ b/tokio-postgres/src/connect_raw.rs
@@ -82,7 +82,7 @@ pub(crate) async fn connect_raw_with_password<S, T>(
     stream: S,
     tls: T,
     config: &Config,
-    password: Option<&Vec<u8>>,
+    password: Option<&[u8]>,
 ) -> Result<(Client, Connection<S, T::Stream>), Error>
 where
     S: AsyncRead + AsyncWrite + Unpin,
@@ -116,7 +116,7 @@ where
     S: AsyncRead + AsyncWrite + Unpin,
     T: TlsConnect<S>,
 {
-    connect_raw_with_password(stream, tls, config, config.password.as_ref()).await
+    connect_raw_with_password(stream, tls, config, config.password.as_deref()).await
 }
 
 async fn startup<S, T>(stream: &mut StartupStream<S, T>, config: &Config) -> Result<(), Error>
@@ -150,7 +150,7 @@ where
 async fn authenticate<S, T>(
     stream: &mut StartupStream<S, T>,
     config: &Config,
-    password: Option<&Vec<u8>>,
+    password: Option<&[u8]>,
 ) -> Result<(), Error>
 where
     S: AsyncRead + AsyncWrite + Unpin,
@@ -233,7 +233,7 @@ async fn authenticate_sasl<S, T>(
     stream: &mut StartupStream<S, T>,
     body: AuthenticationSaslBody,
     config: &Config,
-    password: &Vec<u8>,
+    password: &[u8],
 ) -> Result<(), Error>
 where
     S: AsyncRead + AsyncWrite + Unpin,

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -160,6 +160,8 @@ mod copy_out;
 pub mod error;
 mod generic_client;
 mod maybe_tls_stream;
+#[cfg(feature = "runtime")]
+mod passfile;
 mod portal;
 mod prepare;
 mod query;

--- a/tokio-postgres/src/passfile/mod.rs
+++ b/tokio-postgres/src/passfile/mod.rs
@@ -35,7 +35,7 @@ impl<'a> PassfileKey<'a> {
         // This default is applied by the server, rather than our caller, so we have to apply it here too.
         let dbname = dbname.unwrap_or(user);
         PassfileKey {
-            hostname: hostname,
+            hostname,
             port: port_string,
             dbname: dbname.as_bytes(),
             user: user.as_bytes(),
@@ -61,13 +61,9 @@ impl PassfileEntry {
                 if b == b':' {
                     return Ok(value);
                 } else if b == b'\\' {
-                    value.push(match it.next() {
-                        Some(b2) => b2,
-                        // To be consistent with libpq, if the line ends with
-                        // a backslash then the backslash is treated as part
-                        // of the last field's value.
-                        None => b'\\',
-                    })
+                    // To be consistent with libpq, if the line ends with a backslash then the backslash is treated as
+                    // part of the last field's value.
+                    value.push(it.next().unwrap_or(b'\\'))
                 } else {
                     value.push(b)
                 }

--- a/tokio-postgres/src/passfile/mod.rs
+++ b/tokio-postgres/src/passfile/mod.rs
@@ -1,0 +1,192 @@
+//! Support for reading password files.
+//!
+//! Requires the `runtime` Cargo feature.
+
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+
+use tokio::fs::{self, File};
+use tokio::io::BufReader;
+
+use crate::config::{Config, Host};
+
+#[cfg(test)]
+mod test;
+
+/// The data needed to search for a matching passfile entry.
+struct PassfileKey<'a> {
+    hostname: &'a [u8],
+    port: Vec<u8>,
+    dbname: &'a [u8],
+    user: &'a [u8],
+}
+
+impl<'a> PassfileKey<'a> {
+    fn new(host: &'a Host, port: u16, dbname: Option<&'a str>, user: &'a str) -> PassfileKey<'a> {
+        let hostname = match host {
+            Host::Tcp(s) => s.as_bytes(),
+            #[cfg(unix)]
+            // libpq translates DEFAULT_PGSOCKET_DIR to 'localhost' here, but we can't do the same that because we don't
+            // know what DEFAULT_PGSOCKET_DIR is.
+            Host::Unix(pathbuf) => pathbuf.as_os_str().as_bytes(),
+        };
+        let port_string = format!("{}", port).into_bytes();
+        // This default is applied by the server, rather than our caller, so we have to apply it here too.
+        let dbname = dbname.unwrap_or(user);
+        PassfileKey {
+            hostname: hostname,
+            port: port_string,
+            dbname: dbname.as_bytes(),
+            user: user.as_bytes(),
+        }
+    }
+}
+
+/// The data from a single passfile line.
+struct PassfileEntry {
+    hostname: Vec<u8>,
+    port: Vec<u8>,
+    dbname: Vec<u8>,
+    user: Vec<u8>,
+    password: Vec<u8>,
+}
+
+impl PassfileEntry {
+    fn new(s: &[u8]) -> Result<PassfileEntry, ()> {
+        let mut it = s.iter().copied();
+        let mut parse_one_field = |allow_eol| {
+            let mut value = Vec::new();
+            while let Some(b) = it.next() {
+                if b == b':' {
+                    return Ok(value);
+                } else if b == b'\\' {
+                    value.push(match it.next() {
+                        Some(b2) => b2,
+                        // To be consistent with libpq, if the line ends with
+                        // a backslash then the backslash is treated as part
+                        // of the last field's value.
+                        None => b'\\',
+                    })
+                } else {
+                    value.push(b)
+                }
+            }
+            if allow_eol {
+                Ok(value)
+            } else {
+                Err(())
+            }
+        };
+
+        Ok(PassfileEntry {
+            hostname: parse_one_field(false)?,
+            port: parse_one_field(false)?,
+            dbname: parse_one_field(false)?,
+            user: parse_one_field(false)?,
+            password: parse_one_field(true)?,
+        })
+    }
+}
+
+fn field_matches(search_value: &[u8], file_value: &[u8]) -> bool {
+    if file_value == [b'*'] {
+        return true;
+    }
+    file_value == search_value
+}
+
+/// Removes trailing CR and/or LF from a string.
+///
+/// Intended to match libpq's pg_strip_crlf().
+fn strip_crlf(bb: &[u8]) -> &[u8] {
+    for (idx, b) in bb.iter().copied().enumerate().rev() {
+        if b != b'\n' && b != b'\r' {
+            return &bb[..=idx];
+        }
+    }
+    &bb[..0]
+}
+
+/// Searches passfile text for a match.
+///
+/// Intended to match libpq's behavior closely.
+/// If there is an IO error, returns None.
+async fn password_for_key<T>(key: &PassfileKey<'_>, buf: T) -> Option<Vec<u8>>
+where
+    T: tokio::io::AsyncBufReadExt + Unpin,
+{
+    let mut it = buf.split(b'\n');
+    // If we get an io error, just stop reading
+    while let Ok(Some(line)) = it.next_segment().await {
+        if line.starts_with(&[b'#']) {
+            continue;
+        }
+        let line = strip_crlf(&line);
+        if line.is_empty() {
+            continue;
+        }
+        if let Ok(entry) = PassfileEntry::new(line) {
+            if field_matches(key.hostname, &entry.hostname)
+                && field_matches(&key.port, &entry.port)
+                && field_matches(key.dbname, &entry.dbname)
+                && field_matches(key.user, &entry.user)
+            {
+                if entry.password.is_empty() {
+                    // To be consistent with libpq, in this case we need to
+                    // stop searching the password file, but not attempt to
+                    // use the empty password string.
+                    return None;
+                } else {
+                    return Some(entry.password);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Searches a passfile, returning the password from the first matching line.
+///
+/// Returns None if:
+///  - there is no match
+///  - the passfile doesn't exist
+///  - there is an error reading the passfile
+///  - `config` doesn't have a user set.
+///
+/// If `config` doesn't have a dbname set, matches the dbname field against the user name.
+///
+/// Intended to match libpq's behavior closely.
+///
+/// Unlike libpq, doesn't attempt to convert a `host` set to the default socket path into `"localhost"` for matching
+/// purposes. So passfiles using `localhost` to supply passwords for unix socket connections won't work.
+///
+/// Unlike libpq, doesn't enforce any rules on the passfile's permissions.
+pub(crate) async fn find_password(
+    passfile: &Path,
+    config: &Config,
+    host: &Host,
+    port: u16,
+) -> Option<Vec<u8>> {
+    // If we don't have a user, this connection can never work anyway
+    if let Some(user) = config.get_user() {
+        #[cfg(unix)]
+        {
+            let meta = match fs::metadata(&passfile).await {
+                Ok(meta) => meta,
+                Err(_) => return None,
+            };
+            if !meta.is_file() {
+                return None;
+            }
+        }
+        let key = PassfileKey::new(host, port, config.get_dbname(), &user);
+        let file = match File::open(&passfile).await {
+            Ok(file) => file,
+            Err(_) => return None,
+        };
+        password_for_key(&key, BufReader::new(file)).await
+    } else {
+        None
+    }
+}

--- a/tokio-postgres/src/passfile/test.rs
+++ b/tokio-postgres/src/passfile/test.rs
@@ -1,0 +1,314 @@
+use std::path::PathBuf;
+
+use super::*;
+
+const PASSFILE: &str = r#"#
+# empty lines are ignored
+
+# the following lines are ignored as ill-formed
+exhost.test
+exhost.test:5432
+exhost.test:5432:exdb
+exhost.test:5432:exdb:exuser
+# the following lines can't match in practice
+exhost.test:nnnn:exdb:exuser:nonnumeric port
+exhost.test::exdb:exuser:empty port
+# the following line is a comment
+#exhost.test:5433:exdb:exuser:not this one
+# the following lines are well-formed
+exhost.test:5432:exdb:exuser:password-5432
+exhost.test:5433:exdb:exuser:interesting € password
+exhost.test:5432:exuser:exuser:password-exuserdb
+exhost.test:5432:*:exuser:password-star-dbname
+exhost.test:5432:*:exusersl:password-backslash\
+/run/postgresql:5432:*:exuser:password-unix
+# the following line can match (so processing stops), but provides no password
+exhost.test:5432:exdb:exuser2:
+exhost.test:5432:exdb:exuser2:password-shadowed
+exhost.test:5432:exdb:ex\:user:password-colon-user
+exhost.test:5432:exdb:ex\\us\er:password-backslash-user
+exhost.test:5432:exdb:*:password-star-user
+exhost.test:*:exdb:exuser:password-star-port
+*:5432:exdb:exuser:password-star-host
+exhost.test:5433:exdb:exuser3:password-extra:extra:ignored
+exhost.test:5433:exdb:exuser4:p\ass\\word\: with escapes
+"#;
+
+const PASSFILE_CRLF: &str = "\
+    #exhost.test:5433:exdb:exuser:not this one\r\n\
+    \r\n\
+    exhost.test:5432:exdb:exuser:crlfpassword1\r\n\
+    exhost.test:5433:exdb:exuser:crlfpassword2\r\n\
+    exhost.test:5432:exuser:exuser:crlfpassword3\r\n\
+    ";
+
+const PASSFILE_NONL: &str = "exhost.test:5432:exdb:exuser:nonewline";
+
+const PASSFILE_NONUTF8: &[u8] = b"exhost.test:5432:exdb:exuser:\xa3100\n";
+
+async fn lookup(
+    passfile_content: &str,
+    host: &Host,
+    port: u16,
+    dbname: Option<&str>,
+    user: &str,
+) -> Option<Vec<u8>>
+where
+{
+    let key = PassfileKey::new(host, port, dbname, user);
+    password_for_key(&key, passfile_content.as_bytes()).await
+}
+
+async fn check_found(
+    passfile_content: &str,
+    host: &Host,
+    port: u16,
+    dbname: Option<&str>,
+    user: &str,
+) -> String
+where
+{
+    let password = lookup(passfile_content, host, port, dbname, user)
+        .await
+        .unwrap();
+    String::from_utf8(password).unwrap()
+}
+
+#[tokio::test]
+async fn full_key() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5433,
+        Some("exdb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, "interesting € password");
+}
+
+#[tokio::test]
+async fn no_match() {
+    let password = lookup(
+        PASSFILE,
+        &Host::Tcp("nohost.test".to_owned()),
+        5433,
+        Some("exdb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, None);
+}
+
+#[tokio::test]
+async fn default_dbname() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5432,
+        None,
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, "password-exuserdb");
+}
+
+#[tokio::test]
+async fn unix_socket_host() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Unix(PathBuf::from("/run/postgresql")),
+        5432,
+        Some("exdb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, "password-unix");
+}
+
+#[tokio::test]
+async fn star_host() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("nomatch.test".to_owned()),
+        5432,
+        Some("exdb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, "password-star-host");
+}
+
+#[tokio::test]
+async fn star_port() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        9999,
+        Some("exdb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, "password-star-port");
+}
+
+#[tokio::test]
+async fn star_user() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5432,
+        Some("exdb"),
+        "nomatch",
+    )
+    .await;
+    assert_eq!(password, "password-star-user");
+}
+
+#[tokio::test]
+async fn star_dbname() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5432,
+        Some("nodb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, "password-star-dbname");
+}
+
+#[tokio::test]
+async fn colon_in_user() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5432,
+        Some("exdb"),
+        "ex:user",
+    )
+    .await;
+    assert_eq!(password, "password-colon-user");
+}
+
+#[tokio::test]
+async fn backslash_in_user() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5432,
+        Some("exdb"),
+        r#"ex\user"#,
+    )
+    .await;
+    assert_eq!(password, "password-backslash-user");
+}
+
+#[tokio::test]
+async fn extra_ignored_fields() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5433,
+        Some("exdb"),
+        "exuser3",
+    )
+    .await;
+    assert_eq!(password, "password-extra");
+}
+
+#[tokio::test]
+async fn escapes_in_password() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5433,
+        Some("exdb"),
+        "exuser4",
+    )
+    .await;
+    assert_eq!(password, r#"pass\word: with escapes"#);
+}
+
+#[tokio::test]
+async fn final_backslash_in_password() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5432,
+        Some("exdb"),
+        "exusersl",
+    )
+    .await;
+    assert_eq!(password, r#"password-backslash\"#);
+}
+
+#[tokio::test]
+async fn comment_is_ignored() {
+    let password = lookup(
+        PASSFILE,
+        &Host::Tcp("#exhost.test".to_owned()),
+        5433,
+        Some("exdb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, None);
+}
+
+#[tokio::test]
+async fn missing_password_field() {
+    // If a line matches but the password field is missing, no password is
+    // returned and we don't search further.
+    let password = lookup(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5432,
+        Some("exdb"),
+        "exuser2",
+    )
+    .await;
+    assert_eq!(password, None);
+}
+
+#[tokio::test]
+async fn crlf_line_endings() {
+    let password = check_found(
+        PASSFILE_CRLF,
+        &Host::Tcp("exhost.test".to_owned()),
+        5433,
+        Some("exdb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, "crlfpassword2");
+}
+
+#[tokio::test]
+async fn no_final_newline() {
+    let password = check_found(
+        PASSFILE_NONL,
+        &Host::Tcp("exhost.test".to_owned()),
+        5432,
+        Some("exdb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, "nonewline");
+}
+
+#[tokio::test]
+async fn non_utf8_password() {
+    let password = password_for_key(
+        &PassfileKey::new(
+            &Host::Tcp("exhost.test".to_owned()),
+            5432,
+            Some("exdb"),
+            "exuser",
+        ),
+        PASSFILE_NONUTF8,
+    )
+    .await
+    .unwrap();
+    assert_eq!(password, b"\xa3100");
+}

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -19,6 +19,8 @@ use tokio_postgres::{
 mod binary_copy;
 mod parse;
 #[cfg(feature = "runtime")]
+mod passfile;
+#[cfg(feature = "runtime")]
 mod runtime;
 mod types;
 

--- a/tokio-postgres/tests/test/passfile.rs
+++ b/tokio-postgres/tests/test/passfile.rs
@@ -1,0 +1,62 @@
+use tokio_postgres::NoTls;
+
+async fn check_connects(s: &str) {
+    let _ = tokio_postgres::connect(s, NoTls).await.unwrap();
+}
+
+async fn check_fails(s: &str) {
+    match tokio_postgres::connect(s, NoTls).await {
+        Ok(_) => panic!("unexpected success"),
+        Err(e) => assert_eq!(e.to_string(), "invalid configuration: password missing"),
+    }
+}
+
+#[tokio::test]
+async fn passfile_with_plain_password() {
+    check_connects(
+        "host=localhost port=5433 user=pass_user dbname=postgres passfile=../test/pgpass",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn passfile_with_md5_password() {
+    check_connects(
+        "host=localhost port=5433 user=md5_user dbname=postgres passfile=../test/pgpass",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn passfile_with_scram_password() {
+    check_connects(
+        "host=localhost port=5433 user=scram_user dbname=postgres passfile=../test/pgpass",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn explicit_password_is_preferred_to_passfile() {
+    check_connects("host=localhost port=5433 user=pass_user dbname=postgres passfile=../test/pgpass_wrong password=password").await;
+}
+
+#[tokio::test]
+async fn passfile_with_no_match() {
+    check_fails(
+        "host=localhost port=5433 user=md5_user dbname=postgres passfile=../test/pgpass_wrong",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn missing_passfile_is_ignored() {
+    check_fails(
+        "host=localhost port=5433 user=pass_user dbname=postgres passfile=../test/pgpass_missing",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn directory_as_passfile_is_ignored() {
+    check_fails("host=localhost port=5433 user=pass_user dbname=postgres passfile=../test").await;
+}

--- a/tokio-postgres/tests/test/runtime.rs
+++ b/tokio-postgres/tests/test/runtime.rs
@@ -67,6 +67,11 @@ async fn target_session_attrs_err() {
 }
 
 #[tokio::test]
+async fn plain_password_ok() {
+    smoke_test("host=localhost port=5433 user=pass_user dbname=postgres password=password").await;
+}
+
+#[tokio::test]
 async fn cancel_query() {
     let client = connect("host=localhost port=5433 user=postgres").await;
 


### PR DESCRIPTION
Previously requested in #729.

Adds one new config field: `passfile`.

Accepts `pgpass=` in connection strings.

Support is only present when the tokio_postgres `runtime` feature is enabled. Adds a dependency on the tokio `fs` feature in that case.

Notes:

I've tried to match libpq's behaviour quite closely.

PostgreSQL docs are at:
https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-PASSFILE
https://www.postgresql.org/docs/current/libpq-pgpass.html

libpq has a default password file location (`~/.pgpass` or `%APPDATA%\postgresql\pgpass.conf`). I haven't imitated that; password-file lookup won't happen unless a passfile is explicitly requested.

On Unix, libpq rejects password files which are group- or world-readable. I haven't implemented that behaviour. I think it would be easy to add, but I'm not sure how to avoid it causing pain for the integration tests.

libpq treats connections to a unix socket in the default directory (whether specified explicitly or implicitly) as connections to 'localhost' for purposes of password-file lookup. I haven't tried to imitate that, because rust-postgres doesn't have a notion of the default unix socket directory.

