### PR TITLE
[bug] futures-util <0.3.14 doesn't have Stream

### DIFF
--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -38,7 +38,7 @@ with-time-0_3 = ["tokio-postgres/with-time-0_3"]
 [dependencies]
 bytes = "1.0"
 fallible-iterator = "0.2"
-futures-util = { version = "0.3", features = ["sink"] }
+futures-util = { version = "0.3.14", features = ["sink"] }
 tokio-postgres = { version = "0.7.7", path = "../tokio-postgres" }
 
 tokio = { version = "1.0", features = ["rt", "time"] }


### PR DESCRIPTION
Fixes https://github.com/sfackler/rust-postgres/issues/956. I found this while doing some upgrades for https://github.com/palfrey/wait-for-db, but the problem is reproducible here with `cargo +nightly build -Z minimal-versions` (note that currently bugs out in other ways, as some of the other libraries have issues in their earlier versions)