### PR TITLE
Support scalar queries.

### DIFF
--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -15,6 +15,7 @@ use crate::{
 use bytes::Buf;
 use futures_util::TryStreamExt;
 use postgres_protocol::message::frontend;
+use postgres_types::FromSqlOwned;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 /// A representation of a PostgreSQL database transaction.
@@ -114,7 +115,16 @@ impl<'a> Transaction<'a> {
         self.client.query(statement, params).await
     }
 
-    /// Like `Client::query_one`.
+    /// Like [`Client::query_scalar`].
+    pub async fn query_scalar<T: FromSqlOwned>(
+        &self,
+        sql: &str,
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Vec<T>, Error> {
+        self.client.query_scalar(sql, params).await
+    }
+
+    /// Like [`Client::query_one`].
     pub async fn query_one<T>(
         &self,
         statement: &T,
@@ -126,7 +136,16 @@ impl<'a> Transaction<'a> {
         self.client.query_one(statement, params).await
     }
 
-    /// Like `Client::query_opt`.
+    /// Like [`Client::query_one_scalar`].
+    pub async fn query_one_scalar<T: FromSqlOwned>(
+        &self,
+        sql: &str,
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<T, Error> {
+        self.client.query_one_scalar(sql, params).await
+    }
+
+    /// Like [`Client::query_opt`].
     pub async fn query_opt<T>(
         &self,
         statement: &T,
@@ -138,7 +157,16 @@ impl<'a> Transaction<'a> {
         self.client.query_opt(statement, params).await
     }
 
-    /// Like `Client::query_raw`.
+    /// Like [`Client::query_opt_scalar`].
+    pub async fn query_opt_scalar<S: FromSqlOwned>(
+        &self,
+        sql: &str,
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Option<S>, Error> {
+        self.client.query_opt_scalar(sql, params).await
+    }
+
+    /// Like [`Client::query_raw`]
     pub async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
         T: ?Sized + ToStatement,

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -952,3 +952,49 @@ async fn deferred_constraint() {
         .await
         .unwrap_err();
 }
+
+#[tokio::test]
+async fn query_opt_scalar() {
+    let client = connect("user=postgres").await;
+    client
+        .batch_execute(
+            "CREATE TEMPORARY TABLE person (
+                id serial,
+                name text NOT NULL,
+                age integer
+            );
+            INSERT INTO person (name, age) VALUES ('steven', 18);
+            INSERT INTO person (name, age) VALUES ('fred', NULL);
+            ",
+        )
+        .await
+        .unwrap();
+
+    let age: Option<i32> = client
+        .query_opt_scalar("SELECT age FROM person WHERE name = $1", &[&"steven"])
+        .await
+        .unwrap();
+
+    assert_eq!(age, Some(18));
+
+    let age: Option<Option<i32>> = client
+        .query_opt_scalar("SELECT age FROM person WHERE name = $1", &[&"fred"])
+        .await
+        .unwrap();
+
+    assert_eq!(age, Some(None));
+
+    let age: Option<Option<i32>> = client
+        .query_opt_scalar("SELECT age FROM person WHERE name = $1", &[&"steven"])
+        .await
+        .unwrap();
+
+    assert_eq!(age, Some(Some(18)));
+
+    let age: Option<Option<i32>> = client
+        .query_opt_scalar("SELECT age FROM person WHERE name = $1", &[&"barney"])
+        .await
+        .unwrap();
+
+    assert_eq!(age, None);
+}


### PR DESCRIPTION
This PR adds support for querying scalars with the following functions:
- `query_scalar` returns a vector of scalars
- `query_one_scalar` return one scalar
- `query_opt_scalar` rerun optional scalar

It removes the need to always handle a row. 

Also in the process of migrating from `sqlx` to `tokio-postgres` it's convenient to have support for scalar query functions.

Questions and/or suggestions are welcome!