### PR TITLE
Add support for Postgres Interval type

### DIFF
--- a/postgres-types/Cargo.toml
+++ b/postgres-types/Cargo.toml
@@ -25,6 +25,7 @@ with-time-0_2 = ["time-02"]
 
 [dependencies]
 bytes = "1.0"
+byteorder = "1.0"
 fallible-iterator = "0.2"
 postgres-protocol = { version = "0.6.1", path = "../postgres-protocol" }
 postgres-derive = { version = "0.4.0", optional = true, path = "../postgres-derive" }

--- a/postgres-types/src/chrono_04.rs
+++ b/postgres-types/src/chrono_04.rs
@@ -171,7 +171,7 @@ impl<'a> FromSql<'a> for Duration {
 fn interval_from_sql(mut buf: &[u8]) -> Result<Duration, Box<dyn std::error::Error + Sync + Send>> {
     let time = buf.read_i64::<BigEndian>()?;
     let seconds = Duration::seconds(time / 1000000);
-    let frac = Duration::nanoseconds(time % 1000000);
+    let frac = Duration::microseconds(time % 1000000);
     let day = Duration::days(buf.read_i32::<BigEndian>()?.into());
     let month = Duration::seconds((buf.read_i32::<BigEndian>()? * 30 * 86400).into());
 


### PR DESCRIPTION
This patch implements `FromSql` for the Postgres Interval type and maps it to chrono Duration type.