### PR TITLE
Add query_first

### DIFF
--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -302,14 +302,12 @@ impl Client {
         T: ?Sized + ToStatement,
     {
         let stream = self.query_raw(statement, slice_iter(params)).await?;
+
         pin_mut!(stream);
 
-        let row = match stream.try_next().await? {
-            Some(row) => row,
-            None => return Ok(None),
-        };
+        let row = stream.try_next().await?;
 
-        Ok(Some(row))
+        Ok(row)
     }
 
     /// Executes a statement which returns zero or one rows, returning it.

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -805,3 +805,44 @@ async fn query_opt() {
         .err()
         .unwrap();
 }
+
+#[tokio::test]
+async fn query_first() {
+    let client = connect("user=postgres").await;
+
+    client
+        .batch_execute(
+            "
+                CREATE TEMPORARY TABLE foo (
+                    name TEXT
+                );
+                INSERT INTO foo (name) VALUES ('alice'), ('bob'), ('carol'), ('alice');
+            ",
+        )
+        .await
+        .unwrap();
+
+    assert!(client
+        .query_first("SELECT * FROM foo WHERE name = 'dave'", &[])
+        .await
+        .unwrap()
+        .is_none());
+
+    client
+        .query_first("SELECT * FROM foo WHERE name = 'alice'", &[])
+        .await
+        .unwrap()
+        .unwrap();
+
+    client
+        .query_first("SELECT * FROM foo WHERE name = 'bob'", &[])
+        .await
+        .unwrap()
+        .unwrap();
+
+    client
+        .query_first("SELECT * FROM foo", &[])
+        .await
+        .unwrap()
+        .unwrap();
+}


### PR DESCRIPTION
Adds a new function `query_first` to `Client` which returns `Some(Row)` if n > 0 and `None` if n = 0 where n is the amount of returned rows by Postgres. It completely ignores all remaining rows.