### PR TITLE
added `rename_all` container attribute for enums and structs

### DIFF
--- a/postgres-derive-test/src/enums.rs
+++ b/postgres-derive-test/src/enums.rs
@@ -58,15 +58,15 @@ fn rename_all_overrides() {
     #[derive(Debug, ToSql, FromSql, PartialEq)]
     #[postgres(name = "mood", rename_all = "snake_case")]
     enum Mood {
-        Sad,
+        VerySad,
         #[postgres(name = "okay")]
         Ok,
-        Happy,
+        VeryHappy,
     }
 
     let mut conn = Client::connect("user=postgres host=localhost port=5433", NoTls).unwrap();
     conn.execute(
-        "CREATE TYPE pg_temp.mood AS ENUM ('sad', 'okay', 'happy')",
+        "CREATE TYPE pg_temp.mood AS ENUM ('very_sad', 'okay', 'very_happy')",
         &[],
     )
     .unwrap();
@@ -75,9 +75,9 @@ fn rename_all_overrides() {
         &mut conn,
         "mood",
         &[
-            (Mood::Sad, "'sad'"),
+            (Mood::VerySad, "'very_sad'"),
             (Mood::Ok, "'okay'"),
-            (Mood::Happy, "'happy'"),
+            (Mood::VeryHappy, "'very_happy'"),
         ],
     );
 }

--- a/postgres-derive-test/src/enums.rs
+++ b/postgres-derive-test/src/enums.rs
@@ -54,6 +54,35 @@ fn name_overrides() {
 }
 
 #[test]
