### PR TITLE
feat(derive): add `#[postgres(allow_mismatch)]`

### DIFF
--- a/postgres-derive-test/src/compile-fail/invalid-allow-mismatch.rs
+++ b/postgres-derive-test/src/compile-fail/invalid-allow-mismatch.rs
@@ -1,0 +1,31 @@
+use postgres_types::{FromSql, ToSql};
+
+#[derive(ToSql, Debug)]
+#[postgres(allow_mismatch)]
+struct ToSqlAllowMismatchStruct {
+    a: i32,
+}
+
+#[derive(FromSql, Debug)]
+#[postgres(allow_mismatch)]
+struct FromSqlAllowMismatchStruct {
+    a: i32,
+}
+
+#[derive(ToSql, Debug)]
+#[postgres(allow_mismatch)]
+struct ToSqlAllowMismatchTupleStruct(i32, i32);
+
+#[derive(FromSql, Debug)]
+#[postgres(allow_mismatch)]
+struct FromSqlAllowMismatchTupleStruct(i32, i32);
+
+#[derive(FromSql, Debug)]
+#[postgres(transparent, allow_mismatch)]
+struct TransparentFromSqlAllowMismatchStruct(i32);
+
+#[derive(FromSql, Debug)]
+#[postgres(allow_mismatch, transparent)]
+struct AllowMismatchFromSqlTransparentStruct(i32);
+
+fn main() {}

--- a/postgres-derive-test/src/compile-fail/invalid-allow-mismatch.stderr
+++ b/postgres-derive-test/src/compile-fail/invalid-allow-mismatch.stderr
@@ -1,0 +1,43 @@
+error: #[postgres(allow_mismatch)] may only be applied to enums
+ --> src/compile-fail/invalid-allow-mismatch.rs:4:1
+  |
+4 | / #[postgres(allow_mismatch)]
+5 | | struct ToSqlAllowMismatchStruct {
+6 | |     a: i32,
+7 | | }
+  | |_^
+
+error: #[postgres(allow_mismatch)] may only be applied to enums
+  --> src/compile-fail/invalid-allow-mismatch.rs:10:1
+   |
+10 | / #[postgres(allow_mismatch)]
+11 | | struct FromSqlAllowMismatchStruct {
+12 | |     a: i32,
+13 | | }
+   | |_^
+
+error: #[postgres(allow_mismatch)] may only be applied to enums
+  --> src/compile-fail/invalid-allow-mismatch.rs:16:1
+   |
+16 | / #[postgres(allow_mismatch)]
+17 | | struct ToSqlAllowMismatchTupleStruct(i32, i32);
+   | |_______________________________________________^
+
+error: #[postgres(allow_mismatch)] may only be applied to enums
+  --> src/compile-fail/invalid-allow-mismatch.rs:20:1
+   |
+20 | / #[postgres(allow_mismatch)]
+21 | | struct FromSqlAllowMismatchTupleStruct(i32, i32);
+   | |_________________________________________________^
+
+error: #[postgres(transparent)] is not allowed with #[postgres(allow_mismatch)]
+  --> src/compile-fail/invalid-allow-mismatch.rs:24:25
+   |
+24 | #[postgres(transparent, allow_mismatch)]
+   |                         ^^^^^^^^^^^^^^
+
+error: #[postgres(allow_mismatch)] is not allowed with #[postgres(transparent)]
+  --> src/compile-fail/invalid-allow-mismatch.rs:28:28
+   |
+28 | #[postgres(allow_mismatch, transparent)]
+   |                            ^^^^^^^^^^^

--- a/postgres-derive/src/fromsql.rs
+++ b/postgres-derive/src/fromsql.rs
@@ -48,6 +48,26 @@ pub fn expand_derive_fromsql(input: DeriveInput) -> Result<TokenStream, Error> {
                 ))
             }
         }
