### PR TITLE
Add ltree, lquery and ltxtquery support

### DIFF
--- a/docker/sql_setup.sh
+++ b/docker/sql_setup.sh
@@ -96,4 +96,5 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
     CREATE ROLE ssl_user LOGIN;
     CREATE EXTENSION hstore;
     CREATE EXTENSION citext;
+    CREATE EXTENSION ltree;
 EOSQL

--- a/postgres-protocol/Cargo.toml
+++ b/postgres-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postgres-protocol"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 description = "Low level Postgres protocol APIs"

--- a/postgres-protocol/src/types/mod.rs
+++ b/postgres-protocol/src/types/mod.rs
@@ -1060,18 +1060,59 @@ impl Inet {
     }
 }
 
-/// Serializes a Postgres l{tree,query,txtquery} string
+/// Serializes a Postgres ltree string
 #[inline]
 pub fn ltree_to_sql(v: &str, buf: &mut BytesMut) {
-    // A version number is prepended to an Ltree string per spec
+    // A version number is prepended to an ltree string per spec
     buf.put_u8(1);
     // Append the rest of the query
     buf.put_slice(v.as_bytes());
 }
 
-/// Deserialize a Postgres l{tree,query,txtquery} string
+/// Deserialize a Postgres ltree string
 #[inline]
 pub fn ltree_from_sql(buf: &[u8]) -> Result<&str, StdBox<dyn Error + Sync + Send>> {
-    // Remove the version number from the front of the string per spec
-    Ok(str::from_utf8(&buf[1..])?)
+    match buf {
+        // Remove the version number from the front of the ltree per spec
+        [1u8, rest @ ..] => Ok(str::from_utf8(rest)?),
+        _ => Err("ltree version 1 only supported".into()),
+    }
+}
+
+/// Serializes a Postgres lquery string
+#[inline]
+pub fn lquery_to_sql(v: &str, buf: &mut BytesMut) {
+    // A version number is prepended to an lquery string per spec
+    buf.put_u8(1);
+    // Append the rest of the query
+    buf.put_slice(v.as_bytes());
+}
+
+/// Deserialize a Postgres lquery string
+#[inline]
+pub fn lquery_from_sql(buf: &[u8]) -> Result<&str, StdBox<dyn Error + Sync + Send>> {
+    match buf {
+        // Remove the version number from the front of the lquery per spec
+        [1u8, rest @ ..] => Ok(str::from_utf8(rest)?),
+        _ => Err("lquery version 1 only supported".into()),
+    }
+}
+
+/// Serializes a Postgres ltxtquery string
+#[inline]
+pub fn ltxtquery_to_sql(v: &str, buf: &mut BytesMut) {
+    // A version number is prepended to an ltxtquery string per spec
+    buf.put_u8(1);
+    // Append the rest of the query
+    buf.put_slice(v.as_bytes());
+}
+
+/// Deserialize a Postgres ltxtquery string
+#[inline]
+pub fn ltxtquery_from_sql(buf: &[u8]) -> Result<&str, StdBox<dyn Error + Sync + Send>> {
+    match buf {
+        // Remove the version number from the front of the ltxtquery per spec
+        [1u8, rest @ ..] => Ok(str::from_utf8(rest)?),
+        _ => Err("ltxtquery version 1 only supported".into()),
+    }
 }

--- a/postgres-protocol/src/types/mod.rs
+++ b/postgres-protocol/src/types/mod.rs
@@ -1059,3 +1059,19 @@ impl Inet {
         self.netmask
     }
 }
+
+/// Serializes a Postgres l{tree,query,txtquery} string
+#[inline]
+pub fn ltree_to_sql(v: &str, buf: &mut BytesMut) {
+    // A version number is prepended to an Ltree string per spec
+    buf.put_u8(1);
+    // Append the rest of the query
+    buf.put_slice(v.as_bytes());
+}
+
+/// Deserialize a Postgres l{tree,query,txtquery} string
+#[inline]
+pub fn ltree_from_sql(buf: &[u8]) -> Result<&str, StdBox<dyn Error + Sync + Send>> {
+    // Remove the version number from the front of the string per spec
+    Ok(str::from_utf8(&buf[1..])?)
+}

