### PR TITLE
Add support for libpq-compatible password files (`passfile=`) [second draft].

### DIFF
--- a/postgres/src/config.rs
+++ b/postgres/src/config.rs
@@ -51,6 +51,10 @@ use tokio_postgres::{Error, Socket};
 /// * `target_session_attrs` - Specifies requirements of the session. If set to `read-write`, the client will check that
 ///     the `transaction_read_write` session parameter is set to `on`. This can be used to connect to the primary server
 ///     in a database cluster as opposed to the secondary read-only mirrors. Defaults to `all`.
+/// * `passfile` - Filesystem path of a file storing passwords. Each line should have fields
+///    `hostname:port:database:username:password`. Lines beginning with `#` are comments. `*` as a complete field
+///    matches anything. `password` takes precedence if both are set. The file is ignored (on Unix only) if its
+///    permissions allow any access to group or 'other'.
 ///
 /// ## Examples
 ///
@@ -307,6 +311,20 @@ impl Config {
     /// Gets the channel binding behavior.
     pub fn get_channel_binding(&self) -> ChannelBinding {
         self.config.get_channel_binding()
+    }
+
+    /// Sets the password file path.
+    pub fn passfile<T>(&mut self, passfile: T) -> &mut Config
+    where
+        T: AsRef<Path>,
+    {
+        self.config.passfile(passfile);
+        self
+    }
+
+    /// Gets the password file path, if one has been set with the `passfile` method.
+    pub fn get_passfile(&self) -> Option<&Path> {
+        self.config.get_passfile()
     }
 
     /// Sets the notice callback.

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -25,7 +25,7 @@ circle-ci = { repository = "sfackler/rust-postgres" }
 
 [features]
 default = ["runtime"]
-runtime = ["tokio/net", "tokio/time"]
+runtime = ["tokio/net", "tokio/time", "tokio/fs"]
 
 with-bit-vec-0_6 = ["postgres-types/with-bit-vec-0_6"]
 with-chrono-0_4 = ["postgres-types/with-chrono-0_4"]
@@ -57,6 +57,7 @@ tokio-util = { version = "0.6", features = ["codec"] }
 tokio = { version = "1.0", features = ["full"] }
 env_logger = "0.8"
 criterion = "0.3"
+tempfile = "3.2.0"
 
 bit-vec-06 = { version = "0.6", package = "bit-vec" }
 chrono-04 = { version = "0.4", package = "chrono", default-features = false }

--- a/tokio-postgres/src/connect.rs
+++ b/tokio-postgres/src/connect.rs
@@ -1,6 +1,6 @@
 use crate::client::SocketConfig;
 use crate::config::{Host, TargetSessionAttrs};
-use crate::connect_raw::connect_raw;
+use crate::connect_raw::connect_raw_with_password;
 use crate::connect_socket::connect_socket;
 use crate::tls::{MakeTlsConnect, TlsConnect};
 use crate::{Client, Config, Connection, Error, SimpleQueryMessage, Socket};
@@ -69,7 +69,8 @@ where
         config.keepalives_idle,
     )
     .await?;
