### PR TITLE
[Tokio-Postgres] Error handling: Make tokio_postgres::error::Kind public #790

### DIFF
--- a/tokio-postgres/src/error/mod.rs
+++ b/tokio-postgres/src/error/mod.rs
@@ -336,25 +336,43 @@ pub enum ErrorPosition {
     },
 }
 
+/// The kind of error that occurred.
 #[derive(Debug, PartialEq)]
-enum Kind {
+pub enum Kind {
+    /// An I/O error occurred.
     Io,
+    /// An unexpected message from the server.
     UnexpectedMessage,
+    /// An error occurred during TLS handshake.
     Tls,
+    /// An error occurred while serializing a parameter.
     ToSql(usize),
+    /// An error occurred while deserializing a parameter.
     FromSql(usize),
+    /// An error occurred with a specific column.
     Column(String),
+    /// An error occurred with the parameters.
     Parameters(usize, usize),
+    /// The connection is closed.
     Closed,
+    /// A generic database error occurred.
     Db,
+    /// An error occurred while parsing.
     Parse,
+    /// An error occurred while encoding.
     Encode,
+    /// An authentication error occurred.
     Authentication,
+    /// An error occurred while parsing the configuration.
     ConfigParse,
+    /// An error occurred with the configuration.
     Config,
+    /// An error occurred while counting rows.
     RowCount,
     #[cfg(feature = "runtime")]
+    /// An error occurred while connecting.
     Connect,
+    /// A timeout occurred.
     Timeout,
 }
 
@@ -416,6 +434,11 @@ impl Error {
     /// Consumes the error, returning its cause.
     pub fn into_source(self) -> Option<Box<dyn error::Error + Sync + Send>> {
         self.0.cause
+    }
+
+    /// Returns the kind of this error.
+    pub fn kind(&self) -> &Kind {
+        &self.0.kind
     }
 
     /// Returns the source of this error if it was a `DbError`.

--- a/tokio-postgres/src/error/mod.rs
+++ b/tokio-postgres/src/error/mod.rs
@@ -337,7 +337,7 @@ pub enum ErrorPosition {
 }
 
 /// The kind of error that occurred.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Kind {
     /// An I/O error occurred.
     Io,
@@ -437,8 +437,8 @@ impl Error {
     }
 
     /// Returns the kind of this error.
-    pub fn kind(&self) -> &Kind {
-        &self.0.kind
+    pub fn kind(&self) -> Kind {
+        self.0.kind.clone()
     }
 
     /// Returns the source of this error if it was a `DbError`.

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -125,7 +125,7 @@ pub use crate::connection::Connection;
 pub use crate::copy_in::CopyInSink;
 pub use crate::copy_out::CopyOutStream;
 use crate::error::DbError;
-pub use crate::error::Error;
+pub use crate::error::{Error, Kind};
 pub use crate::generic_client::GenericClient;
 pub use crate::portal::Portal;
 pub use crate::query::RowStream;

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -949,7 +949,7 @@ async fn empty_query_one() {
     assert!(res.is_err());
     assert_eq!(
         res.err().unwrap().kind(),
-        &tokio_postgres::error::Kind::RowCount
+        tokio_postgres::error::Kind::RowCount
     );
 }
 

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -928,6 +928,32 @@ async fn query_opt() {
 }
 
 #[tokio::test]
+async fn empty_query_one() {
+    let client = connect("user=postgres").await;
+
+    client
+        .batch_execute(
+            "
+                CREATE TEMPORARY TABLE foo (
+                    name TEXT
+                );
+                INSERT INTO foo (name) VALUES ('alice'), ('bob'), ('carol');
+            ",
+        )
+        .await
+        .unwrap();
+
+    let res = client
+        .query_one("SELECT * FROM foo WHERE name = $1", &[&"not there"])
+        .await;
+    assert!(res.is_err());
+    assert_eq!(
+        res.err().unwrap().kind(),
+        &tokio_postgres::error::Kind::RowCount
+    );
+}
+
+#[tokio::test]
 async fn deferred_constraint() {
     let client = connect("user=postgres").await;
 


### PR DESCRIPTION
Feature request for https://github.com/sfackler/rust-postgres/issues/790

Make `tokio_postgres::error::Kind` public to enable users to match on it from a `tokio_postgres::error::Error`.

I made two commit: one that returns a reference, the other that returns a cloned `tokio_postgres::error::Kind` instance. I was not sure whether it was not clonable on purpose or not.

Please see this comment for more details: https://github.com/sfackler/rust-postgres/issues/790#issuecomment-2095729043