### PR TITLE
OpenBSD misses some TCP keepalive options

### DIFF
--- a/tokio-postgres/src/keepalive.rs
+++ b/tokio-postgres/src/keepalive.rs
@@ -12,12 +12,12 @@ impl From<&KeepaliveConfig> for TcpKeepalive {
     fn from(keepalive_config: &KeepaliveConfig) -> Self {
         let mut tcp_keepalive = Self::new().with_time(keepalive_config.idle);
 
-        #[cfg(not(any(target_os = "redox", target_os = "solaris")))]
+        #[cfg(not(any(target_os = "redox", target_os = "solaris", target_os = "openbsd")))]
         if let Some(interval) = keepalive_config.interval {
             tcp_keepalive = tcp_keepalive.with_interval(interval);
         }
 
-        #[cfg(not(any(target_os = "redox", target_os = "solaris", target_os = "windows")))]
+        #[cfg(not(any(target_os = "redox", target_os = "solaris", target_os = "windows", target_os = "openbsd")))]
         if let Some(retries) = keepalive_config.retries {
             tcp_keepalive = tcp_keepalive.with_retries(retries);
         }

--- a/tokio-postgres/src/keepalive.rs
+++ b/tokio-postgres/src/keepalive.rs
@@ -17,7 +17,12 @@ impl From<&KeepaliveConfig> for TcpKeepalive {
             tcp_keepalive = tcp_keepalive.with_interval(interval);
         }
 
-        #[cfg(not(any(target_os = "redox", target_os = "solaris", target_os = "windows", target_os = "openbsd")))]
+        #[cfg(not(any(
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "windows",
+            target_os = "openbsd"
+        )))]
         if let Some(retries) = keepalive_config.retries {
             tcp_keepalive = tcp_keepalive.with_retries(retries);
         }


### PR DESCRIPTION
On OpenBSD this part of the API isn't provided by socket2 due to the underlying socket options are not available/supported.