### PR TITLE
Boxed owned query parameters

### DIFF
--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -1044,6 +1044,23 @@ impl BorrowToSql for &dyn ToSql {
     }
 }
 
+impl sealed::Sealed for Box<dyn ToSql + Sync> {}
+
+impl BorrowToSql for Box<dyn ToSql + Sync> {
+    #[inline]
+    fn borrow_to_sql(&self) -> &dyn ToSql {
+        self.as_ref()
+    }
+}
+
+impl sealed::Sealed for Box<dyn ToSql + Sync + Send> {}
+impl BorrowToSql for Box<dyn ToSql + Sync + Send> {
+    #[inline]
+    fn borrow_to_sql(&self) -> &dyn ToSql {
+        self.as_ref()
+    }
+}
+
 impl sealed::Sealed for &(dyn ToSql + Sync) {}
 
 /// In async contexts it is sometimes necessary to have the additional


### PR DESCRIPTION
Related issue: #843 

This allows usage of `Vec<Box<dyn ToSql + Sync>>` & `Vec<Box<dyn ToSql + Sync + Send>>` to be used with `Client.query_raw`

```rust
use futures::TryStreamExt;

fn build_params( ... ) -> Vec<Box<(dyn ToSql + Sync + Send)>> { ... }

async fn query_database() {
    let stmt = ....;
    let params = build_params( ... );
    let rows: Vec<Row> = client.query_raw(&stmt, params).await?.try_collect().await?;
}
```