### PR TITLE
adding a notification_callback to the connection in tokio_postgres

### DIFF
--- a/tokio-postgres/src/connection.rs
+++ b/tokio-postgres/src/connection.rs
@@ -329,7 +329,8 @@ where
 
     /// Function intercepting asynchronous notifications sent from the server using "pg_notify" or "notify".
     pub fn notification_callback<F>(&mut self, notification_callback: F)
-        where F: Fn(Notification) + Send + Sync + 'static,
+    where
+        F: Fn(Notification) + Send + Sync + 'static,
     {
         self.notification_callback = Some(Arc::new(notification_callback));
     }
@@ -347,7 +348,7 @@ where
             match message {
                 AsyncMessage::Notice(notice) => {
                     info!("{}: {}", notice.severity(), notice.message());
-                },
+                }
                 AsyncMessage::Notification(notification) => {
                     if let Some(callback) = self.notification_callback.as_ref() {
                         callback(notification);

--- a/tokio-postgres/src/connection.rs
+++ b/tokio-postgres/src/connection.rs
@@ -327,10 +327,11 @@ where
         }
     }
 
+    /// Function intercepting asynchronous notifications sent from the server using "pg_notify" or "notify".
     pub fn notification_callback<F>(&mut self, notification_callback: F)
         where F: Fn(Notification) + Send + Sync + 'static,
     {
-        self.notification_callback = Some(notification_callback);
+        self.notification_callback = Some(Arc::new(notification_callback));
     }
 }
 


### PR DESCRIPTION
 Adding a notification_callback to the connection so you can catch an asynchronous notification from the server triggered with "pg_notify" or "notify"

Example to use:
```
let (client, connection) = tokio_postgres::connect("host=localhost user=postgres", NoTls).await?;
    
connection.notification_callback(|n| {
    println!("notification_callback: {:?}", n);
});

tokio::spawn(async move {
    if let Err(e) = connection.await {
        eprintln!("connection error: {}", e);
    }
});
```