### PR TITLE
support unnamed statements

### DIFF
--- a/postgres-protocol/src/message/backend.rs
+++ b/postgres-protocol/src/message/backend.rs
@@ -72,6 +72,7 @@ impl Header {
 }
 
 /// An enum representing Postgres backend messages.
+#[derive(Debug, PartialEq)]
 #[non_exhaustive]
 pub enum Message {
     AuthenticationCleartextPassword,
@@ -333,6 +334,7 @@ impl Read for Buffer {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct AuthenticationMd5PasswordBody {
     salt: [u8; 4],
 }
@@ -344,6 +346,7 @@ impl AuthenticationMd5PasswordBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct AuthenticationGssContinueBody(Bytes);
 
 impl AuthenticationGssContinueBody {
@@ -353,6 +356,7 @@ impl AuthenticationGssContinueBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct AuthenticationSaslBody(Bytes);
 
 impl AuthenticationSaslBody {
@@ -362,6 +366,7 @@ impl AuthenticationSaslBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct SaslMechanisms<'a>(&'a [u8]);
 
 impl<'a> FallibleIterator for SaslMechanisms<'a> {
@@ -387,6 +392,7 @@ impl<'a> FallibleIterator for SaslMechanisms<'a> {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct AuthenticationSaslContinueBody(Bytes);
 
 impl AuthenticationSaslContinueBody {
@@ -396,6 +402,7 @@ impl AuthenticationSaslContinueBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct AuthenticationSaslFinalBody(Bytes);
 
 impl AuthenticationSaslFinalBody {
@@ -405,6 +412,7 @@ impl AuthenticationSaslFinalBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct BackendKeyDataBody {
     process_id: i32,
     secret_key: i32,
@@ -422,6 +430,7 @@ impl BackendKeyDataBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct CommandCompleteBody {
     tag: Bytes,
 }
@@ -433,6 +442,7 @@ impl CommandCompleteBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct CopyDataBody {
     storage: Bytes,
 }
@@ -449,6 +459,7 @@ impl CopyDataBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct CopyInResponseBody {
     format: u8,
     len: u16,
@@ -470,6 +481,7 @@ impl CopyInResponseBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct ColumnFormats<'a> {
     buf: &'a [u8],
     remaining: u16,
@@ -503,6 +515,7 @@ impl<'a> FallibleIterator for ColumnFormats<'a> {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct CopyOutResponseBody {
     format: u8,
     len: u16,
@@ -524,7 +537,7 @@ impl CopyOutResponseBody {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct DataRowBody {
     storage: Bytes,
     len: u16,
@@ -599,6 +612,7 @@ impl<'a> FallibleIterator for DataRowRanges<'a> {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct ErrorResponseBody {
     storage: Bytes,
 }
@@ -657,6 +671,7 @@ impl<'a> ErrorField<'a> {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct NoticeResponseBody {
     storage: Bytes,
 }
@@ -668,6 +683,7 @@ impl NoticeResponseBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct NotificationResponseBody {
     process_id: i32,
     channel: Bytes,
@@ -691,6 +707,7 @@ impl NotificationResponseBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct ParameterDescriptionBody {
     storage: Bytes,
     len: u16,
@@ -706,6 +723,7 @@ impl ParameterDescriptionBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct Parameters<'a> {
     buf: &'a [u8],
     remaining: u16,
@@ -739,6 +757,7 @@ impl<'a> FallibleIterator for Parameters<'a> {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct ParameterStatusBody {
     name: Bytes,
     value: Bytes,
@@ -756,6 +775,7 @@ impl ParameterStatusBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct ReadyForQueryBody {
     status: u8,
 }
@@ -767,6 +787,7 @@ impl ReadyForQueryBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct RowDescriptionBody {
     storage: Bytes,
     len: u16,

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -59,7 +59,7 @@ postgres-types = { version = "0.2.5", path = "../postgres-types" }
 tokio = { version = "1.27", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 rand = "0.8.5"
-whoami = "1.4.1"
+whoami = "1.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 socket2 = { version = "0.5", features = ["all"] }

--- a/tokio-postgres/src/bind.rs
+++ b/tokio-postgres/src/bind.rs
@@ -31,7 +31,7 @@ where
 
     match responses.next().await? {
         Message::BindComplete => {}
-        _ => return Err(Error::unexpected_message()),
+        m => return Err(Error::unexpected_message(m)),
     }
 
     Ok(Portal::new(client, name, statement))

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -231,7 +231,11 @@ impl Client {
         query: &str,
         parameter_types: &[Type],
     ) -> Result<Statement, Error> {
-        prepare::prepare(&self.inner, query, parameter_types).await
+        prepare::prepare(&self.inner, query, parameter_types, false).await
+    }
+
+    pub(crate) async fn prepare_unnamed(&self, query: &str) -> Result<Statement, Error> {
+        prepare::prepare(&self.inner, query, &[], true).await
     }
 
     /// Executes a statement, returning a vector of the resulting rows.

--- a/tokio-postgres/src/connect.rs
+++ b/tokio-postgres/src/connect.rs
@@ -195,7 +195,7 @@ where
                     }
                 }
                 Some(_) => {}
-                None => return Err(Error::unexpected_message()),
+                None => return Err(Error::closed()),
             }
         }
     }

--- a/tokio-postgres/src/connect_raw.rs
+++ b/tokio-postgres/src/connect_raw.rs
@@ -190,14 +190,14 @@ where
             ))
         }
         Some(Message::ErrorResponse(body)) => return Err(Error::db(body)),
-        Some(_) => return Err(Error::unexpected_message()),
+        Some(m) => return Err(Error::unexpected_message(m)),
         None => return Err(Error::closed()),
     }
 
     match stream.try_next().await.map_err(Error::io)? {
         Some(Message::AuthenticationOk) => Ok(()),
         Some(Message::ErrorResponse(body)) => Err(Error::db(body)),
-        Some(_) => Err(Error::unexpected_message()),
+        Some(m) => Err(Error::unexpected_message(m)),
         None => Err(Error::closed()),
     }
 }
@@ -291,7 +291,7 @@ where
     let body = match stream.try_next().await.map_err(Error::io)? {
         Some(Message::AuthenticationSaslContinue(body)) => body,
         Some(Message::ErrorResponse(body)) => return Err(Error::db(body)),
-        Some(_) => return Err(Error::unexpected_message()),
+        Some(m) => return Err(Error::unexpected_message(m)),
         None => return Err(Error::closed()),
     };
 
@@ -309,7 +309,7 @@ where
     let body = match stream.try_next().await.map_err(Error::io)? {
         Some(Message::AuthenticationSaslFinal(body)) => body,
         Some(Message::ErrorResponse(body)) => return Err(Error::db(body)),
-        Some(_) => return Err(Error::unexpected_message()),
+        Some(m) => return Err(Error::unexpected_message(m)),
         None => return Err(Error::closed()),
     };
 
@@ -348,7 +348,7 @@ where
             }
             Some(Message::ReadyForQuery(_)) => return Ok((process_id, secret_key, parameters)),
             Some(Message::ErrorResponse(body)) => return Err(Error::db(body)),
-            Some(_) => return Err(Error::unexpected_message()),
+            Some(m) => return Err(Error::unexpected_message(m)),
             None => return Err(Error::closed()),
         }
     }

--- a/tokio-postgres/src/connection.rs
+++ b/tokio-postgres/src/connection.rs
@@ -139,7 +139,8 @@ where
                 Some(response) => response,
                 None => match messages.next().map_err(Error::parse)? {
                     Some(Message::ErrorResponse(error)) => return Err(Error::db(error)),
-                    _ => return Err(Error::unexpected_message()),
+                    Some(m) => return Err(Error::unexpected_message(m)),
+                    None => return Err(Error::closed()),
                 },
             };
 

--- a/tokio-postgres/src/copy_in.rs
+++ b/tokio-postgres/src/copy_in.rs
@@ -114,7 +114,7 @@ where
                             let rows = extract_row_affected(&body)?;
                             return Poll::Ready(Ok(rows));
                         }
-                        _ => return Poll::Ready(Err(Error::unexpected_message())),
+                        m => return Poll::Ready(Err(Error::unexpected_message(m))),
                     }
                 }
             }
@@ -206,13 +206,18 @@ where
         .map_err(|_| Error::closed())?;
 
     match responses.next().await? {
+        Message::ParseComplete => {}
+        m => return Err(Error::unexpected_message(m)),
+    }
+
+    match responses.next().await? {
         Message::BindComplete => {}
-        _ => return Err(Error::unexpected_message()),
+        m => return Err(Error::unexpected_message(m)),
     }
 
     match responses.next().await? {
         Message::CopyInResponse(_) => {}
-        _ => return Err(Error::unexpected_message()),
+        m => return Err(Error::unexpected_message(m)),
     }
 
     Ok(CopyInSink {

--- a/tokio-postgres/src/copy_in.rs
+++ b/tokio-postgres/src/copy_in.rs
@@ -206,11 +206,12 @@ where
         .map_err(|_| Error::closed())?;
 
     match responses.next().await? {
-        Message::ParseComplete => {}
-        m => return Err(Error::unexpected_message(m)),
-    }
-
-    match responses.next().await? {
+        Message::ParseComplete => {
+            match responses.next().await? {
+                Message::BindComplete => {}
+                m => return Err(Error::unexpected_message(m)),
+            }
+        }
         Message::BindComplete => {}
         m => return Err(Error::unexpected_message(m)),
     }

--- a/tokio-postgres/src/copy_out.rs
+++ b/tokio-postgres/src/copy_out.rs
@@ -26,13 +26,17 @@ async fn start(client: &InnerClient, buf: Bytes) -> Result<Responses, Error> {
     let mut responses = client.send(RequestMessages::Single(FrontendMessage::Raw(buf)))?;
 
     match responses.next().await? {
+        Message::ParseComplete => match responses.next().await? {
+            Message::BindComplete => {}
+            m => return Err(Error::unexpected_message(m)),
+        },
         Message::BindComplete => {}
-        _ => return Err(Error::unexpected_message()),
+        m => return Err(Error::unexpected_message(m)),
     }
 
     match responses.next().await? {
         Message::CopyOutResponse(_) => {}
-        _ => return Err(Error::unexpected_message()),
+        m => return Err(Error::unexpected_message(m)),
     }
 
     Ok(responses)
@@ -56,7 +60,7 @@ impl Stream for CopyOutStream {
         match ready!(this.responses.poll_next(cx)?) {
             Message::CopyData(body) => Poll::Ready(Some(Ok(body.into_bytes()))),
             Message::CopyDone => Poll::Ready(None),
-            _ => Poll::Ready(Some(Err(Error::unexpected_message()))),
+            m => Poll::Ready(Some(Err(Error::unexpected_message(m)))),
         }
     }
 }

--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -69,18 +69,18 @@ pub async fn prepare(
 
     match responses.next().await? {
         Message::ParseComplete => {}
-        _ => return Err(Error::unexpected_message()),
+        m => return Err(Error::unexpected_message(m)),
     }
 
     let parameter_description = match responses.next().await? {
         Message::ParameterDescription(body) => body,
-        _ => return Err(Error::unexpected_message()),
+        m => return Err(Error::unexpected_message(m)),
     };
 
     let row_description = match responses.next().await? {
         Message::RowDescription(body) => Some(body),
         Message::NoData => None,
-        _ => return Err(Error::unexpected_message()),
+        m => return Err(Error::unexpected_message(m)),
     };
 
     let mut parameters = vec![];
@@ -142,7 +142,7 @@ async fn get_type(client: &Arc<InnerClient>, oid: Oid) -> Result<Type, Error> {
 
     let row = match rows.try_next().await? {
         Some(row) => row,
-        None => return Err(Error::unexpected_message()),
+        None => return Err(Error::closed()),
     };
 
     let name: String = row.try_get(0)?;

--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -62,8 +62,13 @@ pub async fn prepare(
     client: &Arc<InnerClient>,
     query: &str,
     types: &[Type],
+    unnamed: bool,
 ) -> Result<Statement, Error> {
-    let name = format!("s{}", NEXT_ID.fetch_add(1, Ordering::SeqCst));
+    let name = if unnamed {
+        String::new()
+    } else {
+        format!("s{}", NEXT_ID.fetch_add(1, Ordering::SeqCst))
+    };
     let buf = encode(client, &name, query, types)?;
     let mut responses = client.send(RequestMessages::Single(FrontendMessage::Raw(buf)))?;
 
@@ -100,7 +105,11 @@ pub async fn prepare(
         }
     }
 
-    Ok(Statement::new(client, name, parameters, columns))
+    if unnamed {
+        Ok(Statement::unnamed(query.to_owned(), parameters, columns))
+    } else {
+        Ok(Statement::named(client, name, parameters, columns))
+    }
 }
 
 fn prepare_rec<'a>(
@@ -108,7 +117,7 @@ fn prepare_rec<'a>(
     query: &'a str,
     types: &'a [Type],
 ) -> Pin<Box<dyn Future<Output = Result<Statement, Error>> + 'a + Send>> {
-    Box::pin(prepare(client, query, types))
+    Box::pin(prepare(client, query, types, false))
 }
 
 fn encode(client: &InnerClient, name: &str, query: &str, types: &[Type]) -> Result<Bytes, Error> {

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -123,7 +123,7 @@ where
             }
             Message::EmptyQueryResponse => rows = 0,
             Message::ReadyForQuery(_) => return Ok(rows),
-            _ => return Err(Error::unexpected_message()),
+            m => return Err(Error::unexpected_message(m)),
         }
     }
 }
@@ -132,8 +132,12 @@ async fn start(client: &InnerClient, buf: Bytes) -> Result<Responses, Error> {
     let mut responses = client.send(RequestMessages::Single(FrontendMessage::Raw(buf)))?;
 
     match responses.next().await? {
+        Message::ParseComplete => match responses.next().await? {
+            Message::BindComplete => {}
+            m => return Err(Error::unexpected_message(m)),
+        },
         Message::BindComplete => {}
-        _ => return Err(Error::unexpected_message()),
+        m => return Err(Error::unexpected_message(m)),
     }
 
     Ok(responses)
@@ -146,6 +150,9 @@ where
     I::IntoIter: ExactSizeIterator,
 {
     client.with_buf(|buf| {
+        if statement.name().is_empty() {
+            frontend::parse("", statement.query().unwrap(), [], buf).unwrap();
+        }
         encode_bind(statement, params, "", buf)?;
         frontend::execute("", 0, buf).map_err(Error::encode)?;
         frontend::sync(buf);
@@ -228,7 +235,7 @@ impl Stream for RowStream {
                 }
                 Message::EmptyQueryResponse | Message::PortalSuspended => {}
                 Message::ReadyForQuery(_) => return Poll::Ready(None),
-                _ => return Poll::Ready(Some(Err(Error::unexpected_message()))),
+                m => return Poll::Ready(Some(Err(Error::unexpected_message(m)))),
             }
         }
     }

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -150,8 +150,8 @@ where
     I::IntoIter: ExactSizeIterator,
 {
     client.with_buf(|buf| {
-        if statement.name().is_empty() {
-            frontend::parse("", statement.query().unwrap(), [], buf).unwrap();
+        if let Some(query) = statement.query() {
+            frontend::parse("", query, [], buf).unwrap();
         }
         encode_bind(statement, params, "", buf)?;
         frontend::execute("", 0, buf).map_err(Error::encode)?;

--- a/tokio-postgres/src/simple_query.rs
+++ b/tokio-postgres/src/simple_query.rs
@@ -58,7 +58,7 @@ pub async fn batch_execute(client: &InnerClient, query: &str) -> Result<(), Erro
             | Message::EmptyQueryResponse
             | Message::RowDescription(_)
             | Message::DataRow(_) => {}
-            _ => return Err(Error::unexpected_message()),
+            m => return Err(Error::unexpected_message(m)),
         }
     }
 }
@@ -107,12 +107,12 @@ impl Stream for SimpleQueryStream {
                 Message::DataRow(body) => {
                     let row = match &this.columns {
                         Some(columns) => SimpleQueryRow::new(columns.clone(), body)?,
-                        None => return Poll::Ready(Some(Err(Error::unexpected_message()))),
+                        None => return Poll::Ready(Some(Err(Error::closed()))),
                     };
                     return Poll::Ready(Some(Ok(SimpleQueryMessage::Row(row))));
                 }
                 Message::ReadyForQuery(_) => return Poll::Ready(None),
-                _ => return Poll::Ready(Some(Err(Error::unexpected_message()))),
+                m => return Poll::Ready(Some(Err(Error::unexpected_message(m)))),
             }
         }
     }

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -44,7 +44,7 @@ impl Drop for StatementInner {
 pub struct Statement(Arc<StatementInner>);
 
 impl Statement {
-    pub(crate) fn new(
+    pub(crate) fn named(
         inner: &Arc<InnerClient>,
         name: String,
         params: Vec<Type>,
@@ -58,11 +58,11 @@ impl Statement {
         }))
     }
 
-    pub(crate) fn unnamed(prepared: Statement, query: String) -> Self {
+    pub(crate) fn unnamed(query: String, params: Vec<Type>, columns: Vec<Column>) -> Self {
         Statement(Arc::new(StatementInner::Unnamed {
             query,
-            params: prepared.params().to_owned(),
-            columns: prepared.columns().to_owned(),
+            params,
+            columns,
         }))
     }
 
@@ -98,7 +98,6 @@ impl Statement {
 }
 
 /// Information about a column of a query.
-#[derive(Clone)]
 pub struct Column {
     name: String,
     type_: Type,

--- a/tokio-postgres/src/to_statement.rs
+++ b/tokio-postgres/src/to_statement.rs
@@ -15,7 +15,10 @@ mod private {
         pub async fn into_statement(self, client: &Client) -> Result<Statement, Error> {
             match self {
                 ToStatementType::Statement(s) => Ok(s.clone()),
-                ToStatementType::Query(s) => client.prepare(s).await,
+                ToStatementType::Query(s) => {
+                    let prepared = client.prepare(s).await?;
+                    Ok(Statement::unnamed(prepared, s.to_owned()))
+                }
             }
         }
     }

--- a/tokio-postgres/src/to_statement.rs
+++ b/tokio-postgres/src/to_statement.rs
@@ -15,10 +15,7 @@ mod private {
         pub async fn into_statement(self, client: &Client) -> Result<Statement, Error> {
             match self {
                 ToStatementType::Statement(s) => Ok(s.clone()),
-                ToStatementType::Query(s) => {
-                    let prepared = client.prepare(s).await?;
-                    Ok(Statement::unnamed(prepared, s.to_owned()))
-                }
+                ToStatementType::Query(s) => client.prepare_unnamed(s).await,
             }
         }
     }


### PR DESCRIPTION
Refs: https://github.com/sfackler/rust-postgres/issues/1017
Refs: https://github.com/sfackler/rust-postgres/issues/1044

This PR implements unnamed statements when querying the database. This is not a performance optimization. The library still uses a "prepared" statement in order to parse the columns and types of queries, so round trips are not reduced (although we don't need to send an additional query to clean up the named prepared statement, which is nice). The reason for this change is to enable queries against pgbouncer instances which are running in transaction or statement pooling modes. A named prepared statement *cannot* be used in these modes, because the connection may be swapped from under you between preparing the statement and using it.

I found this helpful in understanding what was going on while I was debugging this problem: https://jpcamara.com/2023/04/12/pgbouncer-is-useful.html#prepared-statements

While writing this I also changed the "unexpected message" errors to help me debug, but I can remove that from this PR if you feel it is out of scope.