### PR TITLE
`tokio-postgres`: Set user to executing process' user by default.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - run: docker compose up -d
       - uses: sfackler/actions/rustup@master
         with:
-          version: 1.65.0
+          version: 1.67.0
       - run: echo "version=$(rustc --version)" >> $GITHUB_OUTPUT
         id: rust-version
       - uses: actions/cache@v3

--- a/postgres/src/config.rs
+++ b/postgres/src/config.rs
@@ -29,7 +29,7 @@ use tokio_postgres::{Error, Socket};
 ///
 /// ## Keys
 ///
-/// * `user` - The username to authenticate with. Required.
+/// * `user` - The username to authenticate with. Defaults to the user executing this process.
 /// * `password` - The password to authenticate with.
 /// * `dbname` - The name of the database to connect to. Defaults to the username.
 /// * `options` - Command line options used to configure the server.
@@ -143,15 +143,16 @@ impl Config {
 
     /// Sets the user to authenticate with.
     ///
-    /// Required.
+    /// If the user is not set, then this defaults to the user executing this process.
     pub fn user(&mut self, user: &str) -> &mut Config {
         self.config.user(user);
         self
     }
 
-    /// Gets the user to authenticate with, if one has been configured with
-    /// the `user` method.
-    pub fn get_user(&self) -> Option<&str> {
+    /// Gets the user to authenticate with.
+    /// If no user has been configured with the [`user`](Config::user) method,
+    /// then this defaults to the user executing this process.
+    pub fn get_user(&self) -> &str {
         self.config.get_user()
     }
 

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -59,6 +59,7 @@ postgres-types = { version = "0.2.4", path = "../postgres-types" }
 tokio = { version = "1.27", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 rand = "0.8.5"
+whoami = "1.4.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 socket2 = { version = "0.5", features = ["all"] }

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -93,7 +93,7 @@ pub enum Host {
 ///
 /// ## Keys
 ///
-/// * `user` - The username to authenticate with. Required.
+/// * `user` - The username to authenticate with. Defaults to the user executing this process.
 /// * `password` - The password to authenticate with.
 /// * `dbname` - The name of the database to connect to. Defaults to the username.
 /// * `options` - Command line options used to configure the server.
@@ -190,7 +190,7 @@ pub enum Host {
 /// ```
 #[derive(Clone, PartialEq, Eq)]
 pub struct Config {
-    pub(crate) user: Option<String>,
+    user: String,
     pub(crate) password: Option<Vec<u8>>,
     pub(crate) dbname: Option<String>,
     pub(crate) options: Option<String>,
@@ -219,7 +219,7 @@ impl Config {
     /// Creates a new configuration.
     pub fn new() -> Config {
         Config {
-            user: None,
+            user: whoami::username(),
             password: None,
             dbname: None,
             options: None,
@@ -245,16 +245,17 @@ impl Config {
 
     /// Sets the user to authenticate with.
     ///
-    /// Required.
+    /// If the user is not set, then this defaults to the user executing this process.
     pub fn user(&mut self, user: &str) -> &mut Config {
-        self.user = Some(user.to_string());
+        self.user = user.to_string();
         self
     }
 
-    /// Gets the user to authenticate with, if one has been configured with
-    /// the `user` method.
-    pub fn get_user(&self) -> Option<&str> {
-        self.user.as_deref()
+    /// Gets the user to authenticate with.
+    /// If no user has been configured with the [`user`](Config::user) method,
+    /// then this defaults to the user executing this process.
+    pub fn get_user(&self) -> &str {
+        &self.user
     }
 
     /// Sets the password to authenticate with.
@@ -1124,7 +1125,7 @@ mod tests {
     fn test_simple_parsing() {
         let s = "user=pass_user dbname=postgres host=host1,host2 hostaddr=127.0.0.1,127.0.0.2 port=26257";
         let config = s.parse::<Config>().unwrap();
-        assert_eq!(Some("pass_user"), config.get_user());
+        assert_eq!("pass_user", config.get_user());
         assert_eq!(Some("postgres"), config.get_dbname());
         assert_eq!(
             [

--- a/tokio-postgres/src/connect_raw.rs
+++ b/tokio-postgres/src/connect_raw.rs
@@ -113,9 +113,7 @@ where
     T: AsyncRead + AsyncWrite + Unpin,
 {
     let mut params = vec![("client_encoding", "UTF8")];
-    if let Some(user) = &config.user {
-        params.push(("user", &**user));
-    }
+    params.push(("user", config.get_user()));
     if let Some(dbname) = &config.dbname {
         params.push(("database", &**dbname));
     }
@@ -158,10 +156,7 @@ where
         Some(Message::AuthenticationMd5Password(body)) => {
             can_skip_channel_binding(config)?;
 
-            let user = config
-                .user
-                .as_ref()
-                .ok_or_else(|| Error::config("user missing".into()))?;
+            let user = config.get_user();
             let pass = config
                 .password
                 .as_ref()


### PR DESCRIPTION
This mimics the behaviour of libpq and some other libraries (see #1024). This commit uses the `whoami` crate, and thus goes as far as defaulting the user to the executing process' user name on all operating systems.

Closes #1024