### PR TITLE
Derive Generic FromSql/ToSql

### DIFF
--- a/postgres-derive-test/src/composites.rs
+++ b/postgres-derive-test/src/composites.rs
@@ -1,6 +1,6 @@
 use crate::{test_type, test_type_asymmetric};
 use postgres::{Client, NoTls};
-use postgres_types::{FromSql, FromSqlOwned, ToSql, WrongType};
+use postgres_types::{FromSql, ToSql, WrongType};
 use std::error::Error;
 
 #[test]
@@ -242,9 +242,9 @@ fn raw_ident_field() {
 #[test]
 fn generics() {
     #[derive(FromSql, Debug, PartialEq)]
-    struct InventoryItem<T: FromSqlOwned, U>
+    struct InventoryItem<T: Clone, U>
     where
-        U: FromSqlOwned,
+        U: Clone,
     {
         name: String,
         supplier_id: T,
@@ -254,9 +254,9 @@ fn generics() {
     // doesn't make sense to implement derived FromSql on a type with borrows
     #[derive(ToSql, Debug, PartialEq)]
     #[postgres(name = "InventoryItem")]
-    struct InventoryItemRef<'a, T: 'a + ToSql, U>
+    struct InventoryItemRef<'a, T: 'a + Clone, U>
     where
-        U: 'a + ToSql,
+        U: 'a + Clone,
     {
         name: &'a str,
         supplier_id: &'a T,

--- a/postgres-derive-test/src/lib.rs
+++ b/postgres-derive-test/src/lib.rs
@@ -27,6 +27,30 @@ where
     }
 }
 
+pub fn test_type_asymmetric<T, F, S, C>(
+    conn: &mut Client,
+    sql_type: &str,
+    checks: &[(T, S)],
+    cmp: C,
+) where
+    T: ToSql + Sync,
+    F: FromSqlOwned,
+    S: fmt::Display,
+    C: Fn(&T, &F) -> bool,
+{
+    for &(ref val, ref repr) in checks.iter() {
+        let stmt = conn
+            .prepare(&*format!("SELECT {}::{}", *repr, sql_type))
+            .unwrap();
+        let result: F = conn.query_one(&stmt, &[]).unwrap().get(0);
+        assert!(cmp(val, &result));
+
+        let stmt = conn.prepare(&*format!("SELECT $1::{}", sql_type)).unwrap();
+        let result: F = conn.query_one(&stmt, &[val]).unwrap().get(0);
+        assert!(cmp(val, &result));
+    }
+}
+
 #[test]
 fn compile_fail() {
     trybuild::TestCases::new().compile_fail("src/compile-fail/*.rs");

--- a/postgres-derive/src/composites.rs
+++ b/postgres-derive/src/composites.rs
@@ -1,4 +1,8 @@
-use syn::{Error, Ident, Type};
+use proc_macro2::Span;
+use syn::{
+    punctuated::Punctuated, Error, GenericParam, Generics, Ident, Path, PathSegment, Type,
+    TypeParamBound,
+};
 
 use crate::overrides::Overrides;
 
@@ -25,4 +29,24 @@ impl Field {
             type_: raw.ty.clone(),
         })
     }
+}
+
+pub(crate) fn append_generic_bound(mut generics: Generics, bound: &TypeParamBound) -> Generics {
+    for param in &mut generics.params {
+        if let GenericParam::Type(param) = param {
+            param.bounds.push(bound.to_owned())
+        }
+    }
+    generics
+}
+
+pub(crate) fn new_derive_path(last: PathSegment) -> Path {
+    let mut path = Path {
+        leading_colon: None,
+        segments: Punctuated::new(),
+    };
+    path.segments
+        .push(Ident::new("postgres_types", Span::call_site()).into());
+    path.segments.push(last);
+    path
 }

--- a/postgres-derive/src/tosql.rs
+++ b/postgres-derive/src/tosql.rs
@@ -1,10 +1,14 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use std::iter;
-use syn::{Data, DataStruct, DeriveInput, Error, Fields, Ident};
+use syn::{
+    Data, DataStruct, DeriveInput, Error, Fields, Ident, TraitBound, TraitBoundModifier,
+    TypeParamBound,
+};
 
 use crate::accepts;
 use crate::composites::Field;
+use crate::composites::{append_generic_bound, new_derive_path};
 use crate::enums::Variant;
 use crate::overrides::Overrides;
 
@@ -82,7 +86,8 @@ pub fn expand_derive_tosql(input: DeriveInput) -> Result<TokenStream, Error> {
     };
 
     let ident = &input.ident;
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let generics = append_generic_bound(input.generics.to_owned(), &new_tosql_bound());
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let out = quote! {
         impl#impl_generics postgres_types::ToSql for #ident#ty_generics #where_clause {
             fn to_sql(&self,
@@ -181,4 +186,13 @@ fn composite_body(fields: &[Field]) -> TokenStream {
 
         std::result::Result::Ok(postgres_types::IsNull::No)
     }
+}
+
+fn new_tosql_bound() -> TypeParamBound {
+    TypeParamBound::Trait(TraitBound {
+        lifetimes: None,
+        modifier: TraitBoundModifier::None,
+        paren_token: None,
+        path: new_derive_path(Ident::new("ToSql", Span::call_site()).into()),
+    })
 }

--- a/postgres-derive/src/tosql.rs
+++ b/postgres-derive/src/tosql.rs
@@ -82,8 +82,9 @@ pub fn expand_derive_tosql(input: DeriveInput) -> Result<TokenStream, Error> {
     };
 
     let ident = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let out = quote! {
-        impl postgres_types::ToSql for #ident {
+        impl#impl_generics postgres_types::ToSql for #ident#ty_generics #where_clause {
             fn to_sql(&self,
                       _type: &postgres_types::Type,
                       buf: &mut postgres_types::private::BytesMut)


### PR DESCRIPTION
Allows for derivation of FromSql and ToSql for generic types. Borrowed types are allowed for ToSql, but not meaningful to support for FromSql (so not supported). (also noted in #570)

Would you be interested in this change? A test was added. Happy to iterate.