+    } else if overrides.allow_mismatch {
+        match input.data {
+            Data::Enum(ref data) => {
+                let variants = data
+                    .variants
+                    .iter()
+                    .map(|variant| Variant::parse(variant, overrides.rename_all))
+                    .collect::<Result<Vec<_>, _>>()?;
+                (
+                    accepts::enum_body(&name, &variants, overrides.allow_mismatch),
+                    enum_body(&input.ident, &variants),
+                )
+            }
+            _ => {
+                return Err(Error::new_spanned(
+                    input,
+                    "#[postgres(allow_mismatch)] may only be applied to enums",
+                ));
+            }
+        }
     } else {
         match input.data {
         Data::Enum(ref data) => {
@@ -57,7 +77,7 @@ pub fn expand_derive_fromsql(input: DeriveInput) -> Result<TokenStream, Error> {
                 .map(|variant| Variant::parse(variant, overrides.rename_all))
                 .collect::<Result<Vec<_>, _>>()?;
             (
-                accepts::enum_body(&name, &variants),
+                accepts::enum_body(&name, &variants, overrides.allow_mismatch),
                 enum_body(&input.ident, &variants),
             )
         }

--- a/postgres-derive/src/tosql.rs
+++ b/postgres-derive/src/tosql.rs
@@ -44,6 +44,26 @@ pub fn expand_derive_tosql(input: DeriveInput) -> Result<TokenStream, Error> {
                 ));
             }
         }
+    } else if overrides.allow_mismatch {
+        match input.data {
+            Data::Enum(ref data) => {
+                let variants = data
+                    .variants
+                    .iter()
+                    .map(|variant| Variant::parse(variant, overrides.rename_all))
+                    .collect::<Result<Vec<_>, _>>()?;
+                (
+                    accepts::enum_body(&name, &variants, overrides.allow_mismatch),
+                    enum_body(&input.ident, &variants),
+                )
+            }
+            _ => {
+                return Err(Error::new_spanned(
+                    input,
+                    "#[postgres(allow_mismatch)] may only be applied to enums",
+                ));
+            }
+        }
     } else {
         match input.data {
             Data::Enum(ref data) => {
@@ -53,7 +73,7 @@ pub fn expand_derive_tosql(input: DeriveInput) -> Result<TokenStream, Error> {
                     .map(|variant| Variant::parse(variant, overrides.rename_all))
                     .collect::<Result<Vec<_>, _>>()?;
                 (
-                    accepts::enum_body(&name, &variants),
+                    accepts::enum_body(&name, &variants, overrides.allow_mismatch),
                     enum_body(&input.ident, &variants),
                 )
             }

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -138,7 +138,6 @@
 //! #[derive(Debug, ToSql, FromSql)]
 //! #[postgres(name = "mood", rename_all = "snake_case")]
 //! enum Mood {
-//!     VerySad,        // very_sad
 //!     #[postgres(name = "ok")]
 //!     Ok,             // ok
 //!     VeryHappy,      // very_happy
@@ -155,10 +154,28 @@
 //! - `"kebab-case"`
 //! - `"SCREAMING-KEBAB-CASE"`
 //! - `"Train-Case"`
-
+//!
+//! ## Allowing Enum Mismatches
+//!
+//! By default the generated implementation of [`ToSql`] & [`FromSql`] for enums will require an exact match of the enum
+//! variants between the Rust and Postgres types.
+//! To allow mismatches, the `#[postgres(allow_mismatch)]` attribute can be used on the enum definition:
+//!
+//! ```sql
+//! CREATE TYPE mood AS ENUM (
+//!   'Sad',
+//!   'Ok',
+//!   'Happy'
+//! );
+//! ```
+//! #[postgres(allow_mismatch)]
+//! enum Mood {
+//!    Happy,
+//!    Meh,
+//! }
+//! ```
 #![doc(html_root_url = "https://docs.rs/postgres-types/0.2")]
 #![warn(clippy::all, rust_2018_idioms, missing_docs)]
-
 use fallible_iterator::FallibleIterator;
 use postgres_protocol::types::{self, ArrayDimension};
 use std::any::type_name;


### PR DESCRIPTION
As discussed on #1023, this PR implements an override/attribute that allows mismatching Rust and Postgres enums.

## Example

```rust
#[derive(ToSql, FromSql)]
#[postgres(allow_mismatch)]
enum Mood {
    Sad,
    Happy,
    Meh,
}
```