### PR TITLE
tokio_postgres: add batch_execute to GenericClient

### DIFF
--- a/tokio-postgres/src/generic_client.rs
+++ b/tokio-postgres/src/generic_client.rs
@@ -72,7 +72,6 @@ pub trait GenericClient: private::Sealed {
     /// Like `Client::batch_execute`.
     async fn batch_execute(&self, query: &str) -> Result<(), Error>;
 
-
     /// Returns a reference to the underlying `Client`.
     fn client(&self) -> &Client;
 }

--- a/tokio-postgres/src/generic_client.rs
+++ b/tokio-postgres/src/generic_client.rs
@@ -69,6 +69,10 @@ pub trait GenericClient: private::Sealed {
     /// Like `Client::transaction`.
     async fn transaction(&mut self) -> Result<Transaction<'_>, Error>;
 
+    /// Like `Client::batch_execute`.
+    async fn batch_execute(&self, query: &str) -> Result<(), Error>;
+
+
     /// Returns a reference to the underlying `Client`.
     fn client(&self) -> &Client;
 }
@@ -147,6 +151,10 @@ impl GenericClient for Client {
 
     async fn transaction(&mut self) -> Result<Transaction<'_>, Error> {
         self.transaction().await
+    }
+
+    async fn batch_execute(&self, query: &str) -> Result<(), Error> {
+        self.batch_execute(query).await
     }
 
     fn client(&self) -> &Client {
@@ -230,6 +238,10 @@ impl GenericClient for Transaction<'_> {
     #[allow(clippy::needless_lifetimes)]
     async fn transaction<'a>(&'a mut self) -> Result<Transaction<'a>, Error> {
         self.transaction().await
+    }
+
+    async fn batch_execute(&self, query: &str) -> Result<(), Error> {
+        self.batch_execute(query).await
     }
 
     fn client(&self) -> &Client {


### PR DESCRIPTION
`batch_execute` is in both `tokio_postgres::Client` and `tokio_postgres::Transaction` and is therefore present in the non-tokio `postgres::GenericClient` but is missing from `tokio_postgres::GenericClient`.