### PR TITLE
Adds support for zero-copy FromSql derive

### DIFF
--- a/postgres-derive-test/src/transparent.rs
+++ b/postgres-derive-test/src/transparent.rs
@@ -16,3 +16,38 @@ fn round_trip() {
         UserId(123)
     );
 }
+
+#[test]
+fn struct_with_reference() {
+    #[derive(FromSql, ToSql, Debug, PartialEq)]
+    #[postgres(transparent)]
+    struct UserName<'a>(&'a str);
+
+    let mut conn = Client::connect("user=postgres host=localhost port=5433", NoTls).unwrap();
+
+    let user_name = "tester";
+    let row = conn
+        .query_one("SELECT $1", &[&UserName(user_name)])
+        .unwrap();
+    let result: UserName<'_> = row.get(0);
+    assert_eq!(user_name, result.0);
+}
+
+#[test]
+fn nested_struct_with_reference() {
+    #[derive(FromSql, ToSql, Debug, PartialEq)]
+    #[postgres(transparent)]
+    struct Inner<'a>(&'a str);
+
+    #[derive(FromSql, ToSql, Debug, PartialEq)]
+    #[postgres(transparent)]
+    struct UserName<'a>(#[postgres(borrow)] Inner<'a>);
+
+    let mut conn = Client::connect("user=postgres host=localhost port=5433", NoTls).unwrap();
+
+    let user_name = "tester";
+    let inner = Inner(user_name);
+    let row = conn.query_one("SELECT $1", &[&UserName(inner)]).unwrap();
+    let result: UserName<'_> = row.get(0);
+    assert_eq!(user_name, result.0 .0);
+}

--- a/postgres-derive/src/accepts.rs
+++ b/postgres-derive/src/accepts.rs
@@ -3,7 +3,7 @@ use quote::quote;
 use std::iter;
 use syn::Ident;
 
-use crate::composites::Field;
+use crate::composites::NamedField;
 use crate::enums::Variant;
 
 pub fn transparent_body(field: &syn::Field) -> TokenStream {
@@ -66,7 +66,7 @@ pub fn enum_body(name: &str, variants: &[Variant], allow_mismatch: bool) -> Toke
     }
 }
 