--- a/postgres-protocol/src/types/test.rs
+++ b/postgres-protocol/src/types/test.rs
@@ -1,4 +1,4 @@
-use bytes::BytesMut;
+use bytes::{Buf, BytesMut};
 use fallible_iterator::FallibleIterator;
 use std::collections::HashMap;
 
@@ -155,4 +155,118 @@ fn non_null_array() {
     assert_eq!(array.element_type(), 10);
     assert_eq!(array.dimensions().collect::<Vec<_>>().unwrap(), dimensions);
     assert_eq!(array.values().collect::<Vec<_>>().unwrap(), values);
+}
+
+#[test]
+fn ltree_sql() {
+    let mut query = vec![1u8];
+    query.extend_from_slice("A.B.C".as_bytes());
+
+    let mut buf = BytesMut::new();
+
+    ltree_to_sql("A.B.C", &mut buf);
+
+    assert_eq!(query.as_slice(), buf.chunk());
+}
+
+#[test]
+fn ltree_str() {
+    let mut query = vec![1u8];
+    query.extend_from_slice("A.B.C".as_bytes());
+
+    let success = match ltree_from_sql(query.as_slice()) {
+        Ok(_) => true,
+        _ => false,
+    };
+
+    assert!(success)
+}
+
+#[test]
+fn ltree_wrong_version() {
+    let mut query = vec![2u8];
+    query.extend_from_slice("A.B.C".as_bytes());
+
+    let success = match ltree_from_sql(query.as_slice()) {
+        Err(_) => true,
+        _ => false,
+    };
+
+    assert!(success)
+}
+
+#[test]
+fn lquery_sql() {
+    let mut query = vec![1u8];
+    query.extend_from_slice("A.B.C".as_bytes());
+
+    let mut buf = BytesMut::new();
+
+    lquery_to_sql("A.B.C", &mut buf);
+
+    assert_eq!(query.as_slice(), buf.chunk());
+}
+
+#[test]
+fn lquery_str() {
+    let mut query = vec![1u8];
+    query.extend_from_slice("A.B.C".as_bytes());
+
+    let success = match lquery_from_sql(query.as_slice()) {
+        Ok(_) => true,
+        _ => false,
+    };
+
+    assert!(success)
+}
+
+#[test]
+fn lquery_wrong_version() {
+    let mut query = vec![2u8];
+    query.extend_from_slice("A.B.C".as_bytes());
+
+    let success = match lquery_from_sql(query.as_slice()) {
+        Err(_) => true,
+        _ => false,
+    };
+
+    assert!(success)
+}
+
+#[test]
+fn ltxtquery_sql() {
+    let mut query = vec![1u8];
+    query.extend_from_slice("a & b*".as_bytes());
+
+    let mut buf = BytesMut::new();
+
+    ltree_to_sql("a & b*", &mut buf);
+
+    assert_eq!(query.as_slice(), buf.chunk());
+}
+
+#[test]
+fn ltxtquery_str() {
+    let mut query = vec![1u8];
+    query.extend_from_slice("a & b*".as_bytes());
+
+    let success = match ltree_from_sql(query.as_slice()) {
+        Ok(_) => true,
+        _ => false,
+    };
+
+    assert!(success)
+}
+
+#[test]
+fn ltxtquery_wrong_version() {
+    let mut query = vec![2u8];
+    query.extend_from_slice("a & b*".as_bytes());
+
+    let success = match ltree_from_sql(query.as_slice()) {
+        Err(_) => true,
+        _ => false,
+    };
+
+    assert!(success)
 }

