### PR TITLE
feat: add support for wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,33 @@ jobs:
           key: clippy-target-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}y
       - run: cargo clippy --all --all-targets
 
+  check-wasm32:
+    name: check-wasm32
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: sfackler/actions/rustup@master
+      - run: echo "version=$(rustc --version)" >> $GITHUB_OUTPUT
+        id: rust-version
+      - run: rustup target add wasm32-unknown-unknown
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry/index
+          key: index-${{ runner.os }}-${{ github.run_number }}
+          restore-keys: |
+            index-${{ runner.os }}-
+      - run: cargo generate-lockfile
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry/cache
+          key: registry-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}
+      - run: cargo fetch
+      - uses: actions/cache@v3
+        with:
+          path: target
+          key: clippy-target-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}y
+      - run: cargo check --target wasm32-unknown-unknown --manifest-path tokio-postgres/Cargo.toml --no-default-features
+
   test:
     name: test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           # dev dependencies can add unwanted dependencies to the build, so we'll hackily disable them for this check.
 
           sed -i 's/\[dev-dependencies]/[ignore-dependencies]/g' ./tokio-postgres/Cargo.toml
-          cargo check --target wasm32-unknown-unknown --manifest-path tokio-postgres/Cargo.toml --no-default-features
+          cargo check --target wasm32-unknown-unknown --manifest-path tokio-postgres/Cargo.toml --no-default-features --features js
 
   test:
     name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: sfackler/actions/rustup@master
       - uses: sfackler/actions/rustfmt@master
-  
+
   clippy:
     name: clippy
     runs-on: ubuntu-latest
@@ -72,7 +72,12 @@ jobs:
         with:
           path: target
           key: clippy-target-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}y
