### PR TITLE
Make incorrect number of paramaters an error

### DIFF
--- a/postgres/src/client.rs
+++ b/postgres/src/client.rs
@@ -57,10 +57,6 @@ impl Client {
     /// repeatedly executed (perhaps with different query parameters), consider preparing the statement up front
     /// with the `prepare` method.
     ///
-    /// # Panics
-    ///
-    /// Panics if the number of parameters provided does not match the number expected.
-    ///
     /// # Example
     ///
     /// ```no_run
@@ -96,10 +92,6 @@ impl Client {
     /// repeatedly executed (perhaps with different query parameters), consider preparing the statement up front
     /// with the `prepare` method.
     ///
-    /// # Panics
-    ///
-    /// Panics if the number of parameters provided does not match the number expected.
-    ///
     /// # Examples
     ///
     /// ```no_run
@@ -134,10 +126,6 @@ impl Client {
     /// repeatedly executed (perhaps with different query parameters), consider preparing the statement up front
     /// with the `prepare` method.
     ///
-    /// # Panics
-    ///
-    /// Panics if the number of parameters provided does not match the number expected.
-    ///
     /// # Examples
     ///
     /// ```no_run
@@ -171,10 +159,6 @@ impl Client {
     /// The `query` argument can either be a `Statement`, or a raw query string. If the same statement will be
     /// repeatedly executed (perhaps with different query parameters), consider preparing the statement up front
     /// with the `prepare` method.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the number of parameters provided does not match the number expected.
     ///
     /// # Examples
     ///
@@ -212,10 +196,6 @@ impl Client {
     ///
     /// It takes an iterator of parameters rather than a slice, and returns an iterator of rows rather than collecting
     /// them into an array.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the number of parameters provided does not match the number expected.
     ///
     /// # Examples
     ///

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -230,10 +230,6 @@ impl Client {
     /// The `statement` argument can either be a `Statement`, or a raw query string. If the same statement will be
     /// repeatedly executed (perhaps with different query parameters), consider preparing the statement up front
     /// with the `prepare` method.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the number of parameters provided does not match the number expected.
     pub async fn query<T>(
         &self,
         statement: &T,
@@ -258,10 +254,6 @@ impl Client {
     /// The `statement` argument can either be a `Statement`, or a raw query string. If the same statement will be
     /// repeatedly executed (perhaps with different query parameters), consider preparing the statement up front
     /// with the `prepare` method.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the number of parameters provided does not match the number expected.
     pub async fn query_one<T>(
         &self,
         statement: &T,
@@ -295,10 +287,6 @@ impl Client {
     /// The `statement` argument can either be a `Statement`, or a raw query string. If the same statement will be
     /// repeatedly executed (perhaps with different query parameters), consider preparing the statement up front
     /// with the `prepare` method.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the number of parameters provided does not match the number expected.
     pub async fn query_opt<T>(
         &self,
         statement: &T,
@@ -330,10 +318,6 @@ impl Client {
     /// The `statement` argument can either be a `Statement`, or a raw query string. If the same statement will be
     /// repeatedly executed (perhaps with different query parameters), consider preparing the statement up front
     /// with the `prepare` method.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the number of parameters provided does not match the number expected.
     ///
     /// [`query`]: #method.query
     ///
@@ -382,10 +366,6 @@ impl Client {
     /// with the `prepare` method.
     ///
     /// If the statement does not modify any rows (e.g. `SELECT`), 0 is returned.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the number of parameters provided does not match the number expected.
     pub async fn execute<T>(
         &self,
         statement: &T,
@@ -406,10 +386,6 @@ impl Client {
     /// repeatedly executed (perhaps with different query parameters), consider preparing the statement up front
     /// with the `prepare` method.
     ///
-    /// # Panics
-    ///
-    /// Panics if the number of parameters provided does not match the number expected.
-    ///
     /// [`execute`]: #method.execute
     pub async fn execute_raw<T, P, I>(&self, statement: &T, params: I) -> Result<u64, Error>
     where
@@ -426,10 +402,6 @@ impl Client {
     ///
     /// PostgreSQL does not support parameters in `COPY` statements, so this method does not take any. The copy *must*
     /// be explicitly completed via the `Sink::close` or `finish` methods. If it is not, the copy will be aborted.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the statement contains parameters.
     pub async fn copy_in<T, U>(&self, statement: &T) -> Result<CopyInSink<U>, Error>
     where
         T: ?Sized + ToStatement,
@@ -442,10 +414,6 @@ impl Client {
     /// Executes a `COPY TO STDOUT` statement, returning a stream of the resulting data.
     ///
     /// PostgreSQL does not support parameters in `COPY` statements, so this method does not take any.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the statement contains parameters.
     pub async fn copy_out<T>(&self, statement: &T) -> Result<CopyOutStream, Error>
     where
         T: ?Sized + ToStatement,

--- a/tokio-postgres/src/error/mod.rs
+++ b/tokio-postgres/src/error/mod.rs
@@ -344,6 +344,7 @@ enum Kind {
     ToSql(usize),
     FromSql(usize),
     Column(String),
+    Parameters(usize, usize),
     Closed,
     Db,
     Parse,
@@ -383,6 +384,9 @@ impl fmt::Display for Error {
             Kind::ToSql(idx) => write!(fmt, "error serializing parameter {}", idx)?,
             Kind::FromSql(idx) => write!(fmt, "error deserializing column {}", idx)?,
             Kind::Column(column) => write!(fmt, "invalid column `{}`", column)?,
+            Kind::Parameters(real, expected) => {
+                write!(fmt, "expected {expected} parameters but got {real}")?
+            }
             Kind::Closed => fmt.write_str("connection closed")?,
             Kind::Db => fmt.write_str("db error")?,
             Kind::Parse => fmt.write_str("error parsing response from server")?,
@@ -472,6 +476,10 @@ impl Error {
 
     pub(crate) fn column(column: String) -> Error {
         Error::new(Kind::Column(column), None)
+    }
+
+    pub(crate) fn parameters(real: usize, expected: usize) -> Error {
+        Error::new(Kind::Parameters(real, expected), None)
     }
 
     pub(crate) fn tls(e: Box<dyn error::Error + Sync + Send>) -> Error {

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -167,12 +167,9 @@ where
     let param_types = statement.params();
     let params = params.into_iter();
 
-    assert!(
-        param_types.len() == params.len(),
-        "expected {} parameters but got {}",
-        param_types.len(),
-        params.len()
-    );
+    if param_types.len() != params.len() {
+        return Err(Error::parameters(params.len(), param_types.len()));
+    }
 
     let (param_formats, params): (Vec<_>, Vec<_>) = params
         .zip(param_types.iter())


### PR DESCRIPTION
Modifies the `query` method and its siblings to return a new error type instead of panicking when the number of provided parameters doesn't match the number of parameters in the statement.

Closes #998.