### PR TITLE
Add text format result support 

### DIFF
--- a/postgres/src/client.rs
+++ b/postgres/src/client.rs
@@ -46,6 +46,24 @@ impl Client {
         Config::new()
     }
 
+    /// Return the result format of client
+    ///
+    /// true indicates that the client will receive the result in binary format
+    /// false indicates that the client will receive the result in text format
+    pub fn result_format(&self) -> bool {
+        self.client.result_format()
+    }
+
+    /// Set the format of return result.
+    ///
+    /// format
+    ///    true: binary format
+    ///   false: text format
+    /// default format is binary format(result_format = true)
+    pub fn set_result_format(&mut self, format: bool) {
+        self.client.set_result_format(format);
+    }
+
     /// Executes a statement, returning the number of rows modified.
     ///
     /// A statement may contain parameters, specified by `$n`, where `n` is the index of the parameter of the list

--- a/tokio-postgres/src/bind.rs
+++ b/tokio-postgres/src/bind.rs
@@ -14,6 +14,7 @@ pub async fn bind<P, I>(
     client: &Arc<InnerClient>,
     statement: Statement,
     params: I,
+    result_format: bool,
 ) -> Result<Portal, Error>
 where
     P: BorrowToSql,
@@ -22,7 +23,7 @@ where
 {
     let name = format!("p{}", NEXT_ID.fetch_add(1, Ordering::SeqCst));
     let buf = client.with_buf(|buf| {
-        query::encode_bind(&statement, params, &name, buf)?;
+        query::encode_bind(&statement, params, &name, buf, result_format)?;
         frontend::sync(buf);
         Ok(buf.split().freeze())
     })?;

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -170,6 +170,7 @@ pub struct Client {
     ssl_mode: SslMode,
     process_id: i32,
     secret_key: i32,
+    result_format: bool,
 }
 
 impl Client {
@@ -190,6 +191,7 @@ impl Client {
             ssl_mode,
             process_id,
             secret_key,
+            result_format: true,
         }
     }
 
@@ -200,6 +202,24 @@ impl Client {
     #[cfg(feature = "runtime")]
     pub(crate) fn set_socket_config(&mut self, socket_config: SocketConfig) {
         self.socket_config = Some(socket_config);
+    }
+
+    /// Return the result format of client
+    ///
+    /// true indicates that the client will receive the result in binary format
+    /// false indicates that the client will receive the result in text format
+    pub fn result_format(&self) -> bool {
+        self.result_format
+    }
+
+    /// Set the format of return result.
+    ///
+    /// format
+    ///    true: binary format
+    ///   false: text format
+    /// default format is binary format(result_format = true)
+    pub fn set_result_format(&mut self, format: bool) {
+        self.result_format = format;
     }
 
     /// Creates a new prepared statement.
@@ -369,7 +389,7 @@ impl Client {
         I::IntoIter: ExactSizeIterator,
     {
         let statement = statement.__convert().into_statement(self).await?;
-        query::query(&self.inner, statement, params).await
+        query::query(&self.inner, statement, params, self.result_format).await
     }
 
     /// Executes a statement, returning the number of rows modified.

--- a/tokio-postgres/src/copy_in.rs
+++ b/tokio-postgres/src/copy_in.rs
@@ -1,7 +1,7 @@
 use crate::client::{InnerClient, Responses};
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
-use crate::{query, slice_iter, Error, Statement};
+use crate::{query, slice_iter, Error, Statement, DEFAULT_RESULT_FORMAT};
 use bytes::{Buf, BufMut, BytesMut};
 use futures_channel::mpsc;
 use futures_util::{future, ready, Sink, SinkExt, Stream, StreamExt};
@@ -200,7 +200,7 @@ where
 {
     debug!("executing copy in statement {}", statement.name());
 
-    let buf = query::encode(client, &statement, slice_iter(&[]))?;
+    let buf = query::encode(client, &statement, slice_iter(&[]), DEFAULT_RESULT_FORMAT)?;
 
     let (mut sender, receiver) = mpsc::channel(1);
     let receiver = CopyInReceiver::new(receiver);

--- a/tokio-postgres/src/copy_out.rs
+++ b/tokio-postgres/src/copy_out.rs
@@ -1,7 +1,7 @@
 use crate::client::{InnerClient, Responses};
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
-use crate::{query, slice_iter, Error, Statement};
+use crate::{query, slice_iter, Error, Statement, DEFAULT_RESULT_FORMAT};
 use bytes::Bytes;
 use futures_util::{ready, Stream};
 use log::debug;
@@ -14,7 +14,7 @@ use std::task::{Context, Poll};
 pub async fn copy_out(client: &InnerClient, statement: Statement) -> Result<CopyOutStream, Error> {
     debug!("executing copy out statement {}", statement.name());
 
-    let buf = query::encode(client, &statement, slice_iter(&[]))?;
+    let buf = query::encode(client, &statement, slice_iter(&[]), DEFAULT_RESULT_FORMAT)?;
     let responses = start(client, buf).await?;
     Ok(CopyOutStream {
         responses,

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -179,6 +179,9 @@ mod transaction;
 mod transaction_builder;
 pub mod types;
 
+// Default result format : binary(true)
+const DEFAULT_RESULT_FORMAT: bool = true;
+
 /// A convenience function which parses a connection string and connects to the database.
 ///
 /// See the documentation for [`Config`] for details on the connection string format.

--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -3,7 +3,7 @@ use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
 use crate::error::SqlState;
 use crate::types::{Field, Kind, Oid, Type};
-use crate::{query, slice_iter};
+use crate::{query, slice_iter, DEFAULT_RESULT_FORMAT};
 use crate::{Column, Error, Statement};
 use bytes::Bytes;
 use fallible_iterator::FallibleIterator;
@@ -137,7 +137,7 @@ async fn get_type(client: &Arc<InnerClient>, oid: Oid) -> Result<Type, Error> {
 
     let stmt = typeinfo_statement(client).await?;
 
-    let rows = query::query(client, stmt, slice_iter(&[&oid])).await?;
+    let rows = query::query(client, stmt, slice_iter(&[&oid]), DEFAULT_RESULT_FORMAT).await?;
     pin_mut!(rows);
 
     let row = match rows.try_next().await? {
@@ -207,7 +207,7 @@ async fn typeinfo_statement(client: &Arc<InnerClient>) -> Result<Statement, Erro
 async fn get_enum_variants(client: &Arc<InnerClient>, oid: Oid) -> Result<Vec<String>, Error> {
     let stmt = typeinfo_enum_statement(client).await?;
 
-    query::query(client, stmt, slice_iter(&[&oid]))
+    query::query(client, stmt, slice_iter(&[&oid]), DEFAULT_RESULT_FORMAT)
         .await?
         .and_then(|row| async move { row.try_get(0) })
         .try_collect()
@@ -234,7 +234,7 @@ async fn typeinfo_enum_statement(client: &Arc<InnerClient>) -> Result<Statement,
 async fn get_composite_fields(client: &Arc<InnerClient>, oid: Oid) -> Result<Vec<Field>, Error> {
     let stmt = typeinfo_composite_statement(client).await?;
 
-    let rows = query::query(client, stmt, slice_iter(&[&oid]))
+    let rows = query::query(client, stmt, slice_iter(&[&oid]), DEFAULT_RESULT_FORMAT)
         .await?
         .try_collect::<Vec<_>>()
         .await?;


### PR DESCRIPTION
## What this PR do 
This PR add the TEXT format support for query result. In addition, this modification is compatitable for previous version. User needn't to change the original query.

## Context 
The rust-postgres only support binary format query result in extended query mode before. But in some cases, binary format of some type(such as multidimensional list) isn't support well. Sometimes, TEXT format result is more convenient. Such as in [sqllogictest](https://github.com/risinglightdb/sqllogictest-rs)(It is a testing framework to verify the correctness of an SQL database), it can test a database using extended query protocol. In this case, TEXT format is more convenient to compare the actual result with the expect result. 

I try to support text format in this PR. To make it compatible with the previous version, I add a result_format flag in client. The query will send message according to the result_format. And add the `get_text ` in row to get the result as TEXT format.

## Some problem may need to solved 
- Row can't guarantee the `get_text` will caused panic or error if user use it in a 'binary format row'. I only add the comment to indicate that user must guarantee use `get_text` in 'text format row'.
- I add the test case but I'm not sure whether enough.

Anyway, I'm glad to make any modification and hope it can be merged into main version. 

related issue: #882 