### PR TITLE
Add table_oid and column_id to column structure of prepared statements

### DIFF
--- a/tokio-postgres/CHANGELOG.md
+++ b/tokio-postgres/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Disable `rustc-serialize` compatibility of `eui48-1` dependency
 * Remove tests for `eui48-04`
-
+* Add `table_oid` and `field_id` fields to `Columns` struct of prepared statements.
 
 ## v0.7.10 - 2023-08-25
 

--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -100,7 +100,7 @@ pub async fn prepare(
                 name: field.name().to_string(),
                 table_oid: NonZeroU32::new(field.table_oid()),
                 column_id: NonZeroI16::new(field.column_id()),
-                type_,
+                r#type: type_,
             };
             columns.push(column);
         }

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -5,6 +5,7 @@ use crate::types::Type;
 use postgres_protocol::message::frontend;
 use std::{
     fmt,
+    num::{NonZeroI16, NonZeroU32},
     sync::{Arc, Weak},
 };
 
@@ -66,18 +67,26 @@ impl Statement {
 
 /// Information about a column of a query.
 pub struct Column {
-    name: String,
-    type_: Type,
+    pub(crate) name: String,
+    pub(crate) table_oid: Option<NonZeroU32>,
+    pub(crate) column_id: Option<NonZeroI16>,
+    pub(crate) type_: Type,
 }
 
 impl Column {
-    pub(crate) fn new(name: String, type_: Type) -> Column {
-        Column { name, type_ }
-    }
-
     /// Returns the name of the column.
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// Returns the OID of the underlying database table.
+    pub fn table_oid(&self) -> Option<NonZeroU32> {
+        self.table_oid
+    }
+
+    /// Return the column ID within the underlying database table.
+    pub fn column_id(&self) -> Option<NonZeroI16> {
+        self.column_id
     }
 
     /// Returns the type of the column.
@@ -90,6 +99,8 @@ impl fmt::Debug for Column {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Column")
             .field("name", &self.name)
+            .field("table_oid", &self.table_oid)
+            .field("column_id", &self.column_id)
             .field("type", &self.type_)
             .finish()
     }

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -4,7 +4,6 @@ use crate::connection::RequestMessages;
 use crate::types::Type;
 use postgres_protocol::message::frontend;
 use std::{
-    fmt,
     num::{NonZeroI16, NonZeroU32},
     sync::{Arc, Weak},
 };
@@ -66,11 +65,12 @@ impl Statement {
 }
 
 /// Information about a column of a query.
+#[derive(Debug)]
 pub struct Column {
     pub(crate) name: String,
     pub(crate) table_oid: Option<NonZeroU32>,
     pub(crate) column_id: Option<NonZeroI16>,
-    pub(crate) type_: Type,
+    pub(crate) r#type: Type,
 }
 
 impl Column {
@@ -91,17 +91,6 @@ impl Column {
 
     /// Returns the type of the column.
     pub fn type_(&self) -> &Type {
-        &self.type_
-    }
-}
-
-impl fmt::Debug for Column {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("Column")
-            .field("name", &self.name)
-            .field("table_oid", &self.table_oid)
-            .field("column_id", &self.column_id)
-            .field("type", &self.type_)
-            .finish()
+        &self.r#type
     }
 }


### PR DESCRIPTION
I want to access the underlying table and column of a query and found those two information not exposed in the `statement::Column` structure.

I also simplified the `Debug` implementation of `Column` by using `r#type` rather than `type_` so `#[derive(Debug)]` can be used. As the argument list grew longer I also removed the `new` method in favor of making all the fields `pub(crate)`.

Should we maybe expose the three remaining fields as well?
- `type_size: i16`
- `type_modifier: i32`
- `format: i16`

I don't have an immediate need for them. They could provide useful in the future, though.

What are your thoughts on using `NonZeroU32` and `NonZeroI16`? I'm not 100% sure if that's really a good choice for the type. Yet it felt somewhat natural to use it as `0` denotes that this information is not available.