### PR TITLE
Implement Unknown encoding for query parameters

### DIFF
--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -772,17 +772,12 @@ pub trait ToSql: fmt::Debug {
 
     /// Specify the encode format
     fn encode_format(&self) -> i16 { 1 }
-
-    /// return string representation
-    fn as_string(&self) -> String {
-        panic!("as_string not implemented for {:?}", self)
-    }
 }
 
 
 /// A Wrapper type used for sending query parameters encoded as unknown.
 #[derive(Debug)]
-pub struct Unknown<'a>(pub &'a (dyn ToSql + Sync));
+pub struct Unknown<'a>(pub &'a str);
 
 impl ToSql for Unknown<'_> {
     fn to_sql(
@@ -792,7 +787,7 @@ impl ToSql for Unknown<'_> {
     ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         match *self {
             Unknown(val) => {
-                types::text_to_sql(&val.as_string(), out);
+                types::text_to_sql(val, out);
                 Ok(IsNull::No)
             }
         }
@@ -939,7 +934,7 @@ impl<'a> ToSql for &'a str {
             _ => false,
         }
     }
-    fn as_string(&self) -> String { self.to_string() }
+
     to_sql_checked!();
 }
 
@@ -963,7 +958,7 @@ impl ToSql for String {
     fn accepts(ty: &Type) -> bool {
         <&str as ToSql>::accepts(ty)
     }
-    fn as_string(&self) -> String { self.clone() }
+
     to_sql_checked!();
 }
 
@@ -976,10 +971,6 @@ macro_rules! simple_to {
                       -> Result<IsNull, Box<dyn Error + Sync + Send>> {
                 types::$f(*self, w);
                 Ok(IsNull::No)
-            }
-
-            fn as_string(&self) -> String {
-                format!("{}", &self)
             }
 
             accepts!($($expected),+);

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -156,8 +156,7 @@ where
     I: IntoIterator<Item = P>,
     I::IntoIter: ExactSizeIterator,
 {
-    
-    let (param_formats, params):(Vec<_>, Vec<_>) = params.into_iter().map(|p| (p.borrow_to_sql().encode_format(),p)).unzip();
+    let (param_formats, params):(Vec<_>, Vec<_>) = params.into_iter().map(|p|->(i16, P){(p.borrow_to_sql().encode_format().into(),p)}).unzip();
     let params = params.into_iter();
 
     assert!(

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -156,6 +156,8 @@ where
     I: IntoIterator<Item = P>,
     I::IntoIter: ExactSizeIterator,
 {
+    
+    let (param_formats, params):(Vec<_>, Vec<_>) = params.into_iter().map(|p| (p.borrow_to_sql().encode_format(),p)).unzip();
     let params = params.into_iter();
 
     assert!(
@@ -169,7 +171,7 @@ where
     let r = frontend::bind(
         portal,
         statement.name(),
-        Some(1),
+        param_formats,
         params.zip(statement.params()).enumerate(),
         |(idx, (param, ty)), buf| match param.borrow_to_sql().to_sql_checked(ty, buf) {
             Ok(IsNull::No) => Ok(postgres_protocol::IsNull::No),


### PR DESCRIPTION
After looking at @NAlexPear #747 PR  in relation to #746, it looks like it's changing a lot of function signatures exposed by this library (which probably is not desirable).

Here i propose another solution with the basic ideas being:
Provide a struct like this `pub struct Unknown<'a>(pub &'a (dyn ToSql + Sync));`
and amend the `ToSql` trait with `encode_format` which has a default implementation and only `Unknown` overrides it
With this additional functionality, `encode_bind` can selectively switch between binary and text encoding.

As an implementation detail (which can be changed), `Unknown` requires a method to get the string representation of the inner type so i added an additional `as_string` function to the `ToSql` trait and for most of the basic types the function was implemented in the  `simple_to` macro using `format!("{}", ...`, which looks a bit like a hack but it is a starting point.

I would have liked to somehow implement it inside the `Unknown` without the need for `as_string` function,  but i am not sure how to get the concrete type out of `&(dyn ToSql + Sync)` variable

All of this provides the following interface
`client.query("select 10 + $1 + $2", &[&10, &Unknown(&"20")])`
where the last `$2` parameter would be text encoded and pg would infer it's type

@sfackler please let me know if you are interested in this approach and would like me to clean this up (implement `as_string` for everything that needs it and write up some tests.