--- a/postgres-protocol/src/types/test.rs
+++ b/postgres-protocol/src/types/test.rs
@@ -174,12 +174,7 @@ fn ltree_str() {
     let mut query = vec![1u8];
     query.extend_from_slice("A.B.C".as_bytes());
 
-    let success = match ltree_from_sql(query.as_slice()) {
-        Ok(_) => true,
-        _ => false,
-    };
-
-    assert!(success)
+    assert!(matches!(ltree_from_sql(query.as_slice()), Ok(_)))
 }
 
 #[test]
@@ -187,12 +182,7 @@ fn ltree_wrong_version() {
     let mut query = vec![2u8];
     query.extend_from_slice("A.B.C".as_bytes());
 
-    let success = match ltree_from_sql(query.as_slice()) {
-        Err(_) => true,
-        _ => false,
-    };
-
-    assert!(success)
+    assert!(matches!(ltree_from_sql(query.as_slice()), Err(_)))
 }
 
 #[test]
@@ -212,12 +202,7 @@ fn lquery_str() {
     let mut query = vec![1u8];
     query.extend_from_slice("A.B.C".as_bytes());
 
-    let success = match lquery_from_sql(query.as_slice()) {
-        Ok(_) => true,
-        _ => false,
-    };
-
-    assert!(success)
+    assert!(matches!(lquery_from_sql(query.as_slice()), Ok(_)))
 }
 
 #[test]
@@ -225,12 +210,7 @@ fn lquery_wrong_version() {
     let mut query = vec![2u8];
     query.extend_from_slice("A.B.C".as_bytes());
 
-    let success = match lquery_from_sql(query.as_slice()) {
-        Err(_) => true,
-        _ => false,
-    };
-
-    assert!(success)
+    assert!(matches!(lquery_from_sql(query.as_slice()), Err(_)))
 }
 
 #[test]
@@ -250,12 +230,7 @@ fn ltxtquery_str() {
     let mut query = vec![1u8];
     query.extend_from_slice("a & b*".as_bytes());
 
-    let success = match ltree_from_sql(query.as_slice()) {
-        Ok(_) => true,
-        _ => false,
-    };
-
-    assert!(success)
+    assert!(matches!(ltree_from_sql(query.as_slice()), Ok(_)))
 }
 
 #[test]
@@ -263,10 +238,5 @@ fn ltxtquery_wrong_version() {
     let mut query = vec![2u8];
     query.extend_from_slice("a & b*".as_bytes());
 
-    let success = match ltree_from_sql(query.as_slice()) {
-        Err(_) => true,
-        _ => false,
-    };
-
-    assert!(success)
+    assert!(matches!(ltree_from_sql(query.as_slice()), Err(_)))
 }

--- a/postgres-types/Cargo.toml
+++ b/postgres-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postgres-types"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
@@ -28,7 +28,7 @@ with-time-0_3 = ["time-03"]
 [dependencies]
 bytes = "1.0"
 fallible-iterator = "0.2"
-postgres-protocol = { version = "0.6.1", path = "../postgres-protocol" }
+postgres-protocol = { version = "0.6.4", path = "../postgres-protocol" }
 postgres-derive = { version = "0.4.0", optional = true, path = "../postgres-derive" }
 
 array-init = { version = "2", optional = true }

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -619,24 +619,24 @@ impl<'a> FromSql<'a> for Box<str> {
 impl<'a> FromSql<'a> for &'a str {
     fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<&'a str, Box<dyn Error + Sync + Send>> {
         match *ty {
-            ref ty if (
-                ty.name() == "ltree"    ||
-                ty.name() == "lquery"   ||
-                ty.name() == "ltxtquery"
-            ) => types::ltree_from_sql(raw),
-            _ => types::text_from_sql(raw)
+            ref ty if ty.name() == "ltree" => types::ltree_from_sql(raw),
+            ref ty if ty.name() == "lquery" => types::lquery_from_sql(raw),
+            ref ty if ty.name() == "ltxtquery" => types::ltxtquery_from_sql(raw),
+            _ => types::text_from_sql(raw),
         }
     }
 
     fn accepts(ty: &Type) -> bool {
         match *ty {
             Type::VARCHAR | Type::TEXT | Type::BPCHAR | Type::NAME | Type::UNKNOWN => true,
-            ref ty if (
-                ty.name() == "citext"   ||
-                ty.name() == "ltree"    ||
-                ty.name() == "lquery"   ||
-                ty.name() == "ltxtquery"
-            ) => true,
+            ref ty
+                if (ty.name() == "citext"
+                    || ty.name() == "ltree"
+                    || ty.name() == "lquery"
+                    || ty.name() == "ltxtquery") =>
+            {
+                true
+            }
             _ => false,
         }
     }
