### PR TITLE
Tokio-Postgres Make function from_str public

### DIFF
--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -516,7 +516,7 @@ impl Config {
 impl FromStr for Config {
     type Err = Error;
 
-    fn from_str(s: &str) -> Result<Config, Error> {
+    pub fn from_str(s: &str) -> Result<Config, Error> {
         match UrlParser::parse(s)? {
             Some(config) => Ok(config),
             None => Parser::parse(s),


### PR DESCRIPTION
Seems to me an oversight there is no public handler for URL config that is publicly available. I tried to import URLParser and use method from_string in my code and they were private.