-    let (mut client, mut connection) = connect_raw(socket, tls, config).await?;
+    let (mut client, mut connection) =
+        connect_raw_with_password(socket, tls, config, config.password.as_deref()).await?;
 
     if let TargetSessionAttrs::ReadWrite = config.target_session_attrs {
         let rows = client.simple_query_raw("SHOW transaction_read_only");

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -160,6 +160,8 @@ mod copy_out;
 pub mod error;
 mod generic_client;
 mod maybe_tls_stream;
+#[cfg(feature = "runtime")]
+mod passfile;
 mod portal;
 mod prepare;
 mod query;

--- a/tokio-postgres/src/passfile/mod.rs
+++ b/tokio-postgres/src/passfile/mod.rs
@@ -1,0 +1,199 @@
+//! Support for reading password files.
+//!
+//! Requires the `runtime` Cargo feature.
+
+#[cfg(unix)]
+use std::os::unix::{ffi::OsStrExt, fs::MetadataExt};
+use std::path::Path;
+
+use log::warn;
+use tokio::fs::{self, File};
+use tokio::io::BufReader;
+
+use crate::config::{Config, Host};
+
+#[cfg(test)]
+mod test;
+
+/// The data needed to search for a matching passfile entry.
+struct PassfileKey<'a> {
+    hostname: &'a [u8],
+    port: Vec<u8>,
+    dbname: &'a [u8],
+    user: &'a [u8],
+}
+
+impl<'a> PassfileKey<'a> {
+    fn new(host: &'a Host, port: u16, dbname: Option<&'a str>, user: &'a str) -> PassfileKey<'a> {
+        let hostname = match host {
+            Host::Tcp(s) => s.as_bytes(),
+            #[cfg(unix)]
+            // libpq translates DEFAULT_PGSOCKET_DIR to 'localhost' here, but we can't do the same that because we don't
+            // know what DEFAULT_PGSOCKET_DIR is.
+            Host::Unix(pathbuf) => pathbuf.as_os_str().as_bytes(),
+        };
+        let port_string = format!("{}", port).into_bytes();
+        // This default is applied by the server, rather than our caller, so we have to apply it here too.
+        let dbname = dbname.unwrap_or(user);
+        PassfileKey {
+            hostname,
+            port: port_string,
+            dbname: dbname.as_bytes(),
+            user: user.as_bytes(),
+        }
+    }
+}
+
+/// The data from a single passfile line.
+struct PassfileEntry {
+    hostname: Vec<u8>,
+    port: Vec<u8>,
+    dbname: Vec<u8>,
+    user: Vec<u8>,
+    password: Vec<u8>,
+}
+
+impl PassfileEntry {
+    fn new(s: &[u8]) -> Result<PassfileEntry, ()> {
+        let mut it = s.iter().copied();
+        let mut parse_one_field = |allow_eol| {
+            let mut value = Vec::new();
+            while let Some(b) = it.next() {
+                if b == b':' {
+                    return Ok(value);
+                } else if b == b'\\' {
+                    // To be consistent with libpq, if the line ends with a backslash then the backslash is treated as
+                    // part of the last field's value.
+                    value.push(it.next().unwrap_or(b'\\'))
+                } else {
+                    value.push(b)
+                }
+            }
+            if allow_eol {
+                Ok(value)
+            } else {
+                Err(())
+            }
+        };
+
+        Ok(PassfileEntry {
+            hostname: parse_one_field(false)?,
+            port: parse_one_field(false)?,
+            dbname: parse_one_field(false)?,
+            user: parse_one_field(false)?,
+            password: parse_one_field(true)?,
+        })
+    }
+}
+
+fn field_matches(search_value: &[u8], file_value: &[u8]) -> bool {
+    if file_value == [b'*'] {
+        return true;
+    }
+    file_value == search_value
+}
+
+/// Removes trailing CR and/or LF from a string.
+///
+/// Intended to match libpq's pg_strip_crlf().
+fn strip_crlf(bb: &[u8]) -> &[u8] {
+    for (idx, b) in bb.iter().copied().enumerate().rev() {
+        if b != b'\n' && b != b'\r' {
+            return &bb[..=idx];
+        }
+    }
+    &bb[..0]
+}
+
+/// Searches passfile text for a match.
+///
+/// Intended to match libpq's behavior closely.
+/// If there is an IO error, returns None.
+async fn password_for_key<T>(key: &PassfileKey<'_>, buf: T) -> Option<Vec<u8>>
+where
+    T: tokio::io::AsyncBufReadExt + Unpin,
+{
+    let mut it = buf.split(b'\n');
+    // If we get an io error, just stop reading
+    while let Ok(Some(line)) = it.next_segment().await {
+        if line.starts_with(&[b'#']) {
+            continue;
+        }
+        let line = strip_crlf(&line);
+        if line.is_empty() {
+            continue;
+        }
+        if let Ok(entry) = PassfileEntry::new(line) {
+            if field_matches(key.hostname, &entry.hostname)
+                && field_matches(&key.port, &entry.port)
+                && field_matches(key.dbname, &entry.dbname)
+                && field_matches(key.user, &entry.user)
+            {
+                if entry.password.is_empty() {
+                    // To be consistent with libpq, in this case we need to
+                    // stop searching the password file, but not attempt to
+                    // use the empty password string.
+                    return None;
+                } else {
+                    return Some(entry.password);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Searches a passfile, returning the password from the first matching line.
+///
+/// Returns None if:
+///  - there is no match
+///  - the passfile doesn't exist
+///  - the passfile permissions allow any access for group or 'other' (unix only)
+///  - there is an error reading the passfile
+///  - `config` doesn't have a user set.
+///
+/// If `config` doesn't have a dbname set, matches the dbname field against the user name.
+///
+/// Intended to match libpq's behavior closely.
+///
+/// Unlike libpq, doesn't attempt to convert a `host` set to the default socket path into `"localhost"` for matching
+/// purposes. So passfiles using `localhost` to supply passwords for unix socket connections won't work.
+pub(crate) async fn find_password(
+    passfile: &Path,
+    config: &Config,
+    host: &Host,
+    port: u16,
+) -> Option<Vec<u8>> {
+    // If we don't have a user, this connection can never work anyway
+    if let Some(user) = config.get_user() {
+        #[cfg(unix)]
+        {
+            let meta = match fs::metadata(&passfile).await {
+                Ok(meta) => meta,
+                Err(_) => return None,
+            };
+            if !meta.is_file() {
+                warn!(
+                    "password file \"{}\" is not a plain file",
+                    &passfile.to_string_lossy()
+                );
+                return None;
+            }
+            if (meta.mode() & 0o0077) != 0 {
+                warn!(
+                    "password file \"{}\" has group or world access; permissions should be u=rw (0600) or less",
+                    &passfile.to_string_lossy()
+                );
+                return None;
+            }
+        }
+        let key = PassfileKey::new(host, port, config.get_dbname(), &user);
+        let file = match File::open(&passfile).await {
+            Ok(file) => file,
+            Err(_) => return None,
+        };
+        password_for_key(&key, BufReader::new(file)).await
+    } else {
+        None
+    }
+}

--- a/tokio-postgres/src/passfile/test.rs
+++ b/tokio-postgres/src/passfile/test.rs
@@ -1,0 +1,314 @@
+use std::path::PathBuf;
+
+use super::*;
+
+const PASSFILE: &str = r#"#
+# empty lines are ignored
+
+# the following lines are ignored as ill-formed
+exhost.test
+exhost.test:5432
+exhost.test:5432:exdb
+exhost.test:5432:exdb:exuser
+# the following lines can't match in practice
+exhost.test:nnnn:exdb:exuser:nonnumeric port
+exhost.test::exdb:exuser:empty port
+# the following line is a comment
+#exhost.test:5433:exdb:exuser:not this one
+# the following lines are well-formed
+exhost.test:5432:exdb:exuser:password-5432
+exhost.test:5433:exdb:exuser:interesting € password
+exhost.test:5432:exuser:exuser:password-exuserdb
+exhost.test:5432:*:exuser:password-star-dbname
+exhost.test:5432:*:exusersl:password-backslash\
+/run/postgresql:5432:*:exuser:password-unix
+# the following line can match (so processing stops), but provides no password
+exhost.test:5432:exdb:exuser2:
+exhost.test:5432:exdb:exuser2:password-shadowed
+exhost.test:5432:exdb:ex\:user:password-colon-user
+exhost.test:5432:exdb:ex\\us\er:password-backslash-user
+exhost.test:5432:exdb:*:password-star-user
+exhost.test:*:exdb:exuser:password-star-port
+*:5432:exdb:exuser:password-star-host
+exhost.test:5433:exdb:exuser3:password-extra:extra:ignored
+exhost.test:5433:exdb:exuser4:p\ass\\word\: with escapes
+"#;
+
+const PASSFILE_CRLF: &str = "\
+    #exhost.test:5433:exdb:exuser:not this one\r\n\
+    \r\n\
+    exhost.test:5432:exdb:exuser:crlfpassword1\r\n\
+    exhost.test:5433:exdb:exuser:crlfpassword2\r\n\
+    exhost.test:5432:exuser:exuser:crlfpassword3\r\n\
+    ";
+
+const PASSFILE_NONL: &str = "exhost.test:5432:exdb:exuser:nonewline";
+
+const PASSFILE_NONUTF8: &[u8] = b"exhost.test:5432:exdb:exuser:\xa3100\n";
+
+async fn lookup(
+    passfile_content: &str,
+    host: &Host,
+    port: u16,
+    dbname: Option<&str>,
+    user: &str,
+) -> Option<Vec<u8>>
+where
+{
+    let key = PassfileKey::new(host, port, dbname, user);
+    password_for_key(&key, passfile_content.as_bytes()).await
+}
+
+async fn check_found(
+    passfile_content: &str,
+    host: &Host,
+    port: u16,
+    dbname: Option<&str>,
+    user: &str,
+) -> String
+where
+{
+    let password = lookup(passfile_content, host, port, dbname, user)
+        .await
+        .unwrap();
+    String::from_utf8(password).unwrap()
+}
+
+#[tokio::test]
+async fn full_key() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5433,
+        Some("exdb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, "interesting € password");
+}
+
+#[tokio::test]
+async fn no_match() {
+    let password = lookup(
+        PASSFILE,
+        &Host::Tcp("nohost.test".to_owned()),
+        5433,
+        Some("exdb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, None);
+}
+
+#[tokio::test]
+async fn default_dbname() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5432,
+        None,
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, "password-exuserdb");
+}
+
+#[tokio::test]
+async fn unix_socket_host() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Unix(PathBuf::from("/run/postgresql")),
+        5432,
+        Some("exdb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, "password-unix");
+}
+
+#[tokio::test]
+async fn star_host() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("nomatch.test".to_owned()),
+        5432,
+        Some("exdb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, "password-star-host");
+}
+
+#[tokio::test]
+async fn star_port() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        9999,
+        Some("exdb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, "password-star-port");
+}
+
+#[tokio::test]
+async fn star_user() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5432,
+        Some("exdb"),
+        "nomatch",
+    )
+    .await;
+    assert_eq!(password, "password-star-user");
+}
+
+#[tokio::test]
+async fn star_dbname() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5432,
+        Some("nodb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, "password-star-dbname");
+}
+
+#[tokio::test]
+async fn colon_in_user() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5432,
+        Some("exdb"),
+        "ex:user",
+    )
+    .await;
+    assert_eq!(password, "password-colon-user");
+}
+
+#[tokio::test]
+async fn backslash_in_user() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5432,
+        Some("exdb"),
+        r#"ex\user"#,
+    )
+    .await;
+    assert_eq!(password, "password-backslash-user");
+}
+
+#[tokio::test]
+async fn extra_ignored_fields() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5433,
+        Some("exdb"),
+        "exuser3",
+    )
+    .await;
+    assert_eq!(password, "password-extra");
+}
+
+#[tokio::test]
+async fn escapes_in_password() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5433,
+        Some("exdb"),
+        "exuser4",
+    )
+    .await;
+    assert_eq!(password, r#"pass\word: with escapes"#);
+}
+
+#[tokio::test]
+async fn final_backslash_in_password() {
+    let password = check_found(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5432,
+        Some("exdb"),
+        "exusersl",
+    )
+    .await;
+    assert_eq!(password, r#"password-backslash\"#);
+}
+
+#[tokio::test]
+async fn comment_is_ignored() {
+    let password = lookup(
+        PASSFILE,
+        &Host::Tcp("#exhost.test".to_owned()),
+        5433,
+        Some("exdb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, None);
+}
+
+#[tokio::test]
+async fn missing_password_field() {
+    // If a line matches but the password field is missing, no password is
+    // returned and we don't search further.
+    let password = lookup(
+        PASSFILE,
+        &Host::Tcp("exhost.test".to_owned()),
+        5432,
+        Some("exdb"),
+        "exuser2",
+    )
+    .await;
+    assert_eq!(password, None);
+}
+
+#[tokio::test]
+async fn crlf_line_endings() {
+    let password = check_found(
+        PASSFILE_CRLF,
+        &Host::Tcp("exhost.test".to_owned()),
+        5433,
+        Some("exdb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, "crlfpassword2");
+}
+
+#[tokio::test]
+async fn no_final_newline() {
+    let password = check_found(
+        PASSFILE_NONL,
+        &Host::Tcp("exhost.test".to_owned()),
+        5432,
+        Some("exdb"),
+        "exuser",
+    )
+    .await;
+    assert_eq!(password, "nonewline");
+}
+
+#[tokio::test]
+async fn non_utf8_password() {
+    let password = password_for_key(
+        &PassfileKey::new(
+            &Host::Tcp("exhost.test".to_owned()),
+            5432,
+            Some("exdb"),
+            "exuser",
+        ),
+        PASSFILE_NONUTF8,
+    )
+    .await
+    .unwrap();
+    assert_eq!(password, b"\xa3100");
+}

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -19,6 +19,8 @@ use tokio_postgres::{
 mod binary_copy;
 mod parse;
 #[cfg(feature = "runtime")]
+mod passfile;
+#[cfg(feature = "runtime")]
 mod runtime;
 mod types;
 

--- a/tokio-postgres/tests/test/passfile.rs
+++ b/tokio-postgres/tests/test/passfile.rs
@@ -1,0 +1,133 @@
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+use std::{fs::OpenOptions, io::Write};
+
+use tokio_postgres::{Error, NoTls};
+
+const PASSFILE: &str = r#"
+localhost:5433:*:pass_user:password
+localhost:5433:*:md5_user:password
+localhost:5433:*:scram_user:password
+"#;
+
+const PASSFILE_WRONG: &str = r#"
+localhost:5433:*:pass_user:wrong password
+"#;
+
+async fn connect_with_passfile(
+    passfile_content: &str,
+    mode: u32,
+    config: &str,
+) -> Result<(), Error> {
+    let tempdir = tempfile::Builder::new()
+        .prefix("tokio-postgres-tests.")
+        .tempdir()
+        .unwrap();
+    let passfile_name = tempdir.path().join("pgpass");
+    let mut open_options = OpenOptions::new();
+    open_options.write(true).create(true);
+    #[cfg(unix)]
+    {
+        open_options.mode(mode);
+    }
+    let mut passfile = open_options.open(&passfile_name).unwrap();
+    passfile.write_all(passfile_content.as_bytes()).unwrap();
+    let config = config.replace("{}", &passfile_name.to_str().unwrap());
+    tokio_postgres::connect(&config, NoTls).await.map(|_| ())
+}
+
+async fn check_connects(passfile_content: &str, config: &str) {
+    connect_with_passfile(passfile_content, 0o0600, config)
+        .await
+        .unwrap();
+}
+
+fn assert_password_missing<T>(result: Result<T, Error>) {
+    match result {
+        Ok(_) => panic!("unexpected success"),
+        Err(e) => assert_eq!(e.to_string(), "invalid configuration: password missing"),
+    }
+}
+
+#[tokio::test]
+async fn passfile_with_plain_password() {
+    check_connects(
+        PASSFILE,
+        "host=localhost port=5433 user=pass_user dbname=postgres passfile={}",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn passfile_with_md5_password() {
+    check_connects(
+        PASSFILE,
+        "host=localhost port=5433 user=md5_user dbname=postgres passfile={}",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn passfile_with_scram_password() {
+    check_connects(
+        PASSFILE,
+        "host=localhost port=5433 user=scram_user dbname=postgres passfile={}",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn explicit_password_is_preferred_to_passfile() {
+    check_connects(
+        PASSFILE_WRONG,
+        "host=localhost port=5433 user=pass_user dbname=postgres passfile={} password=password",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn passfile_with_no_match() {
+    assert_password_missing(
+        connect_with_passfile(
+            PASSFILE_WRONG,
+            0o600,
+            "host=localhost port=5433 user=md5_user dbname=postgres passfile={}",
+        )
+        .await,
+    )
+}
+
+#[tokio::test]
+async fn missing_passfile_is_ignored() {
+    assert_password_missing(
+        tokio_postgres::connect(
+            "host=localhost port=5433 user=pass_user dbname=postgres passfile=nosuchfile",
+            NoTls,
+        )
+        .await,
+    )
+}
+
+#[tokio::test]
+async fn directory_as_passfile_is_ignored() {
+    assert_password_missing(
+        tokio_postgres::connect(
+            "host=localhost port=5433 user=pass_user dbname=postgres passfile=.",
+            NoTls,
+        )
+        .await,
+    )
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn passfile_with_lax_permissions() {
+    assert_password_missing(
+        connect_with_passfile(
+            PASSFILE,
+            0o640,
+            "host=localhost port=5433 user=pass_user dbname=postgres passfile={}",
+        )
+        .await,
+    )
+}

--- a/tokio-postgres/tests/test/runtime.rs
+++ b/tokio-postgres/tests/test/runtime.rs
@@ -67,6 +67,11 @@ async fn target_session_attrs_err() {
 }
 
 #[tokio::test]
+async fn plain_password_ok() {
+    smoke_test("host=localhost port=5433 user=pass_user dbname=postgres password=password").await;
+}
+
+#[tokio::test]
 async fn cancel_query() {
     let client = connect("host=localhost port=5433 user=postgres").await;
 


### PR DESCRIPTION
Previously requested in #729.

Supersedes PR #758.

Adds one new config field: `passfile`.

Accepts `pgpass=` in connection strings.

Support is only present when the tokio_postgres `runtime` feature is enabled. Adds a dependency on the tokio `fs` feature in that case.

Notes:

I've tried to match libpq's behaviour quite closely.

PostgreSQL docs are at:
https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-PASSFILE
https://www.postgresql.org/docs/current/libpq-pgpass.html

libpq has a default password file location (`~/.pgpass` or `%APPDATA%\postgresql\pgpass.conf`). I haven't imitated that; password-file lookup won't happen unless a passfile is explicitly requested.

libpq treats connections to a unix socket in the default directory (whether specified explicitly or implicitly) as connections to 'localhost' for purposes of password-file lookup. I haven't tried to imitate that, because rust-postgres doesn't have a notion of the default unix socket directory.
