### PR TITLE
export Bytes type through DataRowBody::storage_bytes method.

### DIFF
--- a/postgres-protocol/src/message/backend.rs
+++ b/postgres-protocol/src/message/backend.rs
@@ -544,6 +544,11 @@ impl DataRowBody {
     pub fn buffer(&self) -> &[u8] {
         &self.storage
     }
+
+    #[inline]
+    pub fn storage_bytes(&self) -> &Bytes {
+        &self.storage
+    }
 }
 
 pub struct DataRowRanges<'a> {


### PR DESCRIPTION
Exposing `Bytes` type can be beneficial as https://github.com/sfackler/rust-postgres/issues/996 suggested.

Regarding high level usage it can be introduced as following pesudo api:
```rust
impl Row {
    fn get2<I, T>(&self, idx: &I) -> Result<T, Error>
    where
        I: RowIndex + fmt::Display,
        T: FromSqlOwned,
    {
        ...
    }
}

trait FromSqlOwned {
  fn from_sql(ty: &Type, raw: &Bytes) -> Result<Self, Box<dyn Error + Sync + Send>>;
}

// new type of Bytes with utf8 encoding check for cheap clone.
struct ByteString(Bytes);

impl FromSqlOwned for ByteString {
  fn from_sql(ty: &Type, raw: &Bytes) -> Result<Self, Box<dyn Error + Sync + Send>> {
    std::str::from_utf8(raw.as_ref())?
    ByteString(raw.clone())  
  }
}
```

Closes #996 