@@ -939,13 +939,11 @@ impl ToSql for Vec<u8> {
 
 impl<'a> ToSql for &'a str {
     fn to_sql(&self, ty: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
-        match ty {
-            ref ty if (
-                ty.name() == "ltree" ||
-                ty.name() == "lquery" ||
-                ty.name() == "ltxtquery"
-            ) => types::ltree_to_sql(*self, w),
-            _ => types::text_to_sql(*self, w)
+        match *ty {
+            ref ty if ty.name() == "ltree" => types::ltree_to_sql(*self, w),
+            ref ty if ty.name() == "lquery" => types::lquery_to_sql(*self, w),
+            ref ty if ty.name() == "ltxtquery" => types::ltxtquery_to_sql(*self, w),
+            _ => types::text_to_sql(*self, w),
         }
         Ok(IsNull::No)
     }
@@ -953,12 +951,14 @@ impl<'a> ToSql for &'a str {
     fn accepts(ty: &Type) -> bool {
         match *ty {
             Type::VARCHAR | Type::TEXT | Type::BPCHAR | Type::NAME | Type::UNKNOWN => true,
-            ref ty if (
-                ty.name() == "citext"   ||
-                ty.name() == "ltree"    ||
-                ty.name() == "lquery"   ||
-                ty.name() == "ltxtquery"
-            ) => true,
+            ref ty
+                if (ty.name() == "citext"
+                    || ty.name() == "ltree"
+                    || ty.name() == "lquery"
+                    || ty.name() == "ltxtquery") =>
+            {
+                true
+            }
             _ => false,
         }
     }

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -407,6 +407,7 @@ impl WrongType {
 /// | `f32`                             | REAL                                          |
 /// | `f64`                             | DOUBLE PRECISION                              |
 /// | `&str`/`String`                   | VARCHAR, CHAR(n), TEXT, CITEXT, NAME, UNKNOWN |
+/// |                                   | LTREE, LQUERY, LTXTQUERY                      |
 /// | `&[u8]`/`Vec<u8>`                 | BYTEA                                         |
 /// | `HashMap<String, Option<String>>` | HSTORE                                        |
 /// | `SystemTime`                      | TIMESTAMP, TIMESTAMP WITH TIME ZONE           |
@@ -739,6 +740,7 @@ pub enum IsNull {
 /// | `f32`                             | REAL                                 |
 /// | `f64`                             | DOUBLE PRECISION                     |
 /// | `&str`/`String`                   | VARCHAR, CHAR(n), TEXT, CITEXT, NAME |
+/// |                                   | LTREE, LQUERY, LTXTQUERY             |
 /// | `&[u8]`/`Vec<u8>`                 | BYTEA                                |
 /// | `HashMap<String, Option<String>>` | HSTORE                               |
 /// | `SystemTime`                      | TIMESTAMP, TIMESTAMP WITH TIME ZONE  |

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-postgres"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
@@ -50,8 +50,8 @@ parking_lot = "0.12"
 percent-encoding = "2.0"
 pin-project-lite = "0.2"
 phf = "0.10"
-postgres-protocol = { version = "0.6.1", path = "../postgres-protocol" }
-postgres-types = { version = "0.2.2", path = "../postgres-types" }
+postgres-protocol = { version = "0.6.4", path = "../postgres-protocol" }
+postgres-types = { version = "0.2.3", path = "../postgres-types" }
 socket2 = "0.4"
 tokio = { version = "1.0", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["codec"] }

--- a/tokio-postgres/tests/test/types/mod.rs
+++ b/tokio-postgres/tests/test/types/mod.rs
@@ -652,74 +652,122 @@ async fn inet() {
 #[tokio::test]
 async fn ltree() {
     let client = connect("user=postgres").await;
-    client.execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[]).await.unwrap();
+    client
+        .execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[])
+        .await
+        .unwrap();
 
-    test_type("ltree", &[
-        (Some("b.c.d".to_owned()), "'b.c.d'"),
-        (None, "NULL"),
-    ]).await;
+    test_type(
+        "ltree",
+        &[(Some("b.c.d".to_owned()), "'b.c.d'"), (None, "NULL")],
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn ltree_any() {
     let client = connect("user=postgres").await;
-    client.execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[]).await.unwrap();
+    client
+        .execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[])
+        .await
+        .unwrap();
 
-    test_type("ltree[]", &[
-        (Some(vec![]), "ARRAY[]"),
-        (Some(vec!["a.b.c".to_string()]), "ARRAY['a.b.c']"),
-        (Some(vec!["a.b.c".to_string(), "e.f.g".to_string()]), "ARRAY['a.b.c','e.f.g']"),
-        (None, "NULL"),
-    ]).await;
+    test_type(
+        "ltree[]",
+        &[
+            (Some(vec![]), "ARRAY[]"),
+            (Some(vec!["a.b.c".to_string()]), "ARRAY['a.b.c']"),
+            (
+                Some(vec!["a.b.c".to_string(), "e.f.g".to_string()]),
+                "ARRAY['a.b.c','e.f.g']",
+            ),
+            (None, "NULL"),
+        ],
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn lquery() {
     let client = connect("user=postgres").await;
-    client.execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[]).await.unwrap();
+    client
+        .execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[])
+        .await
+        .unwrap();
 
-    test_type("lquery", &[
-        (Some("b.c.d".to_owned()), "'b.c.d'"),
-        (Some("b.c.*".to_owned()), "'b.c.*'"),
-        (Some("b.*{1,2}.d|e".to_owned()), "'b.*{1,2}.d|e'"),
-        (None, "NULL"),
-    ]).await;
+    test_type(
+        "lquery",
+        &[
+            (Some("b.c.d".to_owned()), "'b.c.d'"),
+            (Some("b.c.*".to_owned()), "'b.c.*'"),
+            (Some("b.*{1,2}.d|e".to_owned()), "'b.*{1,2}.d|e'"),
+            (None, "NULL"),
+        ],
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn lquery_any() {
     let client = connect("user=postgres").await;
-    client.execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[]).await.unwrap();
+    client
+        .execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[])
+        .await
+        .unwrap();
 
-    test_type("lquery[]", &[
-        (Some(vec![]), "ARRAY[]"),
-        (Some(vec!["b.c.*".to_string()]), "ARRAY['b.c.*']"),
-        (Some(vec!["b.c.*".to_string(), "b.*{1,2}.d|e".to_string()]), "ARRAY['b.c.*','b.*{1,2}.d|e']"),
-        (None, "NULL"),
-    ]).await;
+    test_type(
+        "lquery[]",
+        &[
+            (Some(vec![]), "ARRAY[]"),
+            (Some(vec!["b.c.*".to_string()]), "ARRAY['b.c.*']"),
+            (
+                Some(vec!["b.c.*".to_string(), "b.*{1,2}.d|e".to_string()]),
+                "ARRAY['b.c.*','b.*{1,2}.d|e']",
+            ),
+            (None, "NULL"),
+        ],
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn ltxtquery() {
     let client = connect("user=postgres").await;
-    client.execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[]).await.unwrap();
+    client
+        .execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[])
+        .await
+        .unwrap();
 
-    test_type("ltxtquery", &[
-        (Some("b & c & d".to_owned()), "'b & c & d'"),
-        (Some("b@* & !c".to_owned()), "'b@* & !c'"),
-        (None, "NULL"),
-    ]).await;
+    test_type(
+        "ltxtquery",
+        &[
+            (Some("b & c & d".to_owned()), "'b & c & d'"),
+            (Some("b@* & !c".to_owned()), "'b@* & !c'"),
+            (None, "NULL"),
+        ],
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn ltxtquery_any() {
     let client = connect("user=postgres").await;
-    client.execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[]).await.unwrap();
+    client
+        .execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[])
+        .await
+        .unwrap();
 
-    test_type("ltxtquery[]", &[
-        (Some(vec![]), "ARRAY[]"),
-        (Some(vec!["b & c & d".to_string()]), "ARRAY['b & c & d']"),
-        (Some(vec!["b & c & d".to_string(), "b@* & !c".to_string()]), "ARRAY['b & c & d','b@* & !c']"),
-        (None, "NULL"),
-    ]).await;
+    test_type(
+        "ltxtquery[]",
+        &[
+            (Some(vec![]), "ARRAY[]"),
+            (Some(vec!["b & c & d".to_string()]), "ARRAY['b & c & d']"),
+            (
+                Some(vec!["b & c & d".to_string(), "b@* & !c".to_string()]),
+                "ARRAY['b & c & d','b@* & !c']",
+            ),
+            (None, "NULL"),
+        ],
+    )
+    .await;
 }

--- a/tokio-postgres/tests/test/types/mod.rs
+++ b/tokio-postgres/tests/test/types/mod.rs
@@ -651,12 +651,6 @@ async fn inet() {
 
 #[tokio::test]
 async fn ltree() {
-    let client = connect("user=postgres").await;
-    client
-        .execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[])
-        .await
-        .unwrap();
-
     test_type(
         "ltree",
         &[(Some("b.c.d".to_owned()), "'b.c.d'"), (None, "NULL")],
@@ -666,12 +660,6 @@ async fn ltree() {
 
 #[tokio::test]
 async fn ltree_any() {
-    let client = connect("user=postgres").await;
-    client
-        .execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[])
-        .await
-        .unwrap();
-
     test_type(
         "ltree[]",
         &[
@@ -689,12 +677,6 @@ async fn ltree_any() {
 
 #[tokio::test]
 async fn lquery() {
-    let client = connect("user=postgres").await;
-    client
-        .execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[])
-        .await
-        .unwrap();
-
     test_type(
         "lquery",
         &[
@@ -709,12 +691,6 @@ async fn lquery() {
 
 #[tokio::test]
 async fn lquery_any() {
-    let client = connect("user=postgres").await;
-    client
-        .execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[])
-        .await
-        .unwrap();
-
     test_type(
         "lquery[]",
         &[
@@ -732,12 +708,6 @@ async fn lquery_any() {
 
 #[tokio::test]
 async fn ltxtquery() {
-    let client = connect("user=postgres").await;
-    client
-        .execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[])
-        .await
-        .unwrap();
-
     test_type(
         "ltxtquery",
         &[
@@ -751,12 +721,6 @@ async fn ltxtquery() {
 
 #[tokio::test]
 async fn ltxtquery_any() {
-    let client = connect("user=postgres").await;
-    client
-        .execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[])
-        .await
-        .unwrap();
-
     test_type(
         "ltxtquery[]",
         &[

--- a/tokio-postgres/tests/test/types/mod.rs
+++ b/tokio-postgres/tests/test/types/mod.rs
@@ -648,3 +648,78 @@ async fn inet() {
     )
     .await;
 }
+
+#[tokio::test]
+async fn ltree() {
+    let client = connect("user=postgres").await;
+    client.execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[]).await.unwrap();
+
+    test_type("ltree", &[
+        (Some("b.c.d".to_owned()), "'b.c.d'"),
+        (None, "NULL"),
+    ]).await;
+}
+
+#[tokio::test]
+async fn ltree_any() {
+    let client = connect("user=postgres").await;
+    client.execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[]).await.unwrap();
+
+    test_type("ltree[]", &[
+        (Some(vec![]), "ARRAY[]"),
+        (Some(vec!["a.b.c".to_string()]), "ARRAY['a.b.c']"),
+        (Some(vec!["a.b.c".to_string(), "e.f.g".to_string()]), "ARRAY['a.b.c','e.f.g']"),
+        (None, "NULL"),
+    ]).await;
+}
+
+#[tokio::test]
+async fn lquery() {
+    let client = connect("user=postgres").await;
+    client.execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[]).await.unwrap();
+
+    test_type("lquery", &[
+        (Some("b.c.d".to_owned()), "'b.c.d'"),
+        (Some("b.c.*".to_owned()), "'b.c.*'"),
+        (Some("b.*{1,2}.d|e".to_owned()), "'b.*{1,2}.d|e'"),
+        (None, "NULL"),
+    ]).await;
+}
+
+#[tokio::test]
+async fn lquery_any() {
+    let client = connect("user=postgres").await;
+    client.execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[]).await.unwrap();
+
+    test_type("lquery[]", &[
+        (Some(vec![]), "ARRAY[]"),
+        (Some(vec!["b.c.*".to_string()]), "ARRAY['b.c.*']"),
+        (Some(vec!["b.c.*".to_string(), "b.*{1,2}.d|e".to_string()]), "ARRAY['b.c.*','b.*{1,2}.d|e']"),
+        (None, "NULL"),
+    ]).await;
+}
+
+#[tokio::test]
+async fn ltxtquery() {
+    let client = connect("user=postgres").await;
+    client.execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[]).await.unwrap();
+
+    test_type("ltxtquery", &[
+        (Some("b & c & d".to_owned()), "'b & c & d'"),
+        (Some("b@* & !c".to_owned()), "'b@* & !c'"),
+        (None, "NULL"),
+    ]).await;
+}
+
+#[tokio::test]
+async fn ltxtquery_any() {
+    let client = connect("user=postgres").await;
+    client.execute("CREATE EXTENSION IF NOT EXISTS ltree;", &[]).await.unwrap();
+
+    test_type("ltxtquery[]", &[
+        (Some(vec![]), "ARRAY[]"),
+        (Some(vec!["b & c & d".to_string()]), "ARRAY['b & c & d']"),
+        (Some(vec!["b & c & d".to_string(), "b@* & !c".to_string()]), "ARRAY['b & c & d','b@* & !c']"),
+        (None, "NULL"),
+    ]).await;
+}


### PR DESCRIPTION
This adds [Postgres ltree, lquery and ltxtquery](https://www.postgresql.org/docs/current/ltree.html) support to rust-postgres. For the uninitiated, ltree ("label tree") is a Postgres datatype that follows a dot-notated search path for a given row. Lquery and ltxtquery allow users to search for rows that match an ltree. There are many query operators to help traverse the tree in a given query.

There is some commentary in #389 on why we **are not** adding `Inner`s for the three datatypes. In summary, because `ltree` is an extension (one that ships with Postgres), it's Oids are not static like many other datatypes. This renders the `Inner` loading by Oid unusable and thus we must match on the `Type` name, like we do for `citext`.

Long term motivations for this are to incorporate these changes into quaint and then eventually into Prisma.

Fixes  #389