### PR TITLE
feat: add `rows_affected` to RowStream

### DIFF
--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -7,7 +7,7 @@ use bytes::{Bytes, BytesMut};
 use futures_util::{ready, Stream};
 use log::{debug, log_enabled, Level};
 use pin_project_lite::pin_project;
-use postgres_protocol::message::backend::Message;
+use postgres_protocol::message::backend::{CommandCompleteBody, Message};
 use postgres_protocol::message::frontend;
 use std::fmt;
 use std::marker::PhantomPinned;
@@ -52,6 +52,7 @@ where
     Ok(RowStream {
         statement,
         responses,
+        rows_affected: None,
         _p: PhantomPinned,
     })
 }
@@ -72,8 +73,22 @@ pub async fn query_portal(
     Ok(RowStream {
         statement: portal.statement().clone(),
         responses,
+        rows_affected: None,
         _p: PhantomPinned,
     })
+}
+
+/// Extract the number of rows affected from [`CommandCompleteBody`].
+pub fn extract_row_affected(body: &CommandCompleteBody) -> Result<u64, Error> {
+    let rows = body
+        .tag()
+        .map_err(Error::parse)?
+        .rsplit(' ')
+        .next()
+        .unwrap()
+        .parse()
+        .unwrap_or(0);
+    Ok(rows)
 }
 
 pub async fn execute<P, I>(
@@ -104,14 +119,7 @@ where
         match responses.next().await? {
             Message::DataRow(_) => {}
             Message::CommandComplete(body) => {
-                rows = body
-                    .tag()
-                    .map_err(Error::parse)?
-                    .rsplit(' ')
-                    .next()
-                    .unwrap()
-                    .parse()
-                    .unwrap_or(0);
+                rows = extract_row_affected(&body)?;
             }
             Message::EmptyQueryResponse => rows = 0,
             Message::ReadyForQuery(_) => return Ok(rows),
@@ -202,6 +210,7 @@ pin_project! {
     pub struct RowStream {
         statement: Statement,
         responses: Responses,
+        rows_affected: Option<u64>,
         #[pin]
         _p: PhantomPinned,
     }
@@ -217,12 +226,22 @@ impl Stream for RowStream {
                 Message::DataRow(body) => {
                     return Poll::Ready(Some(Ok(Row::new(this.statement.clone(), body)?)))
                 }
-                Message::EmptyQueryResponse
-                | Message::CommandComplete(_)
-                | Message::PortalSuspended => {}
+                Message::CommandComplete(body) => {
+                    *this.rows_affected = Some(extract_row_affected(&body)?);
+                }
+                Message::EmptyQueryResponse | Message::PortalSuspended => {}
                 Message::ReadyForQuery(_) => return Poll::Ready(None),
                 _ => return Poll::Ready(Some(Err(Error::unexpected_message()))),
             }
         }
+    }
+}
+
+impl RowStream {
+    /// Returns the number of rows affected by the query.
+    ///
+    /// This will be `None` if the information is not available yet.
+    pub fn rows_affected(&self) -> Option<u64> {
+        self.rows_affected
     }
 }

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -240,7 +240,7 @@ impl Stream for RowStream {
 impl RowStream {
     /// Returns the number of rows affected by the query.
     ///
-    /// This will be `None` if the information is not available yet.
+    /// This function will return `None` until the stream has been exhausted.
     pub fn rows_affected(&self) -> Option<u64> {
         self.rows_affected
     }

--- a/tokio-postgres/src/simple_query.rs
+++ b/tokio-postgres/src/simple_query.rs
@@ -1,6 +1,7 @@
 use crate::client::{InnerClient, Responses};
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
+use crate::query::extract_row_affected;
 use crate::{Error, SimpleQueryMessage, SimpleQueryRow};
 use bytes::Bytes;
 use fallible_iterator::FallibleIterator;
@@ -87,14 +88,7 @@ impl Stream for SimpleQueryStream {
         loop {
             match ready!(this.responses.poll_next(cx)?) {
                 Message::CommandComplete(body) => {
-                    let rows = body
-                        .tag()
-                        .map_err(Error::parse)?
-                        .rsplit(' ')
-                        .next()
-                        .unwrap()
-                        .parse()
-                        .unwrap_or(0);
+                    let rows = extract_row_affected(&body)?;
                     return Poll::Ready(Some(Ok(SimpleQueryMessage::CommandComplete(rows))));
                 }
                 Message::EmptyQueryResponse => {


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

This PR adds a new `RawStream` for query result in extended protocol. In some cases, users won't know if the query is a DML or DDL beforehand. `RawStream` returns an enum of `Row` or `RowsAffected`, so that users can always retrieve the information they need.

Previously, only `RowStream` or `query` can get the row contents, and `execute` can only get number of rows affected.

This is used in https://github.com/risinglightdb/sqllogictest-rs/pull/151, which correctly adds Postgres extended protocol support for our Rust version of sqllogictest.

This PR also eliminates duplicated code for extracting number of rows from CommandCompleted. Now we have a single function `extract_row_affected` for that.

Thanks for review! @sfackler 