### PR TITLE
Ver 87494 evaluate pgcompat rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,15 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
+  V_HOST: localhost
+  V_PORT: 5433
+  V_USER: dbadmin
+  V_DATABASE: VMart
 
 jobs:
   rustfmt:
@@ -79,10 +84,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: docker compose up -d
+      - name: Set up a Vertica server docker container
+        timeout-minutes: 15
+        run: |
+          docker run -d -p 5433:5433 -p 5444:5444 \
+            --name vertica_docker \
+            vertica/vertica-ce:23.3.0-0
+          echo "Vertica startup ..."
+          until docker exec vertica_docker test -f /data/vertica/VMart/agent_start.out; do \
+            echo "..."; \
+            sleep 3; \
+          done;
+          echo "Vertica is up"
+          docker exec -u dbadmin vertica_docker /opt/vertica/bin/vsql -c "\l"
+          docker exec -u dbadmin vertica_docker /opt/vertica/bin/vsql -c "select version()"
       - uses: sfackler/actions/rustup@master
         with:
-          version: 1.65.0
+          version: 1.71.0
       - run: echo "version=$(rustc --version)" >> $GITHUB_OUTPUT
         id: rust-version
       - uses: actions/cache@v3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# sets up postgres, replaced with vertica-ce
+# to run in ci.yml, replace vertica logic with - run: docker compose up -d
 version: '2'
 services:
   postgres:

--- a/docker/sql_setup.sh
+++ b/docker/sql_setup.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+#sets up postgres keys and certs, run in docker-compose.yml
 set -e
 
 cat > "$PGDATA/server.key" <<-EOKEY

--- a/postgres/src/test.rs
+++ b/postgres/src/test.rs
@@ -10,10 +10,23 @@ use tokio_postgres::NoTls;
 use super::*;
 use crate::binary_copy::{BinaryCopyInWriter, BinaryCopyOutIter};
 use fallible_iterator::FallibleIterator;
+use std::env;
+
+fn get_connection_string() -> String {
+    let host = env::var("TEST_HOST").unwrap_or("localhost".to_string());
+    let port = env::var("TEST_PORT").unwrap_or("5433".to_string());
+    let user = env::var("TEST_USER").unwrap_or("postgres".to_string());
+    let dbname = env::var("TEST_DB").unwrap_or("mydb".to_string());
+
+    format!(
+        "host={} port={} user={} dbname={}",
+        host, port, user, dbname
+    )
+}
 
 #[test]
 fn prepare() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     let stmt = client.prepare("SELECT 1::INT, $1::TEXT").unwrap();
     assert_eq!(stmt.params(), &[Type::TEXT]);