-      - run: cargo check --target wasm32-unknown-unknown --manifest-path tokio-postgres/Cargo.toml --no-default-features
+      - run: |
+          # Hack: wasm support currently relies on not having tokio with features like socket enabled. With resolver 1
+          # dev dependencies can add unwanted dependencies to the build, so we'll hackily disable them for this check.
+
+          sed -i 's/\[dev-dependencies]/[ignore-dependencies]/g' ./tokio-postgres/Cargo.toml
+          cargo check --target wasm32-unknown-unknown --manifest-path tokio-postgres/Cargo.toml --no-default-features
 
   test:
     name: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-resolver = "2"
 members = [
     "codegen",
     "postgres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "codegen",
     "postgres",

--- a/postgres-protocol/Cargo.toml
+++ b/postgres-protocol/Cargo.toml
@@ -8,6 +8,10 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/sfackler/rust-postgres"
 readme = "../README.md"
 
+[features]
+default = []
+js = ["getrandom/js"]
+
 [dependencies]
 base64 = "0.21"
 byteorder = "1.0"
@@ -19,6 +23,4 @@ memchr = "2.0"
 rand = "0.8"
 sha2 = "0.10"
 stringprep = "0.1"
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2.9", features = ["js"] }
+getrandom = { version = "0.2", optional = true }

--- a/postgres-protocol/Cargo.toml
+++ b/postgres-protocol/Cargo.toml
@@ -19,3 +19,6 @@ memchr = "2.0"
 rand = "0.8"
 sha2 = "0.10"
 stringprep = "0.1"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2.9", features = ["js"] }

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -40,6 +40,7 @@ with-uuid-0_8 = ["postgres-types/with-uuid-0_8"]
 with-uuid-1 = ["postgres-types/with-uuid-1"]
 with-time-0_2 = ["postgres-types/with-time-0_2"]
 with-time-0_3 = ["postgres-types/with-time-0_3"]
+js = ["postgres-protocol/js"]
 
 [dependencies]
 async-trait = "0.1"

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -55,9 +55,11 @@ pin-project-lite = "0.2"
 phf = "0.11"
 postgres-protocol = { version = "0.6.5", path = "../postgres-protocol" }
 postgres-types = { version = "0.2.4", path = "../postgres-types" }
-socket2 = { version = "0.5", features = ["all"] }
 tokio = { version = "1.27", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["codec"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+socket2 = { version = "0.5", features = ["all"] }
 
 [dev-dependencies]
 futures-executor = "0.3"

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -3,6 +3,7 @@
 #[cfg(feature = "runtime")]
 use crate::connect::connect;
 use crate::connect_raw::connect_raw;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::keepalive::KeepaliveConfig;
 #[cfg(feature = "runtime")]
 use crate::tls::MakeTlsConnect;
@@ -165,6 +166,7 @@ pub struct Config {
     pub(crate) connect_timeout: Option<Duration>,
     pub(crate) tcp_user_timeout: Option<Duration>,
     pub(crate) keepalives: bool,
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) keepalive_config: KeepaliveConfig,
     pub(crate) target_session_attrs: TargetSessionAttrs,
     pub(crate) channel_binding: ChannelBinding,
@@ -179,11 +181,6 @@ impl Default for Config {
 impl Config {
     /// Creates a new configuration.
     pub fn new() -> Config {
-        let keepalive_config = KeepaliveConfig {
-            idle: Duration::from_secs(2 * 60 * 60),
-            interval: None,
-            retries: None,
-        };
         Config {
             user: None,
             password: None,
@@ -196,7 +193,12 @@ impl Config {
             connect_timeout: None,
             tcp_user_timeout: None,
             keepalives: true,
-            keepalive_config,
+            #[cfg(not(target_arch = "wasm32"))]
+            keepalive_config: KeepaliveConfig {
+                idle: Duration::from_secs(2 * 60 * 60),
+                interval: None,
+                retries: None,
+            },
             target_session_attrs: TargetSessionAttrs::Any,
             channel_binding: ChannelBinding::Prefer,
         }
@@ -377,6 +379,7 @@ impl Config {
     /// Sets the amount of idle time before a keepalive packet is sent on the connection.
     ///
     /// This is ignored for Unix domain sockets, or if the `keepalives` option is disabled. Defaults to 2 hours.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn keepalives_idle(&mut self, keepalives_idle: Duration) -> &mut Config {
         self.keepalive_config.idle = keepalives_idle;
         self
@@ -384,6 +387,7 @@ impl Config {
 
     /// Gets the configured amount of idle time before a keepalive packet will
     /// be sent on the connection.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn get_keepalives_idle(&self) -> Duration {
         self.keepalive_config.idle
     }
@@ -392,12 +396,14 @@ impl Config {
     /// On Windows, this sets the value of the tcp_keepalive struct’s keepaliveinterval field.
     ///
     /// This is ignored for Unix domain sockets, or if the `keepalives` option is disabled.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn keepalives_interval(&mut self, keepalives_interval: Duration) -> &mut Config {
         self.keepalive_config.interval = Some(keepalives_interval);
         self
     }
 
     /// Gets the time interval between TCP keepalive probes.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn get_keepalives_interval(&self) -> Option<Duration> {
         self.keepalive_config.interval
     }
@@ -405,12 +411,14 @@ impl Config {
     /// Sets the maximum number of TCP keepalive probes that will be sent before dropping a connection.
     ///
     /// This is ignored for Unix domain sockets, or if the `keepalives` option is disabled.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn keepalives_retries(&mut self, keepalives_retries: u32) -> &mut Config {
         self.keepalive_config.retries = Some(keepalives_retries);
         self
     }
 
     /// Gets the maximum number of TCP keepalive probes that will be sent before dropping a connection.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn get_keepalives_retries(&self) -> Option<u32> {
         self.keepalive_config.retries
     }
@@ -503,12 +511,14 @@ impl Config {
                     self.tcp_user_timeout(Duration::from_secs(timeout as u64));
                 }
             }
+            #[cfg(not(target_arch = "wasm32"))]
             "keepalives" => {
                 let keepalives = value
                     .parse::<u64>()
                     .map_err(|_| Error::config_parse(Box::new(InvalidValue("keepalives"))))?;
                 self.keepalives(keepalives != 0);
             }
+            #[cfg(not(target_arch = "wasm32"))]
             "keepalives_idle" => {
                 let keepalives_idle = value
                     .parse::<i64>()
@@ -517,6 +527,7 @@ impl Config {
                     self.keepalives_idle(Duration::from_secs(keepalives_idle as u64));
                 }
             }
+            #[cfg(not(target_arch = "wasm32"))]
             "keepalives_interval" => {
                 let keepalives_interval = value.parse::<i64>().map_err(|_| {
                     Error::config_parse(Box::new(InvalidValue("keepalives_interval")))
@@ -525,6 +536,7 @@ impl Config {
                     self.keepalives_interval(Duration::from_secs(keepalives_interval as u64));
                 }
             }
+            #[cfg(not(target_arch = "wasm32"))]
             "keepalives_retries" => {
                 let keepalives_retries = value.parse::<u32>().map_err(|_| {
                     Error::config_parse(Box::new(InvalidValue("keepalives_retries")))
@@ -614,7 +626,8 @@ impl fmt::Debug for Config {
             }
         }
 
-        f.debug_struct("Config")
+        let mut config_dbg = &mut f.debug_struct("Config");
+        config_dbg = config_dbg
             .field("user", &self.user)
             .field("password", &self.password.as_ref().map(|_| Redaction {}))
             .field("dbname", &self.dbname)
@@ -625,10 +638,17 @@ impl fmt::Debug for Config {
             .field("port", &self.port)
             .field("connect_timeout", &self.connect_timeout)
             .field("tcp_user_timeout", &self.tcp_user_timeout)
-            .field("keepalives", &self.keepalives)
-            .field("keepalives_idle", &self.keepalive_config.idle)
-            .field("keepalives_interval", &self.keepalive_config.interval)
-            .field("keepalives_retries", &self.keepalive_config.retries)
+            .field("keepalives", &self.keepalives);
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            config_dbg = config_dbg
+                .field("keepalives_idle", &self.keepalive_config.idle)
+                .field("keepalives_interval", &self.keepalive_config.interval)
+                .field("keepalives_retries", &self.keepalive_config.retries);
+        }
+
+        config_dbg
             .field("target_session_attrs", &self.target_session_attrs)
             .field("channel_binding", &self.channel_binding)
             .finish()

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -163,6 +163,7 @@ mod copy_in;
 mod copy_out;
 pub mod error;
 mod generic_client;
+#[cfg(not(target_arch = "wasm32"))]
 mod keepalive;
 mod maybe_tls_stream;
 mod portal;


### PR DESCRIPTION
Adds support for compiling to WASM environments that provide JS via wasm-bindgen. Because there's no standardized socket API the caller must provide a connection that implements `AsyncRead`/`AsyncWrite` to `connect_raw`.

The motivation for this is [an open PR to the Rust framework for Cloudflare Workers](https://github.com/cloudflare/workers-rs/pull/324) where Cloudflare recently announced support for [TCP sockets](https://developers.cloudflare.com/workers/runtime-apis/tcp-sockets/).