### PR TITLE
Add `ReadOnly` in `TargetSessionAttrs`

### DIFF
--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -34,6 +34,8 @@ pub enum TargetSessionAttrs {
     Any,
     /// The session must allow writes.
     ReadWrite,
+    /// The session allow only reads.
+    ReadOnly,
 }
 
 /// TLS configuration.
@@ -622,6 +624,7 @@ impl Config {
                 let target_session_attrs = match value {
                     "any" => TargetSessionAttrs::Any,
                     "read-write" => TargetSessionAttrs::ReadWrite,
+                    "read-only" => TargetSessionAttrs::ReadOnly,
                     _ => {
                         return Err(Error::config_parse(Box::new(InvalidValue(
                             "target_session_attrs",

--- a/tokio-postgres/src/connect.rs
+++ b/tokio-postgres/src/connect.rs
@@ -160,7 +160,7 @@ where
     let has_hostname = hostname.is_some();
     let (mut client, mut connection) = connect_raw(socket, tls, has_hostname, config).await?;
 
-    if let TargetSessionAttrs::ReadWrite = config.target_session_attrs {
+    if config.target_session_attrs != TargetSessionAttrs::Any {
         let rows = client.simple_query_raw("SHOW transaction_read_only");
         pin_mut!(rows);
 
@@ -185,10 +185,20 @@ where
 
             match next.await.transpose()? {
                 Some(SimpleQueryMessage::Row(row)) => {
-                    if row.try_get(0)? == Some("on") {
+                    let read_only_result = row.try_get(0)?;
+                    if read_only_result == Some("on")
+                        && config.target_session_attrs == TargetSessionAttrs::ReadWrite
+                    {
                         return Err(Error::connect(io::Error::new(
                             io::ErrorKind::PermissionDenied,
                             "database does not allow writes",
+                        )));
+                    } else if read_only_result == Some("off")
+                        && config.target_session_attrs == TargetSessionAttrs::ReadOnly
+                    {
+                        return Err(Error::connect(io::Error::new(
+                            io::ErrorKind::PermissionDenied,
+                            "database is not read only",
                         )));
                     } else {
                         break;

--- a/tokio-postgres/tests/test/parse.rs
+++ b/tokio-postgres/tests/test/parse.rs
@@ -34,6 +34,14 @@ fn settings() {
             .keepalives_idle(Duration::from_secs(30))
             .target_session_attrs(TargetSessionAttrs::ReadWrite),
     );
+    check(
+        "connect_timeout=3 keepalives=0 keepalives_idle=30 target_session_attrs=read-only",
+        Config::new()
+            .connect_timeout(Duration::from_secs(3))
+            .keepalives(false)
+            .keepalives_idle(Duration::from_secs(30))
+            .target_session_attrs(TargetSessionAttrs::ReadOnly),
+    );
 }
 
 #[test]


### PR DESCRIPTION
Hi!
I've found that there is no option to set `read-only` in `target-session-attrs` for connection to PostgreSQL.  
Please, take a look at this pull request.