@@ -24,7 +37,7 @@ fn prepare() {
 
 #[test]
 fn query_prepared() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     let stmt = client.prepare("SELECT $1::TEXT").unwrap();
     let rows = client.query(&stmt, &[&"hello"]).unwrap();
@@ -34,7 +47,7 @@ fn query_prepared() {
 
 #[test]
 fn query_unprepared() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     let rows = client.query("SELECT $1::TEXT", &[&"hello"]).unwrap();
     assert_eq!(rows.len(), 1);
@@ -43,7 +56,7 @@ fn query_unprepared() {
 
 #[test]
 fn transaction_commit() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     client
         .simple_query("CREATE TEMPORARY TABLE foo (id SERIAL PRIMARY KEY)")
@@ -64,7 +77,7 @@ fn transaction_commit() {
 
 #[test]
 fn transaction_rollback() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     client
         .simple_query("CREATE TEMPORARY TABLE foo (id SERIAL PRIMARY KEY)")
@@ -84,7 +97,7 @@ fn transaction_rollback() {
 
 #[test]
 fn transaction_drop() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     client
         .simple_query("CREATE TEMPORARY TABLE foo (id SERIAL PRIMARY KEY)")
@@ -104,8 +117,8 @@ fn transaction_drop() {
 
 #[test]
 fn transaction_drop_immediate_rollback() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
-    let mut client2 = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
+    let mut client2 = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     client
         .simple_query("CREATE TABLE IF NOT EXISTS foo (id SERIAL PRIMARY KEY)")
@@ -129,7 +142,7 @@ fn transaction_drop_immediate_rollback() {
 
 #[test]
 fn nested_transactions() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     client
         .batch_execute("CREATE TEMPORARY TABLE foo (id INT PRIMARY KEY)")
@@ -180,7 +193,7 @@ fn nested_transactions() {
 
 #[test]
 fn savepoints() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     client
         .batch_execute("CREATE TEMPORARY TABLE foo (id INT PRIMARY KEY)")
@@ -231,7 +244,7 @@ fn savepoints() {
 
 #[test]
 fn copy_in() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     client
         .simple_query("CREATE TEMPORARY TABLE foo (id INT, name TEXT)")
@@ -254,7 +267,7 @@ fn copy_in() {
 
 #[test]
 fn copy_in_abort() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     client
         .simple_query("CREATE TEMPORARY TABLE foo (id INT, name TEXT)")
@@ -273,7 +286,7 @@ fn copy_in_abort() {
 
 #[test]
 fn binary_copy_in() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     client
         .simple_query("CREATE TEMPORARY TABLE foo (id INT, name TEXT)")
@@ -298,7 +311,7 @@ fn binary_copy_in() {
 
 #[test]
 fn copy_out() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     client
         .simple_query(
@@ -319,7 +332,7 @@ fn copy_out() {
 
 #[test]
 fn binary_copy_out() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     client
         .simple_query(
@@ -345,7 +358,7 @@ fn binary_copy_out() {
 
 #[test]
 fn portal() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     client
         .simple_query(
@@ -372,7 +385,7 @@ fn portal() {
 
 #[test]
 fn cancel_query() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     let cancel_token = client.cancel_token();
     let cancel_thread = thread::spawn(move || {
@@ -390,7 +403,7 @@ fn cancel_query() {
 
 #[test]
 fn notifications_iter() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     client
         .batch_execute(
@@ -410,7 +423,7 @@ fn notifications_iter() {
 
 #[test]
 fn notifications_blocking_iter() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     client
         .batch_execute(
@@ -422,7 +435,7 @@ fn notifications_blocking_iter() {
         .unwrap();
 
     thread::spawn(|| {
-        let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+        let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
         thread::sleep(Duration::from_secs(1));
         client
@@ -443,7 +456,7 @@ fn notifications_blocking_iter() {
 
 #[test]
 fn notifications_timeout_iter() {
-    let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
     client
         .batch_execute(
@@ -455,7 +468,7 @@ fn notifications_timeout_iter() {
         .unwrap();
 
     thread::spawn(|| {
-        let mut client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+        let mut client = Client::connect(&get_connection_string(), NoTls).unwrap();
 
         thread::sleep(Duration::from_secs(1));
         client
@@ -481,7 +494,7 @@ fn notifications_timeout_iter() {
 #[test]
 fn notice_callback() {
     let (notice_tx, notice_rx) = mpsc::sync_channel(64);
-    let mut client = Config::from_str("host=localhost port=5433 user=postgres")
+    let mut client = Config::from_str(&get_connection_string())
         .unwrap()
         .notice_callback(move |n| notice_tx.send(n).unwrap())
         .connect(NoTls)
@@ -496,7 +509,7 @@ fn notice_callback() {
 
 #[test]
 fn explicit_close() {
-    let client = Client::connect("host=localhost port=5433 user=postgres", NoTls).unwrap();
+    let client = Client::connect(&get_connection_string(), NoTls).unwrap();
     client.close().unwrap();
 }
 


### PR DESCRIPTION
I added one test that does the basic SQL functions: Create a table, insert data, update it, and delete. 

The main obstacle so far has been prepared statements. It would take a lot of work to edit the driver and get them functional. Postgres uses $1, $2, etc for parameters while Vertica uses a ‘?’, which is why the query_prepared() test fails.

There were some small changes I had to make in a lot of the tests you can see in the diff. Some include: Vertica uses INT8 (64bit) instead of INT4 (32bit) for INT type, temporary tables can’t have SERIAL PRIMARY KEY, can’t insert DEFAULT values (which is NULL for INT).

Some tests were ignored because they have Postgres functionality that Vertica doesn’t have. These are:
Transaction_drop_immediate_rollback - no ON CONFLICT in Vertica
Binary_copy_in - no BINARY option for COPY
Copy_out and binary_copy_out -no COPY to STDOUT
Portal - I changed this test to get it to pass but it could be ignored. Portals work by processing data in chunks, while Vertica gets all the data at once. The test was changed to reflect that.
Notifications_iter, notifications_blocking_iter, and notifications_timeout_iter - no LISTEN

The COPY commands work with a little tweaking. Postgres uses the TEXT type and the UDx creates an alias for it with CREATE TYPE IF NOT EXISTS pg_catalog.text(x=varchar);
However, when trying to copy with TEXT type, I get an error that user created types are not allowed in COPY commands. Something to consider in the future.

Further, with COPY, there is no COPY FROM LOCAL so with a text file, you just have to feed it into STDIN.

The portal() test I had to change from a multi-row insert statement to separate insert statements. I noticed in the ADO.NET driver there’s nowhere that does multi-row inserts. Do we know why this doesn’t work?

TLS is not provided by the driver itself but external libraries postgres-openssl and postgres-native tls. The connection string can have the parameter “sslmode” with three options: disable, prefer, and require.

There’s likely other functionality that exists in Vertica and Postgres that we want to make sure works. If you have any idea what I should add tests for, let me know.
