### PR TITLE
Delegate encode_format to T in &T and Option<T>

### DIFF
--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -844,7 +844,7 @@ pub trait ToSql: fmt::Debug {
 /// Supported Postgres message format types
 ///
 /// Using Text format in a message assumes a Postgres `SERVER_ENCODING` of `UTF8`
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum Format {
     /// Text format (UTF-8)
     Text,

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -868,6 +868,10 @@ where
         T::accepts(ty)
     }
 
+    fn encode_format(&self) -> Format {
+        (*self).encode_format()
+    }
+
     to_sql_checked!();
 }
 
@@ -885,6 +889,13 @@ impl<T: ToSql> ToSql for Option<T> {
 
     fn accepts(ty: &Type) -> bool {
         <T as ToSql>::accepts(ty)
+    }
+
+    fn encode_format(&self) -> Format {
+        match self {
+            Some(ref val) => val.encode_format(),
+            None => Format::Binary,
+        }
     }
 
     to_sql_checked!();

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -844,6 +844,7 @@ pub trait ToSql: fmt::Debug {
 /// Supported Postgres message format types
 ///
 /// Using Text format in a message assumes a Postgres `SERVER_ENCODING` of `UTF8`
+#[derive(Debug)]
 pub enum Format {
     /// Text format (UTF-8)
     Text,


### PR DESCRIPTION
https://github.com/sfackler/rust-postgres/pull/836 has been really useful for my use case, and this PR makes some small improvements to it.

I have a custom type (call it `T`) that `impl`s `ToSql`, and I override `encode_format`. However in some situations I'm working with `&T` or `Option<T>` and I want `to_sql` to use the format that I've specified in `encode_format`. This change ensures that by delegating to `T::encode_format` in these cases.

As well as being useful, I believe this fixes a correctness issue, as these types already delegate to their inner type to implement `to_sql`, so they should do the same for `encode_format` to avoid emitting, e.g., a text encoding that is tagged as binary.

I've also added `[derive(Clone, Copy, Debug)]` to `Format`, as it's a simple enum and this makes working with it a bit easier.