### PR TITLE
Tracing support

### DIFF
--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -58,6 +58,7 @@ postgres-protocol = { version = "0.6.5", path = "../postgres-protocol" }
 postgres-types = { version = "0.2.4", path = "../postgres-types" }
 tokio = { version = "1.27", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["codec"] }
+tracing = "0.1"
 rand = "0.8.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -9,7 +9,7 @@ use crate::simple_query::SimpleQueryStream;
 #[cfg(feature = "runtime")]
 use crate::tls::MakeTlsConnect;
 use crate::tls::TlsConnect;
-use crate::trace::make_span;
+use crate::trace::{make_span, SpanOperation};
 use crate::types::{Oid, ToSql, Type};
 #[cfg(feature = "runtime")]
 use crate::Socket;
@@ -258,8 +258,7 @@ impl Client {
         query: &str,
         parameter_types: &[Type],
     ) -> Result<Statement, Error> {
-        let span = make_span(&self.inner);
-        span.record("db.operation", "prepare");
+        let span = make_span(&self.inner, SpanOperation::Prepare);
 
         prepare::prepare(&self.inner, query, parameter_types)
             .instrument(span)

--- a/tokio-postgres/src/connect_raw.rs
+++ b/tokio-postgres/src/connect_raw.rs
@@ -101,7 +101,7 @@ where
     let (process_id, secret_key, parameters) = read_info(&mut stream).await?;
 
     let (sender, receiver) = mpsc::unbounded();
-    let client = Client::new(sender, config.ssl_mode, process_id, secret_key);
+    let client = Client::new(sender, config.ssl_mode, process_id, secret_key, config);
     let connection = Connection::new(stream.inner, stream.delayed, parameters, receiver);
 
     Ok((client, connection))

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -176,6 +176,7 @@ mod socket;
 mod statement;
 pub mod tls;
 mod to_statement;
+mod trace;
 mod transaction;
 mod transaction_builder;
 pub mod types;

--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -2,7 +2,7 @@ use crate::client::InnerClient;
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
 use crate::error::SqlState;
-use crate::trace::make_span;
+use crate::trace::{make_span, SpanOperation};
 use crate::types::{Field, Kind, Oid, Type};
 use crate::{query, slice_iter};
 use crate::{Column, Error, Statement};
@@ -116,8 +116,7 @@ fn prepare_rec<'a>(
     query: &'a str,
     types: &'a [Type],
 ) -> Pin<Box<dyn Future<Output = Result<Statement, Error>> + 'a + Send>> {
-    let span = make_span(client);
-    span.record("db.operation", "prepare");
+    let span = make_span(client, SpanOperation::Prepare);
     Box::pin(prepare(client, query, types).instrument(span))
 }
 

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -11,6 +11,7 @@ use std::{
 struct StatementInner {
     client: Weak<InnerClient>,
     name: String,
+    query: String,
     params: Vec<Type>,
     columns: Vec<Column>,
 }
@@ -38,12 +39,14 @@ impl Statement {
     pub(crate) fn new(
         inner: &Arc<InnerClient>,
         name: String,
+        query: String,
         params: Vec<Type>,
         columns: Vec<Column>,
     ) -> Statement {
         Statement(Arc::new(StatementInner {
             client: Arc::downgrade(inner),
             name,
+            query,
             params,
             columns,
         }))
@@ -51,6 +54,11 @@ impl Statement {
 
     pub(crate) fn name(&self) -> &str {
         &self.0.name
+    }
+
+    /// Returns the query that was used to create this statement.
+    pub fn query(&self) -> &str {
+        &self.0.query
     }
 
     /// Returns the expected types of the statement's parameters.

--- a/tokio-postgres/src/trace.rs
+++ b/tokio-postgres/src/trace.rs
@@ -1,0 +1,51 @@
+use tracing::{field::Empty, Span};
+
+use crate::client::{Addr, InnerClient};
+
+pub(crate) fn make_span(client: &InnerClient) -> Span {
+    let span = tracing::debug_span!("query",
+        db.system = "postgresql",
+        server.address = Empty,
+        server.socket.address = Empty,
+        server.port = Empty,
+        "network.type" = Empty,
+        network.transport = Empty,
+        db.name = %client.db_name(),
+        db.user = %client.db_user(),
+        otel.name = %format!("psql {}", client.db_name()),
+        otel.kind = "Client",
+
+        // to set when output
+        otel.status_code = Empty,
+        exception.message = Empty,
+        db.operation = Empty,
+
+        // for queries
+        db.statement = Empty,
+        db.statement.params = Empty,
+        db.sql.rows_affected = Empty,
+    );
+    // only executes if span passed the filter
+    span.in_scope(|| {
+        if let Some(socket_config) = client.socket_config() {
+            if let Some(hostname) = socket_config.hostname.as_deref() {
+                span.record("server.address", hostname);
+            }
+            match &socket_config.addr {
+                Addr::Tcp(addr) => {
+                    span.record("server.socket.address", addr.to_string());
+                    let network_type = if addr.is_ipv4() { "ipv4" } else { "ipv6" };
+                    span.record("network.type", network_type);
+                    span.record("network.transport", "tcp");
+                }
+                #[cfg(unix)]
+                Addr::Unix(path) => {
+                    span.record("server.socket.address", path.to_string_lossy().into_owned());
+                    span.record("network.type", "unix");
+                }
+            }
+            span.record("server.port", socket_config.port);
+        }
+    });
+    span
+}


### PR DESCRIPTION
This PR:
* Adds tracing support following [OpenTelemetry database semantic conventions](https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/database/)
* Adds no new dependencies (tracing was already added transitively by other dependencies)
* Will have no performance impact if no tracer or logger is setup at a `DEBUG` or `TRACE` level.

Example trace overview on real application (vaultwarden):

![direct](https://github.com/sfackler/rust-postgres/assets/8600837/0587a421-afb2-4cf2-bcaa-3a4ee5f1b776)

Breaking down to find a slow query:

![direct](https://github.com/sfackler/rust-postgres/assets/8600837/a9e2f163-c42d-47c7-ae7e-24177d4586f5)

Note that this PR does not add distributed tracing support into the database, as it is (AFAIK) experimental and not well supported -- it would also add some extra dependencies.
