### PR TITLE
TLS Support in Wasm Environment

### DIFF
--- a/tokio-postgres/src/tls.rs
+++ b/tokio-postgres/src/tls.rs
@@ -162,3 +162,33 @@ impl fmt::Display for NoTlsError {
 }
 
 impl Error for NoTlsError {}
+
+/// Use TLS when socket already originates TLS connection
+pub struct PassthroughTls;
+
+#[derive(Debug)]
+/// Error type for PassthroughTls.
+/// Should never be returned.
+pub struct PassthroughTlsError;
+
+impl Error for PassthroughTlsError {}
+
+impl fmt::Display for PassthroughTlsError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("PassthroughTlsError: future already polled")
+    }
+}
+
+impl<S: TlsStream + Unpin> TlsConnect<S> for PassthroughTls {
+    type Stream = S;
+    type Error = PassthroughTlsError;
+    type Future = futures_util::future::Ready<Result<S, PassthroughTlsError>>;
+
+    fn connect(self, s: Self::Stream) -> Self::Future {
+        futures_util::future::ready(Ok(s))
+    }
+
+    fn can_connect(&self, _: private::ForcePrivateApi) -> bool {
+        true
+    }
+}


### PR DESCRIPTION
While it may be possible to include a TLS library in Wasm, some environments such as Cloudflare Workers handle TLS origination for you. Today, this appears to not work because once the connection is established, `tokio-postgres` connects to the server in a way that suggests the connection is not encrypted and the server appears to reject the request. 

This is a proposal solution here, where a library can mark a `Stream` as encrypted with TLS by implementing the `TlsStream` trait, and then use a `PassthroughTls` struct to indicate to `tokio-postgres` that it can you the stream as-is, but treat the connection as a TLS connection. 

Note that I have not actually gotten this to work and don't want to merge yet, because my test server appears to be rejecting the TLS version being used by Workers. 

I'm looking for a sanity check on this proposal, or would appreciate any other suggestions for how this could be achieved. 