### PR TITLE
i128 support

### DIFF
--- a/postgres-protocol/src/types/mod.rs
+++ b/postgres-protocol/src/types/mod.rs
@@ -132,10 +132,26 @@ pub fn int8_to_sql(v: i64, buf: &mut BytesMut) {
     buf.put_i64(v);
 }
 
+/// Serializes to a `NUMERIC` value.
+#[inline]
+pub fn int16_to_sql(v: i128, buf: &mut BytesMut) {
+    buf.put_i128(v);
+}
+
 /// Deserializes an `INT8` value.
 #[inline]
 pub fn int8_from_sql(mut buf: &[u8]) -> Result<i64, StdBox<dyn Error + Sync + Send>> {
     let v = buf.read_i64::<BigEndian>()?;
+    if !buf.is_empty() {
+        return Err("invalid buffer size".into());
+    }
+    Ok(v)
+}
+
+/// Deserializes an `NUMERIC` value without fractional part.
+#[inline]
+pub fn int16_from_sql(mut buf: &[u8]) -> Result<i128, StdBox<dyn Error + Sync + Send>> {
+    let v = buf.read_i128::<BigEndian>()?;
     if !buf.is_empty() {
         return Err("invalid buffer size".into());
     }

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -408,6 +408,7 @@ impl WrongType {
 /// | `i32`                             | INT, SERIAL                                   |
 /// | `u32`                             | OID                                           |
 /// | `i64`                             | BIGINT, BIGSERIAL                             |
+/// | `i128`                            | NUMERIC                                       |
 /// | `f32`                             | REAL                                          |
 /// | `f64`                             | DOUBLE PRECISION                              |
 /// | `&str`/`String`                   | VARCHAR, CHAR(n), TEXT, CITEXT, NAME, UNKNOWN |
@@ -678,6 +679,7 @@ simple_from!(i16, int2_from_sql, INT2);
 simple_from!(i32, int4_from_sql, INT4);
 simple_from!(u32, oid_from_sql, OID);
 simple_from!(i64, int8_from_sql, INT8);
+simple_from!(i128, int16_from_sql, INT8);
 simple_from!(f32, float4_from_sql, FLOAT4);
 simple_from!(f64, float8_from_sql, FLOAT8);
 
@@ -755,6 +757,7 @@ pub enum IsNull {
 /// | `i32`                             | INT, SERIAL                          |
 /// | `u32`                             | OID                                  |
 /// | `i64`                             | BIGINT, BIGSERIAL                    |
+/// | `i128`                            | NUMERIC                              |
 /// | `f32`                             | REAL                                 |
 /// | `f64`                             | DOUBLE PRECISION                     |
 /// | `&str`/`String`                   | VARCHAR, CHAR(n), TEXT, CITEXT, NAME |
@@ -1097,6 +1100,7 @@ simple_to!(i16, int2_to_sql, INT2);
 simple_to!(i32, int4_to_sql, INT4);
 simple_to!(u32, oid_to_sql, OID);
 simple_to!(i64, int8_to_sql, INT8);
+simple_to!(i128, int16_to_sql, INT8);
 simple_to!(f32, float4_to_sql, FLOAT4);
 simple_to!(f64, float8_to_sql, FLOAT8);
 


### PR DESCRIPTION
- Untested.

- Contrived use of `NUMERIC` SQL type, fails on numbers with a fractional part.