### PR TITLE
Add smol_str 0.2 support

### DIFF
--- a/postgres-types/Cargo.toml
+++ b/postgres-types/Cargo.toml
@@ -22,6 +22,7 @@ with-geo-types-0_6 = ["geo-types-06"]
 with-geo-types-0_7 = ["geo-types-0_7"]
 with-serde_json-1 = ["serde-1", "serde_json-1"]
 with-smol_str-01 = ["smol_str-01"]
+with-smol_str-02 = ["smol_str-02"]
 with-uuid-0_8 = ["uuid-08"]
 with-uuid-1 = ["uuid-1"]
 with-time-0_2 = ["time-02"]
@@ -52,3 +53,4 @@ uuid-1 = { version = "1.0", package = "uuid", optional = true }
 time-02 = { version = "0.2", package = "time", optional = true }
 time-03 = { version = "0.3", package = "time", default-features = false, optional = true }
 smol_str-01 = { version = "0.1.23", package = "smol_str", default-features = false, optional = true }
+smol_str-02 = { version = "0.2", package = "smol_str", default-features = false, optional = true }

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -280,6 +280,8 @@ mod geo_types_07;
 mod serde_json_1;
 #[cfg(feature = "with-smol_str-01")]
 mod smol_str_01;
+#[cfg(feature = "with-smol_str-02")]
+mod smol_str_02;
 #[cfg(feature = "with-time-0_2")]
 mod time_02;
 #[cfg(feature = "with-time-0_3")]

--- a/postgres-types/src/smol_str_02.rs
+++ b/postgres-types/src/smol_str_02.rs
@@ -1,0 +1,27 @@
+use bytes::BytesMut;
+use smol_str_02::SmolStr;
+use std::error::Error;
+
+use crate::{FromSql, IsNull, ToSql, Type};
+
+impl<'a> FromSql<'a> for SmolStr {
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        Ok(SmolStr::new(<&str as FromSql>::from_sql(ty, raw)?))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <&str as FromSql>::accepts(ty)
+    }
+}
+
+impl ToSql for SmolStr {
+    fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        <&str as ToSql>::to_sql(&self.as_str(), ty, out)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <&str as ToSql>::accepts(ty)
+    }
+
+    to_sql_checked!();
+}

--- a/postgres-types/src/smol_str_02.rs
+++ b/postgres-types/src/smol_str_02.rs
@@ -6,7 +6,7 @@ use crate::{FromSql, IsNull, ToSql, Type};
 
 impl<'a> FromSql<'a> for SmolStr {
     fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
-        Ok(SmolStr::new(<&str as FromSql>::from_sql(ty, raw)?))
+        <&str as FromSql>::from_sql(ty, raw).map(SmolStr::new)
     }
 
     fn accepts(ty: &Type) -> bool {


### PR DESCRIPTION
Add `smol_str 0.2` support, effectively a copy of the 0.1 file. Though I noticed the feature flags for 0.1 are missing an underscore, but changing that would break things so I just matched it for the new one.