-pub fn composite_body(name: &str, trait_: &str, fields: &[Field]) -> TokenStream {
+pub fn composite_body(name: &str, trait_: &str, fields: &[NamedField]) -> TokenStream {
     let num_fields = fields.len();
     let trait_ = Ident::new(trait_, Span::call_site());
     let traits = iter::repeat(&trait_);

--- a/postgres-derive/src/fromsql.rs
+++ b/postgres-derive/src/fromsql.rs
@@ -1,6 +1,8 @@
+use std::collections::{BTreeSet, HashSet};
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
 use std::iter;
+use std::iter::FromIterator;
 use syn::{
     punctuated::Punctuated, token, AngleBracketedGenericArguments, Data, DataStruct, DeriveInput,
     Error, Fields, GenericArgument, GenericParam, Generics, Ident, Lifetime, PathArguments,
@@ -9,8 +11,8 @@ use syn::{
 use syn::{LifetimeParam, TraitBound, TraitBoundModifier, TypeParamBound};
 
 use crate::accepts;
-use crate::composites::Field;
 use crate::composites::{append_generic_bound, new_derive_path};
+use crate::composites::{NamedField, UnnamedField};
 use crate::enums::Variant;
 use crate::overrides::Overrides;
 
@@ -29,16 +31,18 @@ pub fn expand_derive_fromsql(input: DeriveInput) -> Result<TokenStream, Error> {
         .clone()
         .unwrap_or_else(|| input.ident.to_string());
 
-    let (accepts_body, to_sql_body) = if overrides.transparent {
+    let (accepts_body, to_sql_body, borrowed_lifetimes) = if overrides.transparent {
         match input.data {
             Data::Struct(DataStruct {
                 fields: Fields::Unnamed(ref fields),
                 ..
             }) if fields.unnamed.len() == 1 => {
                 let field = fields.unnamed.first().unwrap();
+                let parsed_field = UnnamedField::parse(field)?;
                 (
                     accepts::transparent_body(field),
                     transparent_body(&input.ident, field),
+                    parsed_field.borrowed_lifetimes,
                 )
             }
             _ => {
@@ -59,6 +63,7 @@ pub fn expand_derive_fromsql(input: DeriveInput) -> Result<TokenStream, Error> {
                 (
                     accepts::enum_body(&name, &variants, overrides.allow_mismatch),
                     enum_body(&input.ident, &variants),
+                    HashSet::new(),
                 )
             }
             _ => {
@@ -79,6 +84,7 @@ pub fn expand_derive_fromsql(input: DeriveInput) -> Result<TokenStream, Error> {
             (
                 accepts::enum_body(&name, &variants, overrides.allow_mismatch),
                 enum_body(&input.ident, &variants),
+                HashSet::new(),
             )
         }
         Data::Struct(DataStruct {
@@ -86,9 +92,11 @@ pub fn expand_derive_fromsql(input: DeriveInput) -> Result<TokenStream, Error> {
             ..
         }) if fields.unnamed.len() == 1 => {
             let field = fields.unnamed.first().unwrap();
+            let parsed_field = UnnamedField::parse(field)?;
             (
                 domain_accepts_body(&name, field),
                 domain_body(&input.ident, field),
+                parsed_field.borrowed_lifetimes,
             )
         }
         Data::Struct(DataStruct {
@@ -98,11 +106,16 @@ pub fn expand_derive_fromsql(input: DeriveInput) -> Result<TokenStream, Error> {
             let fields = fields
                 .named
                 .iter()
-                .map(|field| Field::parse(field, overrides.rename_all))
+                .map(|field| NamedField::parse(field, overrides.rename_all))
                 .collect::<Result<Vec<_>, _>>()?;
+            let borrowed_lifetimes: HashSet<_> = fields
+                .iter()
+                .flat_map(|f| f.borrowed_lifetimes.to_owned())
+                .collect();
             (
                 accepts::composite_body(&name, "FromSql", &fields),
                 composite_body(&input.ident, &fields),
+                borrowed_lifetimes
             )
         }
         _ => {
@@ -115,7 +128,7 @@ pub fn expand_derive_fromsql(input: DeriveInput) -> Result<TokenStream, Error> {
     };
 
     let ident = &input.ident;
-    let (generics, lifetime) = build_generics(&input.generics);
+    let (generics, lifetime) = build_generics(&input.generics, borrowed_lifetimes);
     let (impl_generics, _, _) = generics.split_for_impl();
     let (_, ty_generics, where_clause) = input.generics.split_for_impl();
     let out = quote! {
@@ -183,7 +196,7 @@ fn domain_body(ident: &Ident, field: &syn::Field) -> TokenStream {
     }
 }
 
-fn composite_body(ident: &Ident, fields: &[Field]) -> TokenStream {
+fn composite_body(ident: &Ident, fields: &[NamedField]) -> TokenStream {
     let temp_vars = &fields
         .iter()
         .map(|f| format_ident!("__{}", f.ident))
@@ -233,16 +246,15 @@ fn composite_body(ident: &Ident, fields: &[Field]) -> TokenStream {
     }
 }
 
-fn build_generics(source: &Generics) -> (Generics, Lifetime) {
-    // don't worry about lifetime name collisions, it doesn't make sense to derive FromSql on a struct with a lifetime
-    let lifetime = Lifetime::new("'a", Span::call_site());
-
+fn build_generics(source: &Generics, borrowed_lifetimes: HashSet<Lifetime>) -> (Generics, Lifetime) {
+    // This is the same parent lifetime name serde uses
+    let lifetime = Lifetime::new("'de", Span::call_site());
+    // Sort lifetimes for deterministic code-gen
+    let sorted_lifetimes = BTreeSet::from_iter(borrowed_lifetimes);
+    let mut lifetime_param = LifetimeParam::new(lifetime.to_owned());
+    lifetime_param.bounds.extend(sorted_lifetimes);
     let mut out = append_generic_bound(source.to_owned(), &new_fromsql_bound(&lifetime));
-    out.params.insert(
-        0,
-        GenericParam::Lifetime(LifetimeParam::new(lifetime.to_owned())),
-    );
-
+    out.params.insert(0, GenericParam::Lifetime(lifetime_param));
     (out, lifetime)
 }
 

--- a/postgres-derive/src/overrides.rs
+++ b/postgres-derive/src/overrides.rs
@@ -8,6 +8,7 @@ pub struct Overrides {
     pub rename_all: Option<RenameRule>,
     pub transparent: bool,
     pub allow_mismatch: bool,
+    pub borrows: bool,
 }
 
 impl Overrides {
@@ -17,6 +18,7 @@ impl Overrides {
             rename_all: None,
             transparent: false,
             allow_mismatch: false,
+            borrows: false,
         };
 
         for attr in attrs {
@@ -92,6 +94,14 @@ impl Overrides {
                                 ));
                             }
                             overrides.allow_mismatch = true;
+                        } else if path.is_ident("borrow") {
+                            if container_attr {
+                                return Err(Error::new_spanned(
+                                    path,
+                                    "#[postgres(borrow)] is a field attribute",
+                                ));
+                            }
+                            overrides.borrows = true;
                         } else {
                             return Err(Error::new_spanned(path, "unknown override"));
                         }

--- a/postgres-derive/src/tosql.rs
+++ b/postgres-derive/src/tosql.rs
@@ -7,7 +7,7 @@ use syn::{
 };
 
 use crate::accepts;
-use crate::composites::Field;
+use crate::composites::NamedField;
 use crate::composites::{append_generic_bound, new_derive_path};
 use crate::enums::Variant;
 use crate::overrides::Overrides;
@@ -92,7 +92,7 @@ pub fn expand_derive_tosql(input: DeriveInput) -> Result<TokenStream, Error> {
                 let fields = fields
                     .named
                     .iter()
-                    .map(|field| Field::parse(field, overrides.rename_all))
+                    .map(|field| NamedField::parse(field, overrides.rename_all))
                     .collect::<Result<Vec<_>, _>>()?;
                 (
                     accepts::composite_body(&name, "ToSql", &fields),
@@ -168,7 +168,7 @@ fn domain_body() -> TokenStream {
     }
 }
 
-fn composite_body(fields: &[Field]) -> TokenStream {
+fn composite_body(fields: &[NamedField]) -> TokenStream {
     let field_names = fields.iter().map(|f| &f.name);
     let field_idents = fields.iter().map(|f| &f.ident);
 

--- a/postgres-types/Cargo.toml
+++ b/postgres-types/Cargo.toml
@@ -31,7 +31,8 @@ with-time-0_3 = ["time-03"]
 bytes = "1.0"
 fallible-iterator = "0.2"
 postgres-protocol = { version = "0.6.5", path = "../postgres-protocol" }
-postgres-derive = { version = "0.4.5", optional = true, path = "../postgres-derive" }
+#postgres-derive = { version = "0.4.5", optional = true, path = "../postgres-derive" }
+postgres-derive = { optional = true, path = "../postgres-derive" }
 
 array-init = { version = "2", optional = true }
 bit-vec-06 = { version = "0.6", package = "bit-vec", optional = true }


### PR DESCRIPTION
Similar in spirit and implementation to how `serde` supports borrowed deserialization lifetimes. Like `serde`, it uses `'de` as the lifetime of the trait (`FromSql<'de>`) and it adds all borrowed liftimes as lifetime bounds on `'de`.

Also like `serde` all top level references automatically have their lifetimes borrowed, but container types carrying references must explicity be borrowed with the `#[postgres(borrow)]` annotation.

Follows up on: https://github.com/sfackler/rust-postgres/pull/574