### PR TITLE
impl ToSQL/FromSQL on url::Url

### DIFF
--- a/postgres-types/Cargo.toml
+++ b/postgres-types/Cargo.toml
@@ -23,6 +23,7 @@ with-geo-types-0_7 = ["geo-types-0_7"]
 with-serde_json-1 = ["serde-1", "serde_json-1"]
 with-uuid-0_8 = ["uuid-08"]
 with-uuid-1 = ["uuid-1"]
+with-url-2 = ["url-2"]
 with-time-0_2 = ["time-02"]
 with-time-0_3 = ["time-03"]
 
@@ -46,6 +47,7 @@ serde-1 = { version = "1.0", package = "serde", optional = true }
 serde_json-1 = { version = "1.0", package = "serde_json", optional = true }
 uuid-08 = { version = "0.8", package = "uuid", optional = true }
 uuid-1 = { version = "1.0", package = "uuid", optional = true }
+url-2 = { version = "2.2.2", package = "url", optional = true }
 time-02 = { version = "0.2", package = "time", optional = true }
 time-03 = { version = "0.3", package = "time", default-features = false, optional = true }
 

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -234,6 +234,8 @@ mod time_03;
 mod uuid_08;
 #[cfg(feature = "with-uuid-1")]
 mod uuid_1;
+#[cfg(feature = "with-url-2")]
+mod url_2;
 
 // The time::{date, time} macros produce compile errors if the crate package is renamed.
 #[cfg(feature = "with-time-0_2")]

--- a/postgres-types/src/url_2.rs
+++ b/postgres-types/src/url_2.rs
@@ -1,0 +1,25 @@
+use bytes::{BytesMut, BufMut};
+use std::error::Error;
+use url_2::Url;
+
+use crate::{FromSql, IsNull, ToSql, Type};
+
+impl<'a> FromSql<'a> for Url {
+    fn from_sql(_: &Type, raw: &[u8]) -> Result<Url, Box<dyn Error + Sync + Send>> {
+        let url = std::str::from_utf8(raw)?;
+        let url = Url::parse(url)?;
+        Ok(url)
+    }
+
+    accepts!(TEXT);
+}
+
+impl ToSql for Url {
+    fn to_sql(&self, _: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        w.put_slice(self.to_string().as_bytes());
+        Ok(IsNull::No)
+    }
+
+    accepts!(TEXT);
+    to_sql_checked!();
+}


### PR DESCRIPTION
I have a whole bunch of url::Url types in my structs, so here's a simple impl that renders it out as a TEXT string and back (this is probably the best/most interoperable way to implement it?)

My commit message is horrible so you'll want to squash/merge this if you decide this is something you want.