### PR TITLE
tokio-postgres: add `execute_prepared` function

### DIFF
--- a/tokio-postgres/CHANGELOG.md
+++ b/tokio-postgres/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### Added
+
+* Added `execute_prepared` functions.
+
 ## v0.7.7 - 2022-08-21
 
 ## Added

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -6,7 +6,7 @@ use crate::connection::{Request, RequestMessages};
 use crate::copy_out::CopyOutStream;
 #[cfg(feature = "runtime")]
 use crate::keepalive::KeepaliveConfig;
-use crate::query::RowStream;
+use crate::query::{Execute, RowStream};
 use crate::simple_query::SimpleQueryStream;
 #[cfg(feature = "runtime")]
 use crate::tls::MakeTlsConnect;
@@ -420,6 +420,26 @@ impl Client {
     {
         let statement = statement.__convert().into_statement(self).await?;
         query::execute(self.inner(), statement, params).await
+    }
+
+    /// A version of [`execute_raw`] that does not borrow its arguments.
+    ///
+    /// This function is identical to [`execute_raw`] except that:
+    ///
+    /// 1. The returned future does not borrow the parameters or `self`.
+    /// 2. The type of the returned future does not depend on the parameters.
+    /// 3. If multiple such futures are being used concurrently, then they are executed on the server in the order
+    ///    in which this function was called, regardless of the order in which the futures are polled.
+    /// 4. This function can only be used with prepared statements.
+    ///
+    /// [`execute_raw`]: #method.execute_raw
+    pub fn execute_prepared<P, I>(&self, statement: &Statement, params: I) -> Execute
+    where
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        query::execute(self.inner(), statement.clone(), params)
     }
 
     /// Executes a `COPY FROM STDIN` statement, returning a sink used to write the copy data.

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -129,6 +129,7 @@ use crate::error::DbError;
 pub use crate::error::Error;
 pub use crate::generic_client::GenericClient;
 pub use crate::portal::Portal;
+pub use crate::query::Execute;
 pub use crate::query::RowStream;
 pub use crate::row::{Row, SimpleQueryRow};
 pub use crate::simple_query::SimpleQueryStream;

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -1,7 +1,7 @@
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
 use crate::copy_out::CopyOutStream;
-use crate::query::RowStream;
+use crate::query::{Execute, RowStream};
 #[cfg(feature = "runtime")]
 use crate::tls::MakeTlsConnect;
 use crate::tls::TlsConnect;
@@ -170,6 +170,16 @@ impl<'a> Transaction<'a> {
         I::IntoIter: ExactSizeIterator,
     {
         self.client.execute_raw(statement, params).await
+    }
+
+    /// Like `Client::execute_prepared`.
+    pub fn execute_prepared<P, I>(&self, statement: &Statement, params: I) -> Execute
+    where
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        self.client.execute_prepared(statement, params)
     }
 
     /// Binds a statement to a set of parameters, creating a `Portal` which can be incrementally queried.


### PR DESCRIPTION
As it says in the documentation:

> This function is identical to `execute_raw` except that:
>
> 1. The returned future does not borrow the parameters or `self`.
> 2. The type of the returned future does not depend on the parameters.
> 3. If multiple such futures are being used concurrently, then they are
>    executed on the server in the order in which this function was
>    called, regardless of the order in which the futures are polled.
> 4. This function can only be used with prepared statements.

This has the following additional advantages:

1. Multiple non-homogeneous `execute` futures can be stored in a collection without having to box the futures.
2. The parameters can be temporaries that do not need to out-live the futures.
3. We can rely on the order in which the futures reach the server without having to rely on polling order which might not always be documented.