### PR TITLE
WIP add backend messages serialization and frontend messages deserialization

### DIFF
--- a/postgres-protocol/src/message/backend.rs
+++ b/postgres-protocol/src/message/backend.rs
@@ -1,10 +1,11 @@
 #![allow(missing_docs)]
 
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
-use bytes::{Bytes, BytesMut};
+use bytes::{Bytes, BytesMut, BufMut, Buf};
 use fallible_iterator::FallibleIterator;
 use memchr::memchr;
 use std::cmp;
+use std::convert::TryInto;
 use std::io::{self, Read};
 use std::ops::Range;
 use std::str;
@@ -275,6 +276,136 @@ impl Message {
         }
 
         Ok(Some(message))
+    }
+}
+
+impl TryInto<Bytes> for Message {
+    type Error = io::Error;
+
+    fn try_into(self) -> Result<Bytes, Self::Error> {
+        match self {
+            Message::AuthenticationCleartextPassword => {
+                let mut buf = BytesMut::with_capacity(9);
+                buf.put_u8(AUTHENTICATION_TAG);
+                buf.put_i32(8i32);
+                buf.put_i32(3i32);
+                Ok(Bytes::from(buf))
+            },
+            Message::AuthenticationGss => {
+                let mut buf = BytesMut::with_capacity(9);
+                buf.put_u8(AUTHENTICATION_TAG);
+                buf.put_i32(8i32);
+                buf.put_i32(7i32);
+                Ok(Bytes::from(buf))
+            },
+            Message::AuthenticationGssContinue(body) => {
+                let len = body.0.len();
+                let mut buf = BytesMut::with_capacity(len+1+4+4);
+                buf.put_u8(AUTHENTICATION_TAG);
+                buf.put_i32(len as i32);
+                buf.put_i32(8i32);
+                buf.put_slice(body.data());
+                Ok(Bytes::from(buf))
+            },
+            Message::AuthenticationKerberosV5 => {
+                let len = 8i32;
+                let mut buf = BytesMut::with_capacity(len as usize);
+                buf.put_u8(AUTHENTICATION_TAG);
+                buf.put_i32(8i32);
+                buf.put_i32(2i32);
+                Ok(Bytes::from(buf))
+            },
+            Message::AuthenticationMd5Password(body) => {
+                let len = 12i32;
+                let mut buf = BytesMut::with_capacity(len as usize);
+                buf.put_u8(AUTHENTICATION_TAG);
+                buf.put_i32(len);
+                buf.put_i32(5i32);
+                buf.put_slice(&body.salt());
+                Ok(Bytes::from(buf))
+            },
+            Message::AuthenticationOk => {
+                let len = 8i32;
+                let mut buf = BytesMut::with_capacity(len as usize);
+                buf.put_u8(AUTHENTICATION_TAG);
+                buf.put_i32(len);
+                buf.put_i32(0i32);
+                Ok(Bytes::from(buf))
+            },
+            Message::AuthenticationSasl(body) => {
+                let len = body.0.len() + 1 + 4;
+                let mut buf = BytesMut::with_capacity(len);
+                buf.put_u8(AUTHENTICATION_TAG);
+                buf.put_i32(len as i32);
+                buf.put_i32(10i32);
+                buf.put_slice(body.0.chunk());
+                Ok(Bytes::from(buf))
+            },
+            Message::AuthenticationSaslContinue(body) => {
+                let len = body.0.len() + 1 + 4 + 4;
+                let mut buf = BytesMut::with_capacity(len);
+                buf.put_u8(AUTHENTICATION_TAG);
+                buf.put_i32(len as i32);
+                buf.put_i32(11i32);
+                buf.put_slice(body.data());
+                Ok(Bytes::from(buf))
+            },
+            Message::AuthenticationSaslFinal(body) => {
+                let len = body.0.len() + 1 + 4 + 4;
+                let mut buf = BytesMut::with_capacity(len);
+                buf.put_u8(AUTHENTICATION_TAG);
+                buf.put_i32(len as i32);
+                buf.put_i32(12i32);
+                buf.put_slice(body.data());
+                Ok(Bytes::from(buf))
+            },
+            Message::AuthenticationScmCredential => {
+                let len = 8i32;
+                let mut buf = BytesMut::with_capacity(len as usize);
+                buf.put_i32(len);
+                buf.put_i32(6i32);
+                Ok(Bytes::from(buf))
+            },
+            Message::AuthenticationSspi => {
+                let len = 8i32;
+                let mut buf = BytesMut::with_capacity(len as usize);
+                buf.put_i32(len);
+                buf.put_i32(9i32);
+                Ok(Bytes::from(buf))
+            },
+            Message::BackendKeyData(body) => {
+                let len = 12i32;
+                let mut buf = BytesMut::with_capacity(len as usize);
+                buf.put_u8(BACKEND_KEY_DATA_TAG);
+                buf.put_i32(len);
+                buf.put_i32(body.process_id());
+                buf.put_i32(body.secret_key());
+                Ok(Bytes::from(buf))
+            },
+            Message::BindComplete => {
+                let len = 4i32;
+                let mut buf = BytesMut::with_capacity(len as usize);
+                buf.put_u8(BIND_COMPLETE_TAG);
+                buf.put_i32(4i32);
+                Ok(Bytes::from(buf))
+            },
+            Message::CloseComplete => {
+                let len = 4i32;
+                let mut buf = BytesMut::with_capacity(len as usize);
+                buf.put_u8(CLOSE_COMPLETE_TAG);
+                buf.put_i32(4i32);
+                Ok(Bytes::from(buf))
+            },
+            Message::CommandComplete(body) => {
+                let len = body.tag()?.len() + 1 + 4;
+                let mut buf = BytesMut::with_capacity(len);
+                buf.put_u8(COMMAND_COMPLETE_TAG);
+                buf.put_i32(len as i32);
+                buf.put_slice(body.tag()?.as_bytes());
+                Ok(Bytes::from(buf))
+            },
+            _ => todo!("match remaining variants"),
+        }
     }
 }
 


### PR DESCRIPTION
The goal is to allow serialization of backend message into bytes and deserialization of frontend message into rust object that we can handle.
It could be useful for making a proxy or a fake postgresql server. (honeypot)

I've still lot of work here. My approach for backend message serialization is to implement TryFrom for Message in order to convert them into bytes.
I'm open to suggestions if you know a better way to do this of course.

Thank you!