### PR TITLE
feat: support [u8; N] as BYTEA

### DIFF
--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -754,7 +754,7 @@ pub enum IsNull {
 /// | `f64`                             | DOUBLE PRECISION                     |
 /// | `&str`/`String`                   | VARCHAR, CHAR(n), TEXT, CITEXT, NAME |
 /// |                                   | LTREE, LQUERY, LTXTQUERY             |
-/// | `&[u8]`/`Vec<u8>`                 | BYTEA                                |
+/// | `&[u8]`/`Vec<u8>`/`[u8; N]`       | BYTEA                                |
 /// | `HashMap<String, Option<String>>` | HSTORE                               |
 /// | `SystemTime`                      | TIMESTAMP, TIMESTAMP WITH TIME ZONE  |
 /// | `IpAddr`                          | INET                                 |
@@ -794,9 +794,9 @@ pub enum IsNull {
 ///
 /// # Arrays
 ///
-/// `ToSql` is implemented for `Vec<T>`, `&[T]`, `Box<[T]>` and `[T; N]` where
-/// `T` implements `ToSql`, and corresponds to one-dimensional Postgres arrays
-/// with an index offset of 1.
+/// `ToSql` is implemented for `[u8; N]`, `Vec<T>`, `&[T]`, `Box<[T]>` and `[T; N]`
+/// where `T` implements `ToSql` and `N` is const usize, and corresponds to one-dimensional
+/// Postgres arrays with an index offset of 1.
 ///
 /// **Note:** the impl for arrays only exist when the Cargo feature `array-impls`
 /// is enabled.

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -916,6 +916,18 @@ impl<'a> ToSql for &'a [u8] {
 }
 
 #[cfg(feature = "array-impls")]
+impl<const N: usize> ToSql for [u8; N] {
+    fn to_sql(&self, _: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        types::bytea_to_sql(&self[..], w);
+        Ok(IsNull::No)
+    }
+
+    accepts!(BYTEA);
+
+    to_sql_checked!();
+}
+
+#[cfg(feature = "array-impls")]
 impl<T: ToSql, const N: usize> ToSql for [T; N] {
     fn to_sql(&self, ty: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         <&[T] as ToSql>::to_sql(&&self[..], ty, w)


### PR DESCRIPTION
There is a implementation for `&[u8]` but lacking implementation of `[u8; N]` what this PR is try to add.
Waiting for feedback