### PR TITLE
Expose type modifier in Column struct

### DIFF
--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -99,6 +99,7 @@ pub async fn prepare(
                 name: field.name().to_string(),
                 table_oid: Some(field.table_oid()).filter(|n| *n != 0),
                 column_id: Some(field.column_id()).filter(|n| *n != 0),
+                type_modifier: field.type_modifier(),
                 r#type: type_,
             };
             columns.push(column);

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -67,6 +67,7 @@ pub struct Column {
     pub(crate) name: String,
     pub(crate) table_oid: Option<u32>,
     pub(crate) column_id: Option<i16>,
+    pub(crate) type_modifier: i32,
     pub(crate) r#type: Type,
 }
 
@@ -84,6 +85,11 @@ impl Column {
     /// Return the column ID within the underlying database table.
     pub fn column_id(&self) -> Option<i16> {
         self.column_id
+    }
+
+    /// Return the type modifier
+    pub fn type_modifier(&self) -> i32 {
+        self.type_modifier
     }
 
     /// Returns the type of the column.

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -172,12 +172,19 @@ async fn prepare_type_modifier() {
         .await
         .unwrap();
 
+    let varlena_header_length = 4;
     assert_eq!(statement.columns()[0].type_(), &Type::INT8);
     assert_eq!(statement.columns()[0].type_modifier(), -1);
     assert_eq!(statement.columns()[1].type_(), &Type::VARCHAR);
-    assert_eq!(statement.columns()[1].type_modifier(), 7);
+    assert_eq!(
+        statement.columns()[1].type_modifier(),
+        7 + varlena_header_length
+    );
     assert_eq!(statement.columns()[2].type_(), &Type::VARCHAR);
-    assert_eq!(statement.columns()[2].type_modifier(), 101);
+    assert_eq!(
+        statement.columns()[2].type_modifier(),
+        101 + varlena_header_length
+    );
 }
 
 #[tokio::test]

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -161,7 +161,23 @@ async fn pipelined_prepare() {
 
     assert_eq!(statement2.params()[0], Type::INT8);
     assert_eq!(statement2.columns()[0].type_(), &Type::INT8);
-    assert_eq!(statement2.columns()[0].type_modifier(), -1);
+}
+
+#[tokio::test]
+async fn prepare_type_modifier() {
+    let client = connect("user=postgres").await;
+
+    let statement = client
+        .prepare("SELECT $1::BIGINT, $2::VARCHAR(7), $3::VARCHAR(101)")
+        .await
+        .unwrap();
+
+    assert_eq!(statement.columns()[0].type_(), &Type::INT8);
+    assert_eq!(statement.columns()[0].type_modifier(), -1);
+    assert_eq!(statement.columns()[1].type_(), &Type::VARCHAR);
+    assert_eq!(statement.columns()[1].type_modifier(), 7);
+    assert_eq!(statement.columns()[2].type_(), &Type::VARCHAR);
+    assert_eq!(statement.columns()[2].type_modifier(), 101);
 }
 
 #[tokio::test]

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -161,6 +161,7 @@ async fn pipelined_prepare() {
 
     assert_eq!(statement2.params()[0], Type::INT8);
     assert_eq!(statement2.columns()[0].type_(), &Type::INT8);
+    assert_eq!(statement2.columns()[0].type_modifier(), -1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What
Expose the 4-byte type-specific type modifier on the Column struct

## Why
I would like access type modifiers for prepared statement columns. E.g. for a numeric column I would like  to get the numeric precision and scale. For a varchar column I would like to get the varchar length limit.

## Context
This is an extension of https://github.com/sfackler/rust-postgres/pull/1084 where other table and column OIDs were exposed in Column, and exposing type modifiers was noted as a possibility.