### PR TITLE
Making Postgres Types Documentation More Explict For Feature Flags

### DIFF
--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -6,7 +6,12 @@
 //! # Derive
 //!
 //! If the `derive` cargo feature is enabled, you can derive `ToSql` and `FromSql` implementations for custom Postgres
-//! types.
+//! types. Explicitly, modify your `Cargo.toml` file to include the following:
+//!
+//! ```toml
+//! [dependencies]
+//! postgres-types = { version = "0.X.X", features = ["derive"] }
+//! ```
 //!
 //! ## Enums
 //!


### PR DESCRIPTION
I had misread the docs around needing to enable a feature flag in order to access the derive macros for postgress types. If I misread it, I figured that others could as well, so I threw together a quick PR to make it more clear.

This is tied to the issue I posted here: [https://github.com/sfackler/rust-postgres/issues/799]