### PR TITLE
allow `BorrowToSql` for non-static `Box<dyn ToSql>`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - run: docker compose up -d
       - uses: sfackler/actions/rustup@master
         with:
-          version: 1.64.0
+          version: 1.65.0
       - run: echo "version=$(rustc --version)" >> $GITHUB_OUTPUT
         id: rust-version
       - uses: actions/cache@v3

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -1178,17 +1178,17 @@ impl BorrowToSql for &dyn ToSql {
     }
 }
 
-impl sealed::Sealed for Box<dyn ToSql + Sync> {}
+impl<'a> sealed::Sealed for Box<dyn ToSql + Sync + 'a> {}
 
-impl BorrowToSql for Box<dyn ToSql + Sync> {
+impl<'a> BorrowToSql for Box<dyn ToSql + Sync + 'a> {
     #[inline]
     fn borrow_to_sql(&self) -> &dyn ToSql {
         self.as_ref()
     }
 }
 
-impl sealed::Sealed for Box<dyn ToSql + Sync + Send> {}
-impl BorrowToSql for Box<dyn ToSql + Sync + Send> {
+impl<'a> sealed::Sealed for Box<dyn ToSql + Sync + Send + 'a> {}
+impl<'a> BorrowToSql for Box<dyn ToSql + Sync + Send + 'a> {
     #[inline]
     fn borrow_to_sql(&self) -> &dyn ToSql {
         self.as_ref()


### PR DESCRIPTION
This allows me to use `tokio_postgres::binary_copy::BinaryCopyInWriter` with boxed `ToSql` types that are created by borrowing data from somewhere else (and are therefore not `'static`).