### PR TITLE
Add flush() to front-end messages

### DIFF
--- a/postgres-protocol/src/message/frontend.rs
+++ b/postgres-protocol/src/message/frontend.rs
@@ -272,6 +272,12 @@ where
 }
 
 #[inline]
+pub fn flush(buf: &mut BytesMut) {
+    buf.put_u8(b'H');
+    write_body(buf, |_| Ok::<(), io::Error>(())).unwrap();
+}
+
+#[inline]
 pub fn sync(buf: &mut BytesMut) {
     buf.put_u8(b'S');
     write_body(buf, |_| Ok::<(), io::Error>(())).unwrap();


### PR DESCRIPTION
The PostgreSQL wire protocol has a "Flush" message, which can be used by the clients for long-lived connections. Add a flush() helper for it.