### PR TITLE
Support build on wasm32

### DIFF
--- a/tokio-postgres/src/cancel_query.rs
+++ b/tokio-postgres/src/cancel_query.rs
@@ -34,6 +34,7 @@ where
         config.port,
         config.connect_timeout,
         config.tcp_user_timeout,
+        #[cfg(not(target_arch = "wasm32"))]
         config.keepalive.as_ref(),
     )
     .await?;

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -2,7 +2,7 @@ use crate::codec::{BackendMessages, FrontendMessage};
 use crate::config::SslMode;
 use crate::connection::{Request, RequestMessages};
 use crate::copy_out::CopyOutStream;
-#[cfg(feature = "runtime")]
+#[cfg(all(feature = "runtime", not(target_arch = "wasm32")))]
 use crate::keepalive::KeepaliveConfig;
 use crate::query::RowStream;
 use crate::simple_query::SimpleQueryStream;
@@ -27,7 +27,7 @@ use std::collections::HashMap;
 use std::fmt;
 #[cfg(feature = "runtime")]
 use std::net::IpAddr;
-#[cfg(feature = "runtime")]
+#[cfg(all(feature = "runtime", unix))]
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -160,6 +160,7 @@ pub(crate) struct SocketConfig {
     pub port: u16,
     pub connect_timeout: Option<Duration>,
     pub tcp_user_timeout: Option<Duration>,
+    #[cfg(not(target_arch = "wasm32"))]
     pub keepalive: Option<KeepaliveConfig>,
 }
 

--- a/tokio-postgres/src/connect.rs
+++ b/tokio-postgres/src/connect.rs
@@ -146,6 +146,7 @@ where
         port,
         config.connect_timeout,
         config.tcp_user_timeout,
+        #[cfg(not(target_arch = "wasm32"))]
         if config.keepalives {
             Some(&config.keepalive_config)
         } else {
@@ -216,6 +217,7 @@ where
         port,
         connect_timeout: config.connect_timeout,
         tcp_user_timeout: config.tcp_user_timeout,
+        #[cfg(not(target_arch = "wasm32"))]
         keepalive: if config.keepalives {
             Some(config.keepalive_config.clone())
         } else {

--- a/tokio-postgres/src/connect_socket.rs
+++ b/tokio-postgres/src/connect_socket.rs
@@ -1,6 +1,8 @@
 use crate::client::Addr;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::keepalive::KeepaliveConfig;
 use crate::{Error, Socket};
+#[cfg(not(target_arch = "wasm32"))]
 use socket2::{SockRef, TcpKeepalive};
 use std::future::Future;
 use std::io;
@@ -17,7 +19,7 @@ pub(crate) async fn connect_socket(
     #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] tcp_user_timeout: Option<
         Duration,
     >,
-    keepalive_config: Option<&KeepaliveConfig>,
+    #[cfg(not(target_arch = "wasm32"))] keepalive_config: Option<&KeepaliveConfig>,
 ) -> Result<Socket, Error> {
     match addr {
         Addr::Tcp(ip) => {
@@ -26,6 +28,7 @@ pub(crate) async fn connect_socket(
 
             stream.set_nodelay(true).map_err(Error::connect)?;
 
+            #[cfg(not(target_arch = "wasm32"))]
             let sock_ref = SockRef::from(&stream);
             #[cfg(target_os = "linux")]
             {
@@ -34,6 +37,7 @@ pub(crate) async fn connect_socket(
                     .map_err(Error::connect)?;
             }
 
+            #[cfg(not(target_arch = "wasm32"))]
             if let Some(keepalive_config) = keepalive_config {
                 sock_ref
                     .set_tcp_keepalive(&TcpKeepalive::from(keepalive_config))


### PR DESCRIPTION
[In this line](https://github.com/sfackler/rust-postgres/blob/98f5a11bc0a8e451552d8941ffa078c7eb6cd60c/tokio-postgres/src/config.rs#L207-L208), the parameter KeepaliveConfig is ignored when compiled to wasm32, while there is no corresponding conditional compilation elsewhere. Therefore, I added a conditional compilation for wasm32 in the places where Keepalive is needed. This modification allows the crate to be used normally in wasm32 after replacing the underlying tokio with a patch.