+fn rename_all_overrides() {
+    #[derive(Debug, ToSql, FromSql, PartialEq)]
+    #[postgres(name = "mood", rename_all = "snake_case")]
+    enum Mood {
+        Sad,
+        #[postgres(name = "okay")]
+        Ok,
+        Happy,
+    }
+
+    let mut conn = Client::connect("user=postgres host=localhost port=5433", NoTls).unwrap();
+    conn.execute(
+        "CREATE TYPE pg_temp.mood AS ENUM ('sad', 'okay', 'happy')",
+        &[],
+    )
+    .unwrap();
+
+    test_type(
+        &mut conn,
+        "mood",
+        &[
+            (Mood::Sad, "'sad'"),
+            (Mood::Ok, "'okay'"),
+            (Mood::Happy, "'happy'"),
+        ],
+    );
+}
+
+#[test]
 fn wrong_name() {
     #[derive(Debug, ToSql, FromSql, PartialEq)]
     enum Foo {

--- a/postgres-derive/Cargo.toml
+++ b/postgres-derive/Cargo.toml
@@ -15,3 +15,4 @@ test = false
 syn = "2.0"
 proc-macro2 = "1.0"
 quote = "1.0"
+heck = "0.4"

--- a/postgres-derive/src/case.rs
+++ b/postgres-derive/src/case.rs
@@ -1,0 +1,158 @@
+#[allow(deprecated, unused_imports)]
+use std::ascii::AsciiExt;
+
+use self::RenameRule::*;
+
+/// The different possible ways to change case of fields in a struct, or variants in an enum.
+#[allow(clippy::enum_variant_names)]
+#[derive(Copy, Clone, PartialEq)]
+pub enum RenameRule {
+    /// Rename direct children to "lowercase" style.
+    LowerCase,
+    /// Rename direct children to "UPPERCASE" style.
+    UpperCase,
+    /// Rename direct children to "PascalCase" style, as typically used for
+    /// enum variants.
+    PascalCase,
+    /// Rename direct children to "camelCase" style.
+    CamelCase,
+    /// Rename direct children to "snake_case" style, as commonly used for
+    /// fields.
+    SnakeCase,
+    /// Rename direct children to "SCREAMING_SNAKE_CASE" style, as commonly
+    /// used for constants.
+    ScreamingSnakeCase,
+    /// Rename direct children to "kebab-case" style.
+    KebabCase,
+    /// Rename direct children to "SCREAMING-KEBAB-CASE" style.
+    ScreamingKebabCase,
+}
+
+pub static RENAME_RULES: &[(&str, RenameRule)] = &[
+    ("lowercase", LowerCase),
+    ("UPPERCASE", UpperCase),
+    ("PascalCase", PascalCase),
+    ("camelCase", CamelCase),
+    ("snake_case", SnakeCase),
+    ("SCREAMING_SNAKE_CASE", ScreamingSnakeCase),
+    ("kebab-case", KebabCase),
+    ("SCREAMING-KEBAB-CASE", ScreamingKebabCase),
+];
+
+impl RenameRule {
+    /// Apply a renaming rule to an enum variant, returning the version expected in the source.
+    pub fn apply_to_variant(&self, variant: &str) -> String {
+        match *self {
+            PascalCase => variant.to_owned(),
+            LowerCase => variant.to_ascii_lowercase(),
+            UpperCase => variant.to_ascii_uppercase(),
+            CamelCase => variant[..1].to_ascii_lowercase() + &variant[1..],
+            SnakeCase => {
+                let mut snake = String::new();
+                for (i, ch) in variant.char_indices() {
+                    if i > 0 && ch.is_uppercase() {
+                        snake.push('_');
+                    }
+                    snake.push(ch.to_ascii_lowercase());
+                }
+                snake
+            }
+            ScreamingSnakeCase => SnakeCase.apply_to_variant(variant).to_ascii_uppercase(),
+            KebabCase => SnakeCase.apply_to_variant(variant).replace('_', "-"),
+            ScreamingKebabCase => ScreamingSnakeCase
+                .apply_to_variant(variant)
+                .replace('_', "-"),
+        }
+    }
+
+    /// Apply a renaming rule to a struct field, returning the version expected in the source.
+    pub fn apply_to_field(&self, field: &str) -> String {
+        match *self {
+            LowerCase | SnakeCase => field.to_owned(),
+            UpperCase => field.to_ascii_uppercase(),
+            PascalCase => {
+                let mut pascal = String::new();
+                let mut capitalize = true;
+                for ch in field.chars() {
+                    if ch == '_' {
+                        capitalize = true;
+                    } else if capitalize {
+                        pascal.push(ch.to_ascii_uppercase());
+                        capitalize = false;
+                    } else {
+                        pascal.push(ch);
+                    }
+                }
+                pascal
+            }
+            CamelCase => {
+                let pascal = PascalCase.apply_to_field(field);
+                pascal[..1].to_ascii_lowercase() + &pascal[1..]
+            }
+            ScreamingSnakeCase => field.to_ascii_uppercase(),
+            KebabCase => field.replace('_', "-"),
+            ScreamingKebabCase => ScreamingSnakeCase.apply_to_field(field).replace('_', "-"),
+        }
+    }
+}
+
+#[test]
+fn rename_variants() {
+    for &(original, lower, upper, camel, snake, screaming, kebab, screaming_kebab) in &[
+        (
+            "Outcome", "outcome", "OUTCOME", "outcome", "outcome", "OUTCOME", "outcome", "OUTCOME",
+        ),
+        (
+            "VeryTasty",
+            "verytasty",
+            "VERYTASTY",
+            "veryTasty",
+            "very_tasty",
+            "VERY_TASTY",
+            "very-tasty",
+            "VERY-TASTY",
+        ),
+        ("A", "a", "A", "a", "a", "A", "a", "A"),
+        ("Z42", "z42", "Z42", "z42", "z42", "Z42", "z42", "Z42"),
+    ] {
+        assert_eq!(LowerCase.apply_to_variant(original), lower);
+        assert_eq!(UpperCase.apply_to_variant(original), upper);
+        assert_eq!(PascalCase.apply_to_variant(original), original);
+        assert_eq!(CamelCase.apply_to_variant(original), camel);
+        assert_eq!(SnakeCase.apply_to_variant(original), snake);
+        assert_eq!(ScreamingSnakeCase.apply_to_variant(original), screaming);
+        assert_eq!(KebabCase.apply_to_variant(original), kebab);
+        assert_eq!(
+            ScreamingKebabCase.apply_to_variant(original),
+            screaming_kebab
+        );
+    }
+}
+
+#[test]
+fn rename_fields() {
+    for &(original, upper, pascal, camel, screaming, kebab, screaming_kebab) in &[
+        (
+            "outcome", "OUTCOME", "Outcome", "outcome", "OUTCOME", "outcome", "OUTCOME",
+        ),
+        (
+            "very_tasty",
+            "VERY_TASTY",
+            "VeryTasty",
+            "veryTasty",
+            "VERY_TASTY",
+            "very-tasty",
+            "VERY-TASTY",
+        ),
+        ("a", "A", "A", "a", "A", "a", "A"),
+        ("z42", "Z42", "Z42", "z42", "Z42", "z42", "Z42"),
+    ] {
+        assert_eq!(UpperCase.apply_to_field(original), upper);
+        assert_eq!(PascalCase.apply_to_field(original), pascal);
+        assert_eq!(CamelCase.apply_to_field(original), camel);
+        assert_eq!(SnakeCase.apply_to_field(original), original);
+        assert_eq!(ScreamingSnakeCase.apply_to_field(original), screaming);
+        assert_eq!(KebabCase.apply_to_field(original), kebab);
+        assert_eq!(ScreamingKebabCase.apply_to_field(original), screaming_kebab);
+    }
+}

--- a/postgres-derive/src/composites.rs
+++ b/postgres-derive/src/composites.rs
@@ -4,7 +4,7 @@ use syn::{
     TypeParamBound,
 };
 
-use crate::overrides::Overrides;
+use crate::{case::RenameRule, overrides::Overrides};
 
 pub struct Field {
     pub name: String,
@@ -13,18 +13,26 @@ pub struct Field {
 }
 
 impl Field {
-    pub fn parse(raw: &syn::Field) -> Result<Field, Error> {
+    pub fn parse(raw: &syn::Field, rename_all: Option<RenameRule>) -> Result<Field, Error> {
         let overrides = Overrides::extract(&raw.attrs)?;
-
         let ident = raw.ident.as_ref().unwrap().clone();
-        Ok(Field {
-            name: overrides.name.unwrap_or_else(|| {
+
+        // field level name override takes precendence over container level rename_all override
+        let name = match overrides.name {
+            Some(n) => n,
+            None => {
                 let name = ident.to_string();
-                match name.strip_prefix("r#") {
-                    Some(name) => name.to_string(),
-                    None => name,
+                let stripped = name.strip_prefix("r#").map(String::from).unwrap_or(name);
+
+                match rename_all {
+                    Some(rule) => rule.apply_to_field(&stripped),
+                    None => stripped,
                 }
-            }),
+            }
+        };
+
+        Ok(Field {
+            name,
             ident,
             type_: raw.ty.clone(),
         })

--- a/postgres-derive/src/composites.rs
+++ b/postgres-derive/src/composites.rs
@@ -14,7 +14,7 @@ pub struct Field {
 
 impl Field {
     pub fn parse(raw: &syn::Field, rename_all: Option<RenameRule>) -> Result<Field, Error> {
-        let overrides = Overrides::extract(&raw.attrs)?;
+        let overrides = Overrides::extract(&raw.attrs, false)?;
         let ident = raw.ident.as_ref().unwrap().clone();
 
         // field level name override takes precendence over container level rename_all override

--- a/postgres-derive/src/enums.rs
+++ b/postgres-derive/src/enums.rs
@@ -18,7 +18,7 @@ impl Variant {
                 ))
             }
         }
-        let overrides = Overrides::extract(&raw.attrs)?;
+        let overrides = Overrides::extract(&raw.attrs, false)?;
 
         // variant level name override takes precendence over container level rename_all override
         let name = overrides.name.unwrap_or_else(|| match rename_all {

--- a/postgres-derive/src/enums.rs
+++ b/postgres-derive/src/enums.rs
@@ -1,6 +1,6 @@
 use syn::{Error, Fields, Ident};
 
-use crate::overrides::Overrides;
+use crate::{case::RenameRule, overrides::Overrides};
 
 pub struct Variant {
     pub ident: Ident,
@@ -8,7 +8,7 @@ pub struct Variant {
 }
 
 impl Variant {
-    pub fn parse(raw: &syn::Variant) -> Result<Variant, Error> {
+    pub fn parse(raw: &syn::Variant, rename_all: Option<RenameRule>) -> Result<Variant, Error> {
         match raw.fields {
             Fields::Unit => {}
             _ => {
@@ -18,11 +18,16 @@ impl Variant {
                 ))
             }
         }
-
         let overrides = Overrides::extract(&raw.attrs)?;
+
+        // variant level name override takes precendence over container level rename_all override
+        let name = overrides.name.unwrap_or_else(|| match rename_all {
+            Some(rule) => rule.apply_to_variant(&raw.ident.to_string()),
+            None => raw.ident.to_string(),
+        });
         Ok(Variant {
             ident: raw.ident.clone(),
-            name: overrides.name.unwrap_or_else(|| raw.ident.to_string()),
+            name,
         })
     }
 }

--- a/postgres-derive/src/enums.rs
+++ b/postgres-derive/src/enums.rs
@@ -22,7 +22,7 @@ impl Variant {
 
         // variant level name override takes precendence over container level rename_all override
         let name = overrides.name.unwrap_or_else(|| match rename_all {
-            Some(rule) => rule.apply_to_variant(&raw.ident.to_string()),
+            Some(rule) => rule.apply_to_field(&raw.ident.to_string()),
             None => raw.ident.to_string(),
         });
         Ok(Variant {

--- a/postgres-derive/src/fromsql.rs
+++ b/postgres-derive/src/fromsql.rs
@@ -24,7 +24,10 @@ pub fn expand_derive_fromsql(input: DeriveInput) -> Result<TokenStream, Error> {
         ));
     }
 
-    let name = overrides.name.unwrap_or_else(|| input.ident.to_string());
+    let name = overrides
+        .name
+        .clone()
+        .unwrap_or_else(|| input.ident.to_string());
 
     let (accepts_body, to_sql_body) = if overrides.transparent {
         match input.data {
@@ -51,7 +54,7 @@ pub fn expand_derive_fromsql(input: DeriveInput) -> Result<TokenStream, Error> {
             let variants = data
                 .variants
                 .iter()
-                .map(Variant::parse)
+                .map(|variant| Variant::parse(variant, overrides.rename_all))
                 .collect::<Result<Vec<_>, _>>()?;
             (
                 accepts::enum_body(&name, &variants),
@@ -75,7 +78,7 @@ pub fn expand_derive_fromsql(input: DeriveInput) -> Result<TokenStream, Error> {
             let fields = fields
                 .named
                 .iter()
-                .map(Field::parse)
+                .map(|field| Field::parse(field, overrides.rename_all))
                 .collect::<Result<Vec<_>, _>>()?;
             (
                 accepts::composite_body(&name, "FromSql", &fields),

--- a/postgres-derive/src/fromsql.rs
+++ b/postgres-derive/src/fromsql.rs
@@ -17,10 +17,10 @@ use crate::overrides::Overrides;
 pub fn expand_derive_fromsql(input: DeriveInput) -> Result<TokenStream, Error> {
     let overrides = Overrides::extract(&input.attrs, true)?;
 
-    if overrides.name.is_some() && overrides.transparent {
+    if (overrides.name.is_some() || overrides.rename_all.is_some()) && overrides.transparent {
         return Err(Error::new_spanned(
             &input,
-            "#[postgres(transparent)] is not allowed with #[postgres(name = \"...\")]",
+            "#[postgres(transparent)] is not allowed with #[postgres(name = \"...\")] or #[postgres(rename_all = \"...\")]",
         ));
     }
 

--- a/postgres-derive/src/fromsql.rs
+++ b/postgres-derive/src/fromsql.rs
@@ -15,7 +15,7 @@ use crate::enums::Variant;
 use crate::overrides::Overrides;
 
 pub fn expand_derive_fromsql(input: DeriveInput) -> Result<TokenStream, Error> {
-    let overrides = Overrides::extract(&input.attrs)?;
+    let overrides = Overrides::extract(&input.attrs, true)?;
 
     if overrides.name.is_some() && overrides.transparent {
         return Err(Error::new_spanned(

--- a/postgres-derive/src/lib.rs
+++ b/postgres-derive/src/lib.rs
@@ -7,6 +7,7 @@ use proc_macro::TokenStream;
 use syn::parse_macro_input;
 
 mod accepts;
+mod case;
 mod composites;
 mod enums;
 mod fromsql;

--- a/postgres-derive/src/overrides.rs
+++ b/postgres-derive/src/overrides.rs
@@ -10,7 +10,7 @@ pub struct Overrides {
 }
 
 impl Overrides {
-    pub fn extract(attrs: &[Attribute]) -> Result<Overrides, Error> {
+    pub fn extract(attrs: &[Attribute], container_attr: bool) -> Result<Overrides, Error> {
         let mut overrides = Overrides {
             name: None,
             rename_all: None,
@@ -34,6 +34,12 @@ impl Overrides {
                     Meta::NameValue(meta) => {
                         let name_override = meta.path.is_ident("name");
                         let rename_all_override = meta.path.is_ident("rename_all");
+                        if !container_attr && rename_all_override {
+                            return Err(Error::new_spanned(
+                                &meta.path,
+                                "rename_all is a container attribute",
+                            ));
+                        }
                         if !name_override && !rename_all_override {
                             return Err(Error::new_spanned(&meta.path, "unknown override"));
                         }

--- a/postgres-derive/src/overrides.rs
+++ b/postgres-derive/src/overrides.rs
@@ -56,23 +56,19 @@ impl Overrides {
                         if name_override {
                             overrides.name = Some(value);
                         } else if rename_all_override {
-                            let rename_rule = RENAME_RULES
-                                .iter()
-                                .find(|rule| rule.0 == value)
-                                .map(|val| val.1)
-                                .ok_or_else(|| {
-                                    Error::new_spanned(
-                                        &meta.value,
-                                        format!(
-                                            "invalid rename_all rule, expected one of: {}",
-                                            RENAME_RULES
-                                                .iter()
-                                                .map(|rule| format!("\"{}\"", rule.0))
-                                                .collect::<Vec<_>>()
-                                                .join(", ")
-                                        ),
-                                    )
-                                })?;
+                            let rename_rule = RenameRule::from_str(&value).ok_or_else(|| {
+                                Error::new_spanned(
+                                    &meta.value,
+                                    format!(
+                                        "invalid rename_all rule, expected one of: {}",
+                                        RENAME_RULES
+                                            .iter()
+                                            .map(|rule| format!("\"{}\"", rule))
+                                            .collect::<Vec<_>>()
+                                            .join(", ")
+                                    ),
+                                )
+                            })?;
 
                             overrides.rename_all = Some(rename_rule);
                         }

--- a/postgres-derive/src/tosql.rs
+++ b/postgres-derive/src/tosql.rs
@@ -22,7 +22,10 @@ pub fn expand_derive_tosql(input: DeriveInput) -> Result<TokenStream, Error> {
         ));
     }
 
-    let name = overrides.name.unwrap_or_else(|| input.ident.to_string());
+    let name = overrides
+        .name
+        .clone()
+        .unwrap_or_else(|| input.ident.to_string());
 
     let (accepts_body, to_sql_body) = if overrides.transparent {
         match input.data {
@@ -47,7 +50,7 @@ pub fn expand_derive_tosql(input: DeriveInput) -> Result<TokenStream, Error> {
                 let variants = data
                     .variants
                     .iter()
-                    .map(Variant::parse)
+                    .map(|variant| Variant::parse(variant, overrides.rename_all))
                     .collect::<Result<Vec<_>, _>>()?;
                 (
                     accepts::enum_body(&name, &variants),
@@ -69,7 +72,7 @@ pub fn expand_derive_tosql(input: DeriveInput) -> Result<TokenStream, Error> {
                 let fields = fields
                     .named
                     .iter()
-                    .map(Field::parse)
+                    .map(|field| Field::parse(field, overrides.rename_all))
                     .collect::<Result<Vec<_>, _>>()?;
                 (
                     accepts::composite_body(&name, "ToSql", &fields),

--- a/postgres-derive/src/tosql.rs
+++ b/postgres-derive/src/tosql.rs
@@ -13,7 +13,7 @@ use crate::enums::Variant;
 use crate::overrides::Overrides;
 
 pub fn expand_derive_tosql(input: DeriveInput) -> Result<TokenStream, Error> {
-    let overrides = Overrides::extract(&input.attrs)?;
+    let overrides = Overrides::extract(&input.attrs, true)?;
 
     if overrides.name.is_some() && overrides.transparent {
         return Err(Error::new_spanned(

--- a/postgres-derive/src/tosql.rs
+++ b/postgres-derive/src/tosql.rs
@@ -15,10 +15,10 @@ use crate::overrides::Overrides;
 pub fn expand_derive_tosql(input: DeriveInput) -> Result<TokenStream, Error> {
     let overrides = Overrides::extract(&input.attrs, true)?;
 
-    if overrides.name.is_some() && overrides.transparent {
+    if (overrides.name.is_some() || overrides.rename_all.is_some()) && overrides.transparent {
         return Err(Error::new_spanned(
             &input,
-            "#[postgres(transparent)] is not allowed with #[postgres(name = \"...\")]",
+            "#[postgres(transparent)] is not allowed with #[postgres(name = \"...\")] or #[postgres(rename_all = \"...\")]",
         ));
     }
 

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -125,6 +125,37 @@
 //!     Happy,
 //! }
 //! ```
+//!
+//! Alternatively, the `#[postgres(rename_all = "...")]` attribute can be used to rename all fields or variants
+//! with the chosen casing convention. This will not affect the struct or enum's type name. Note that
+//! `#[postgres(name = "...")]` takes precendence when used in conjunction with `#[postgres(rename_all = "...")]`:
+//!
+//! ```rust
+//! # #[cfg(feature = "derive")]
+//! use postgres_types::{ToSql, FromSql};
+//!
+//! # #[cfg(feature = "derive")]
+//! #[derive(Debug, ToSql, FromSql)]
+//! #[postgres(name = "mood", rename_all = "snake_case")]
+//! enum Mood {
+//!     VerySad,        // very_sad
+//!     #[postgres(name = "ok")]
+//!     Ok,             // ok
+//!     VeryHappy,      // very_happy
+//! }
+//! ```
+//!
+//! The following case conventions are supported:
+//! - `"lowercase"`
+//! - `"UPPERCASE"`
+//! - `"PascalCase"`
+//! - `"camelCase"`
+//! - `"snake_case"`
+//! - `"SCREAMING_SNAKE_CASE"`
+//! - `"kebab-case"`
+//! - `"SCREAMING-KEBAB-CASE"`
+//! - `"Train-Case"`
+
 #![doc(html_root_url = "https://docs.rs/postgres-types/0.2")]
 #![warn(clippy::all, rust_2018_idioms, missing_docs)]
 


### PR DESCRIPTION
Related issue: #934 

Adding a `rename_all` attribute to a struct or enum will rename the container's fields/variants according to the rule specified. Similar to serde's `rename_all` but for use with `ToSql` and `FromSql`. 

This removes the need to manually rename each field/variant before inserting/selecting from postgres (especially useful with enums, who's naming standards differ from rust).

Supported rules:
- "lowercase"
- "UPPERCASE"
- "PascalCase"
- "camelCase"
- "snake_case"
- "SCREAMING_SNAKE_CASE"
- "kebab-case"
- "SCREAMING-KEBAB-CASE"

No external dependencies introduced. Case conversion code from [serde](https://github.com/serde-rs/serde/blob/master/serde_derive/src/internals/case.rs) was used.

Thanks @jakubadamw for the test cases from #952 