### PR TITLE
Encode Format based on Type

### DIFF
--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -836,7 +836,7 @@ pub trait ToSql: fmt::Debug {
     ) -> Result<IsNull, Box<dyn Error + Sync + Send>>;
 
     /// Specify the encode format
-    fn encode_format(&self) -> Format {
+    fn encode_format(&self, _ty: &Type) -> Format {
         Format::Binary
     }
 }
@@ -868,8 +868,8 @@ where
         T::accepts(ty)
     }
 
-    fn encode_format(&self) -> Format {
-        (*self).encode_format()
+    fn encode_format(&self, ty: &Type) -> Format {
+        (*self).encode_format(ty)
     }
 
     to_sql_checked!();
@@ -891,9 +891,9 @@ impl<T: ToSql> ToSql for Option<T> {
         <T as ToSql>::accepts(ty)
     }
 
-    fn encode_format(&self) -> Format {
+    fn encode_format(&self, ty: &Type) -> Format {
         match self {
-            Some(ref val) => val.encode_format(),
+            Some(ref val) => val.encode_format(ty),
             None => Format::Binary,
         }
     }

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -157,11 +157,6 @@ where
     I::IntoIter: ExactSizeIterator,
 {
     let param_types = statement.params();
-    let (param_formats, params): (Vec<_>, Vec<_>) = params
-        .into_iter()
-        .zip(param_types.iter())
-        .map(|(p, ty)| (p.borrow_to_sql().encode_format(ty) as i16, p))
-        .unzip();
     let params = params.into_iter();
 
     assert!(
@@ -170,6 +165,13 @@ where
         param_types.len(),
         params.len()
     );
+
+    let (param_formats, params): (Vec<_>, Vec<_>) = params
+        .zip(param_types.iter())
+        .map(|(p, ty)| (p.borrow_to_sql().encode_format(ty) as i16, p))
+        .unzip();
+
+    let params = params.into_iter();
 
     let mut error_idx = 0;
     let r = frontend::bind(


### PR DESCRIPTION
#836 has been helpful as a way of pairing parameter types with their encodings, but the `encode_format` method in the `ToSql` trait would be even more useful with the addition of a reference to `Type`. This would enable more granular encoding of parameters based on the types inferred by Postgres during the `prepare` phase, which would be useful when processing payloads from more general type systems like gRPC or JSON.

Since parameter types are already generated by the time `bind()` is called, it's easy to include them as part of the format-generating process. This PR simply adds a `Type` parameter to the `encode_format` method added to `ToSql`, which should not be a breaking change if it can be made before the next release.