### PR TITLE
replace deprecated chrono::DateTime::from_utc

### DIFF
--- a/postgres-types/src/chrono_04.rs
+++ b/postgres-types/src/chrono_04.rs
@@ -42,7 +42,7 @@ impl ToSql for NaiveDateTime {
 impl<'a> FromSql<'a> for DateTime<Utc> {
     fn from_sql(type_: &Type, raw: &[u8]) -> Result<DateTime<Utc>, Box<dyn Error + Sync + Send>> {
         let naive = NaiveDateTime::from_sql(type_, raw)?;
-        Ok(Utc::from_utc_datetime(naive))
+        Ok(Utc.from_utc_datetime(&naive))
     }
 
     accepts!(TIMESTAMPTZ);

--- a/postgres-types/src/chrono_04.rs
+++ b/postgres-types/src/chrono_04.rs
@@ -40,7 +40,7 @@ impl ToSql for NaiveDateTime {
 impl<'a> FromSql<'a> for DateTime<Utc> {
     fn from_sql(type_: &Type, raw: &[u8]) -> Result<DateTime<Utc>, Box<dyn Error + Sync + Send>> {
         let naive = NaiveDateTime::from_sql(type_, raw)?;
-        Ok(DateTime::from_utc(naive, Utc))
+        Ok(Utc::from_utc_datetime(naive))
     }
 
     accepts!(TIMESTAMPTZ);

--- a/postgres-types/src/chrono_04.rs
+++ b/postgres-types/src/chrono_04.rs
@@ -1,5 +1,7 @@
 use bytes::BytesMut;
-use chrono_04::{DateTime, Duration, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use chrono_04::{
+    DateTime, Duration, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc,
+};
 use postgres_protocol::types;
 use std::error::Error;
 

--- a/tokio-postgres/tests/test/types/chrono_04.rs
+++ b/tokio-postgres/tests/test/types/chrono_04.rs
@@ -53,10 +53,9 @@ async fn test_with_special_naive_date_time_params() {
 async fn test_date_time_params() {
     fn make_check(time: &str) -> (Option<DateTime<Utc>>, &str) {
         (
-            Some(
-                Utc.datetime_from_str(time, "'%Y-%m-%d %H:%M:%S.%f'")
-                    .unwrap(),
-            ),
+            Some(Utc.from_utc_datetime(
+                &NaiveDateTime::parse_from_str(time, "'%Y-%m-%d %H:%M:%S.%f'").unwrap(),
+            )),
             time,
         )
     }
@@ -76,10 +75,9 @@ async fn test_date_time_params() {
 async fn test_with_special_date_time_params() {
     fn make_check(time: &str) -> (Timestamp<DateTime<Utc>>, &str) {
         (
-            Timestamp::Value(
-                Utc.datetime_from_str(time, "'%Y-%m-%d %H:%M:%S.%f'")
-                    .unwrap(),
-            ),
+            Timestamp::Value(Utc.from_utc_datetime(
+                &NaiveDateTime::parse_from_str(time, "'%Y-%m-%d %H:%M:%S.%f'").unwrap(),
+            )),
             time,
         )
     }


### PR DESCRIPTION
Fixes the test run failing in https://github.com/sfackler/rust-postgres/actions/runs/6589121392/job/17903210060?pr=1074 for pull request https://github.com/sfackler/rust-postgres/pull/1074

```
error: use of deprecated associated function `chrono::DateTime::<Tz>::from_utc`: Use TimeZone::from_utc_datetime() or DateTime::from_naive_utc_and_offset instead
  --> postgres-types/src/chrono_04.rs:43:22
   |
43 |         Ok(DateTime::from_utc(naive, Utc))
   |                      ^^^^^^^^
   |
   = note: `-D deprecated` implied by `-D warnings`

error: could not compile `postgres-types` (lib) due to previous error
```