### PR TITLE
feat(types): add default derive to json wrapper

### DIFF
--- a/postgres-types/src/serde_json_1.rs
+++ b/postgres-types/src/serde_json_1.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 use std::io::Read;
 
 /// A wrapper type to allow arbitrary `Serialize`/`Deserialize` types to convert to Postgres JSON values.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct Json<T>(pub T);
 
 impl<'a, T> FromSql<'a> for Json<T>


### PR DESCRIPTION
Adds a Default impl for `Json<T> where T: Default` allowing for other structs to use the wrapper and implement Default.