### PR TITLE
Update whoami to newest version

### DIFF
--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -59,7 +59,7 @@ postgres-types = { version = "0.2.5", path = "../postgres-types" }
 tokio = { version = "1.27", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 rand = "0.8.5"
-whoami = "1.4.1"
+whoami = "1.5.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 socket2 = { version = "0.5", features = ["all"] }


### PR DESCRIPTION
Due to an issue in [whoami](https://github.com/ardaku/whoami) versions < `1.5.0` can lead to buffer overflow as discussed [here](https://github.com/ardaku/whoami/issues/91). This PR is just a bump on the version to avoid possible exploits.