### PR TITLE
use `split_once` instead of `split` to parse lsn strings

### DIFF
--- a/postgres-types/CHANGELOG.md
+++ b/postgres-types/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### Changed
+
+* `FromStr` implementation for `PgLsn` no longer allocates a `Vec` when splitting an lsn string on it's `/`.
+
 ## v0.2.6 - 2023-08-19
 
 ### Fixed

--- a/postgres-types/src/pg_lsn.rs
+++ b/postgres-types/src/pg_lsn.rs
@@ -33,16 +33,14 @@ impl FromStr for PgLsn {
     type Err = ParseLsnError;
 
     fn from_str(lsn_str: &str) -> Result<Self, Self::Err> {
-        let split: Vec<&str> = lsn_str.split('/').collect();
-        if split.len() == 2 {
-            let (hi, lo) = (
-                u64::from_str_radix(split[0], 16).map_err(|_| ParseLsnError(()))?,
-                u64::from_str_radix(split[1], 16).map_err(|_| ParseLsnError(()))?,
-            );
-            Ok(PgLsn((hi << 32) | lo))
-        } else {
-            Err(ParseLsnError(()))
-        }
+        let Some((split_hi, split_lo)) = lsn_str.split_once('/') else {
+            return Err(ParseLsnError(()));
+        };
+        let (hi, lo) = (
+            u64::from_str_radix(split_hi, 16).map_err(|_| ParseLsnError(()))?,
+            u64::from_str_radix(split_lo, 16).map_err(|_| ParseLsnError(()))?,
+        );
+        Ok(PgLsn((hi << 32) | lo))
     }
 }
 


### PR DESCRIPTION
[`str::split`](https://doc.rust-lang.org/std/primitive.str.html#method.split) allocates a vector and generates considerably more instructions when compiled than [`str::split_once`](https://doc.rust-lang.org/std/primitive.str.html#method.split_once).

[`u64::from_str_radix(split_lo, 16)`](https://doc.rust-lang.org/std/primitive.u64.html#method.from_str_radix) will error if the `lsn_str` contains more than one `/` so this change should result in the same behavior as the current implementation despite not explicitly checking this.