### PR TITLE
feat: sslnegotiation and direct ssl for postgres 17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   postgres:
-    image: postgres:14
+    image: docker.io/postgres:17beta2
     ports:
       - 5433:5433
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   postgres:
-    image: docker.io/postgres:17beta2
+    image: docker.io/postgres:17
     ports:
       - 5433:5433
     volumes:

--- a/postgres-native-tls/Cargo.toml
+++ b/postgres-native-tls/Cargo.toml
@@ -16,7 +16,7 @@ default = ["runtime"]
 runtime = ["tokio-postgres/runtime"]
 
 [dependencies]
-native-tls = "0.2"
+native-tls = { version = "0.2", features = ["alpn"] }
 tokio = "1.0"
 tokio-native-tls = "0.3"
 tokio-postgres = { version = "0.7.11", path = "../tokio-postgres", default-features = false }

--- a/postgres-native-tls/src/lib.rs
+++ b/postgres-native-tls/src/lib.rs
@@ -53,6 +53,7 @@
 //! ```
 #![warn(rust_2018_idioms, clippy::all, missing_docs)]
 
+use native_tls::TlsConnectorBuilder;
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
@@ -179,4 +180,11 @@ where
             None => ChannelBinding::none(),
         }
     }
+}
+
+/// Set ALPN for `TlsConnectorBuilder`
+///
+/// This is required when using `sslnegotiation=direct`
+pub fn set_postgresql_alpn(builder: &mut TlsConnectorBuilder) -> &mut TlsConnectorBuilder {
+    builder.request_alpns(&["postgresql"])
 }

--- a/postgres-native-tls/src/lib.rs
+++ b/postgres-native-tls/src/lib.rs
@@ -185,6 +185,6 @@ where
 /// Set ALPN for `TlsConnectorBuilder`
 ///
 /// This is required when using `sslnegotiation=direct`
-pub fn set_postgresql_alpn(builder: &mut TlsConnectorBuilder) -> &mut TlsConnectorBuilder {
-    builder.request_alpns(&["postgresql"])
+pub fn set_postgresql_alpn(builder: &mut TlsConnectorBuilder) {
+    builder.request_alpns(&["postgresql"]);
 }

--- a/postgres-native-tls/src/test.rs
+++ b/postgres-native-tls/src/test.rs
@@ -43,6 +43,22 @@ async fn require() {
 }
 
 #[tokio::test]
+async fn direct() {
+    let connector = native_tls::TlsConnector::builder()
+        .add_root_certificate(
+            Certificate::from_pem(include_bytes!("../../test/server.crt")).unwrap(),
+        )
+        .request_alpns(&["postgresql"])
+        .build()
+        .unwrap();
+    smoke_test(
+        "user=ssl_user dbname=postgres sslmode=require sslnegotiation=direct",
+        TlsConnector::new(connector, "localhost"),
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn prefer() {
     let connector = native_tls::TlsConnector::builder()
         .add_root_certificate(

--- a/postgres-native-tls/src/test.rs
+++ b/postgres-native-tls/src/test.rs
@@ -44,11 +44,12 @@ async fn require() {
 
 #[tokio::test]
 async fn direct() {
-    let connector = set_postgresql_alpn(native_tls::TlsConnector::builder().add_root_certificate(
+    let mut builder = native_tls::TlsConnector::builder();
+    builder.add_root_certificate(
         Certificate::from_pem(include_bytes!("../../test/server.crt")).unwrap(),
-    ))
-    .build()
-    .unwrap();
+    );
+    set_postgresql_alpn(&mut builder);
+    let connector = builder.build().unwrap();
     smoke_test(
         "user=ssl_user dbname=postgres sslmode=require sslnegotiation=direct",
         TlsConnector::new(connector, "localhost"),

--- a/postgres-native-tls/src/test.rs
+++ b/postgres-native-tls/src/test.rs
@@ -5,7 +5,7 @@ use tokio_postgres::tls::TlsConnect;
 
 #[cfg(feature = "runtime")]
 use crate::MakeTlsConnector;
-use crate::TlsConnector;
+use crate::{set_postgresql_alpn, TlsConnector};
 
 async fn smoke_test<T>(s: &str, tls: T)
 where
@@ -44,13 +44,11 @@ async fn require() {
 
 #[tokio::test]
 async fn direct() {
-    let connector = native_tls::TlsConnector::builder()
-        .add_root_certificate(
-            Certificate::from_pem(include_bytes!("../../test/server.crt")).unwrap(),
-        )
-        .request_alpns(&["postgresql"])
-        .build()
-        .unwrap();
+    let connector = set_postgresql_alpn(native_tls::TlsConnector::builder().add_root_certificate(
+        Certificate::from_pem(include_bytes!("../../test/server.crt")).unwrap(),
+    ))
+    .build()
+    .unwrap();
     smoke_test(
         "user=ssl_user dbname=postgres sslmode=require sslnegotiation=direct",
         TlsConnector::new(connector, "localhost"),

--- a/postgres-openssl/src/lib.rs
+++ b/postgres-openssl/src/lib.rs
@@ -53,7 +53,7 @@ use openssl::hash::MessageDigest;
 use openssl::nid::Nid;
 #[cfg(feature = "runtime")]
 use openssl::ssl::SslConnector;
-use openssl::ssl::{self, ConnectConfiguration, SslRef};
+use openssl::ssl::{self, ConnectConfiguration, SslConnectorBuilder, SslRef};
 use openssl::x509::X509VerifyResult;
 use std::error::Error;
 use std::fmt::{self, Debug};
@@ -249,4 +249,11 @@ fn tls_server_end_point(ssl: &SslRef) -> Option<Vec<u8>> {
         nid => MessageDigest::from_nid(nid)?,
     };
     cert.digest(md).ok().map(|b| b.to_vec())
+}
+
+/// Set ALPN for `SslConnectorBuilder`
+///
+/// This is required when using `sslnegotiation=direct`
+pub fn set_postgresql_alpn(builder: &mut SslConnectorBuilder) -> Result<(), ErrorStack> {
+    builder.set_alpn_protos(b"\x0apostgresql")
 }

--- a/postgres-openssl/src/test.rs
+++ b/postgres-openssl/src/test.rs
@@ -41,7 +41,7 @@ async fn require() {
 async fn direct() {
     let mut builder = SslConnector::builder(SslMethod::tls()).unwrap();
     builder.set_ca_file("../test/server.crt").unwrap();
-    builder.set_alpn_protos(b"\x0apostgresql").unwrap();
+    set_postgresql_alpn(&mut builder).unwrap();
     let ctx = builder.build();
     smoke_test(
         "user=ssl_user dbname=postgres sslmode=require sslnegotiation=direct",

--- a/postgres-openssl/src/test.rs
+++ b/postgres-openssl/src/test.rs
@@ -38,6 +38,19 @@ async fn require() {
 }
 
 #[tokio::test]
+async fn direct() {
+    let mut builder = SslConnector::builder(SslMethod::tls()).unwrap();
+    builder.set_ca_file("../test/server.crt").unwrap();
+    builder.set_alpn_protos(b"\x0apostgresql").unwrap();
+    let ctx = builder.build();
+    smoke_test(
+        "user=ssl_user dbname=postgres sslmode=require sslnegotiation=direct",
+        TlsConnector::new(ctx.configure().unwrap(), "localhost"),
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn prefer() {
     let mut builder = SslConnector::builder(SslMethod::tls()).unwrap();
     builder.set_ca_file("../test/server.crt").unwrap();

--- a/postgres-protocol/src/message/backend.rs
+++ b/postgres-protocol/src/message/backend.rs
@@ -475,7 +475,7 @@ pub struct ColumnFormats<'a> {
     remaining: u16,
 }
 
-impl<'a> FallibleIterator for ColumnFormats<'a> {
+impl FallibleIterator for ColumnFormats<'_> {
     type Item = u16;
     type Error = io::Error;
 
@@ -557,7 +557,7 @@ pub struct DataRowRanges<'a> {
     remaining: u16,
 }
 
-impl<'a> FallibleIterator for DataRowRanges<'a> {
+impl FallibleIterator for DataRowRanges<'_> {
     type Item = Option<Range<usize>>;
     type Error = io::Error;
 
@@ -645,7 +645,7 @@ pub struct ErrorField<'a> {
     value: &'a [u8],
 }
 
-impl<'a> ErrorField<'a> {
+impl ErrorField<'_> {
     #[inline]
     pub fn type_(&self) -> u8 {
         self.type_
@@ -717,7 +717,7 @@ pub struct Parameters<'a> {
     remaining: u16,
 }
 
-impl<'a> FallibleIterator for Parameters<'a> {
+impl FallibleIterator for Parameters<'_> {
     type Item = Oid;
     type Error = io::Error;
 

--- a/postgres-protocol/src/types/mod.rs
+++ b/postgres-protocol/src/types/mod.rs
@@ -582,7 +582,7 @@ impl<'a> Array<'a> {
 /// An iterator over the dimensions of an array.
 pub struct ArrayDimensions<'a>(&'a [u8]);
 
-impl<'a> FallibleIterator for ArrayDimensions<'a> {
+impl FallibleIterator for ArrayDimensions<'_> {
     type Item = ArrayDimension;
     type Error = StdBox<dyn Error + Sync + Send>;
 
@@ -950,7 +950,7 @@ pub struct PathPoints<'a> {
     buf: &'a [u8],
 }
 
-impl<'a> FallibleIterator for PathPoints<'a> {
+impl FallibleIterator for PathPoints<'_> {
     type Item = Point;
     type Error = StdBox<dyn Error + Sync + Send>;
 

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -914,7 +914,7 @@ pub enum Format {
     Binary,
 }
 
-impl<'a, T> ToSql for &'a T
+impl<T> ToSql for &T
 where
     T: ToSql,
 {
@@ -963,7 +963,7 @@ impl<T: ToSql> ToSql for Option<T> {
     to_sql_checked!();
 }
 
-impl<'a, T: ToSql> ToSql for &'a [T] {
+impl<T: ToSql> ToSql for &[T] {
     fn to_sql(&self, ty: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         let member_type = match *ty.kind() {
             Kind::Array(ref member) => member,
@@ -1004,7 +1004,7 @@ impl<'a, T: ToSql> ToSql for &'a [T] {
     to_sql_checked!();
 }
 
-impl<'a> ToSql for &'a [u8] {
+impl ToSql for &[u8] {
     fn to_sql(&self, _: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         types::bytea_to_sql(self, w);
         Ok(IsNull::No)
@@ -1064,7 +1064,7 @@ impl<T: ToSql> ToSql for Box<[T]> {
     to_sql_checked!();
 }
 
-impl<'a> ToSql for Cow<'a, [u8]> {
+impl ToSql for Cow<'_, [u8]> {
     fn to_sql(&self, ty: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         <&[u8] as ToSql>::to_sql(&self.as_ref(), ty, w)
     }
@@ -1088,7 +1088,7 @@ impl ToSql for Vec<u8> {
     to_sql_checked!();
 }
 
-impl<'a> ToSql for &'a str {
+impl ToSql for &str {
     fn to_sql(&self, ty: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         match ty.name() {
             "ltree" => types::ltree_to_sql(self, w),
@@ -1109,7 +1109,7 @@ impl<'a> ToSql for &'a str {
     to_sql_checked!();
 }
 
-impl<'a> ToSql for Cow<'a, str> {
+impl ToSql for Cow<'_, str> {
     fn to_sql(&self, ty: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         <&str as ToSql>::to_sql(&self.as_ref(), ty, w)
     }
@@ -1256,17 +1256,17 @@ impl BorrowToSql for &dyn ToSql {
     }
 }
 
-impl<'a> sealed::Sealed for Box<dyn ToSql + Sync + 'a> {}
+impl sealed::Sealed for Box<dyn ToSql + Sync + '_> {}
 
-impl<'a> BorrowToSql for Box<dyn ToSql + Sync + 'a> {
+impl BorrowToSql for Box<dyn ToSql + Sync + '_> {
     #[inline]
     fn borrow_to_sql(&self) -> &dyn ToSql {
         self.as_ref()
     }
 }
 
-impl<'a> sealed::Sealed for Box<dyn ToSql + Sync + Send + 'a> {}
-impl<'a> BorrowToSql for Box<dyn ToSql + Sync + Send + 'a> {
+impl sealed::Sealed for Box<dyn ToSql + Sync + Send + '_> {}
+impl BorrowToSql for Box<dyn ToSql + Sync + Send + '_> {
     #[inline]
     fn borrow_to_sql(&self) -> &dyn ToSql {
         self.as_ref()

--- a/postgres/src/config.rs
+++ b/postgres/src/config.rs
@@ -10,6 +10,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime;
+use tokio_postgres::config::SslNegotiation;
 #[doc(inline)]
 pub use tokio_postgres::config::{
     ChannelBinding, Host, LoadBalanceHosts, SslMode, TargetSessionAttrs,
@@ -40,6 +41,8 @@ use tokio_postgres::{Error, Socket};
 ///     path to the directory containing Unix domain sockets. Otherwise, it is treated as a hostname. Multiple hosts
 ///     can be specified, separated by commas. Each host will be tried in turn when connecting. Required if connecting
 ///     with the `connect` method.
+/// * `sslnegotiation` - TLS negotiation method. If set to `direct`, the client will perform direct TLS handshake, this only works for PostgreSQL 17 and newer.
+///     If set to `postgres`, the default value, it follows original postgres wire protocol to perform the negotiation.
 /// * `hostaddr` - Numeric IP address of host to connect to. This should be in the standard IPv4 address format,
 ///     e.g., 172.28.40.9. If your machine supports IPv6, you can also use those addresses.
 ///     If this parameter is not specified, the value of `host` will be looked up to find the corresponding IP address,
@@ -228,6 +231,17 @@ impl Config {
     /// Gets the SSL configuration.
     pub fn get_ssl_mode(&self) -> SslMode {
         self.config.get_ssl_mode()
+    }
+
+    /// Sets the SSL negotiation method
+    pub fn ssl_negotiation(&mut self, ssl_negotiation: SslNegotiation) -> &mut Config {
+        self.config.ssl_negotiation(ssl_negotiation);
+        self
+    }
+
+    /// Gets the SSL negotiation method
+    pub fn get_ssl_negotiation(&self) -> SslNegotiation {
+        self.config.get_ssl_negotiation()
     }
 
     /// Adds a host to the configuration.

--- a/postgres/src/config.rs
+++ b/postgres/src/config.rs
@@ -10,10 +10,9 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime;
-use tokio_postgres::config::SslNegotiation;
 #[doc(inline)]
 pub use tokio_postgres::config::{
-    ChannelBinding, Host, LoadBalanceHosts, SslMode, TargetSessionAttrs,
+    ChannelBinding, Host, LoadBalanceHosts, SslMode, SslNegotiation, TargetSessionAttrs,
 };
 use tokio_postgres::error::DbError;
 use tokio_postgres::tls::{MakeTlsConnect, TlsConnect};

--- a/postgres/src/config.rs
+++ b/postgres/src/config.rs
@@ -41,6 +41,7 @@ use tokio_postgres::{Error, Socket};
 ///     can be specified, separated by commas. Each host will be tried in turn when connecting. Required if connecting
 ///     with the `connect` method.
 /// * `sslnegotiation` - TLS negotiation method. If set to `direct`, the client will perform direct TLS handshake, this only works for PostgreSQL 17 and newer.
+///     Note that you will need to setup ALPN of TLS client configuration to `postgresql` when using direct TLS.
 ///     If set to `postgres`, the default value, it follows original postgres wire protocol to perform the negotiation.
 /// * `hostaddr` - Numeric IP address of host to connect to. This should be in the standard IPv4 address format,
 ///     e.g., 172.28.40.9. If your machine supports IPv6, you can also use those addresses.

--- a/postgres/src/notifications.rs
+++ b/postgres/src/notifications.rs
@@ -77,7 +77,7 @@ pub struct Iter<'a> {
     connection: ConnectionRef<'a>,
 }
 
-impl<'a> FallibleIterator for Iter<'a> {
+impl FallibleIterator for Iter<'_> {
     type Item = Notification;
     type Error = Error;
 
@@ -100,7 +100,7 @@ pub struct BlockingIter<'a> {
     connection: ConnectionRef<'a>,
 }
 
-impl<'a> FallibleIterator for BlockingIter<'a> {
+impl FallibleIterator for BlockingIter<'_> {
     type Item = Notification;
     type Error = Error;
 
@@ -129,7 +129,7 @@ pub struct TimeoutIter<'a> {
     timeout: Duration,
 }
 
-impl<'a> FallibleIterator for TimeoutIter<'a> {
+impl FallibleIterator for TimeoutIter<'_> {
     type Item = Notification;
     type Error = Error;
 

--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -12,7 +12,7 @@ pub struct Transaction<'a> {
     transaction: Option<tokio_postgres::Transaction<'a>>,
 }
 
-impl<'a> Drop for Transaction<'a> {
+impl Drop for Transaction<'_> {
     fn drop(&mut self) {
         if let Some(transaction) = self.transaction.take() {
             let _ = self.connection.block_on(transaction.rollback());

--- a/tokio-postgres/src/cancel_query.rs
+++ b/tokio-postgres/src/cancel_query.rs
@@ -1,5 +1,5 @@
 use crate::client::SocketConfig;
-use crate::config::SslMode;
+use crate::config::{SslMode, SslNegotiation};
 use crate::tls::MakeTlsConnect;
 use crate::{cancel_query_raw, connect_socket, Error, Socket};
 use std::io;
@@ -7,6 +7,7 @@ use std::io;
 pub(crate) async fn cancel_query<T>(
     config: Option<SocketConfig>,
     ssl_mode: SslMode,
+    ssl_negotiation: SslNegotiation,
     mut tls: T,
     process_id: i32,
     secret_key: i32,
@@ -38,6 +39,14 @@ where
     )
     .await?;
 
-    cancel_query_raw::cancel_query_raw(socket, ssl_mode, tls, has_hostname, process_id, secret_key)
-        .await
+    cancel_query_raw::cancel_query_raw(
+        socket,
+        ssl_mode,
+        ssl_negotiation,
+        tls,
+        has_hostname,
+        process_id,
+        secret_key,
+    )
+    .await
 }

--- a/tokio-postgres/src/cancel_query_raw.rs
+++ b/tokio-postgres/src/cancel_query_raw.rs
@@ -1,4 +1,4 @@
-use crate::config::SslMode;
+use crate::config::{SslMode, SslNegotiation};
 use crate::tls::TlsConnect;
 use crate::{connect_tls, Error};
 use bytes::BytesMut;
@@ -8,6 +8,7 @@ use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 pub async fn cancel_query_raw<S, T>(
     stream: S,
     mode: SslMode,
+    negotiation: SslNegotiation,
     tls: T,
     has_hostname: bool,
     process_id: i32,
@@ -17,7 +18,7 @@ where
     S: AsyncRead + AsyncWrite + Unpin,
     T: TlsConnect<S>,
 {
-    let mut stream = connect_tls::connect_tls(stream, mode, tls, has_hostname).await?;
+    let mut stream = connect_tls::connect_tls(stream, mode, negotiation, tls, has_hostname).await?;
 
     let mut buf = BytesMut::new();
     frontend::cancel_request(process_id, secret_key, &mut buf);

--- a/tokio-postgres/src/cancel_token.rs
+++ b/tokio-postgres/src/cancel_token.rs
@@ -1,4 +1,4 @@
-use crate::config::SslMode;
+use crate::config::{SslMode, SslNegotiation};
 use crate::tls::TlsConnect;
 #[cfg(feature = "runtime")]
 use crate::{cancel_query, client::SocketConfig, tls::MakeTlsConnect, Socket};
@@ -12,6 +12,7 @@ pub struct CancelToken {
     #[cfg(feature = "runtime")]
     pub(crate) socket_config: Option<SocketConfig>,
     pub(crate) ssl_mode: SslMode,
+    pub(crate) ssl_negotiation: SslNegotiation,
     pub(crate) process_id: i32,
     pub(crate) secret_key: i32,
 }
@@ -37,6 +38,7 @@ impl CancelToken {
         cancel_query::cancel_query(
             self.socket_config.clone(),
             self.ssl_mode,
+            self.ssl_negotiation,
             tls,
             self.process_id,
             self.secret_key,
@@ -54,6 +56,7 @@ impl CancelToken {
         cancel_query_raw::cancel_query_raw(
             stream,
             self.ssl_mode,
+            self.ssl_negotiation,
             tls,
             true,
             self.process_id,

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -1,5 +1,5 @@
 use crate::codec::BackendMessages;
-use crate::config::SslMode;
+use crate::config::{SslMode, SslNegotiation};
 use crate::connection::{Request, RequestMessages};
 use crate::copy_out::CopyOutStream;
 #[cfg(feature = "runtime")]
@@ -180,6 +180,7 @@ pub struct Client {
     #[cfg(feature = "runtime")]
     socket_config: Option<SocketConfig>,
     ssl_mode: SslMode,
+    ssl_negotiation: SslNegotiation,
     process_id: i32,
     secret_key: i32,
 }
@@ -188,6 +189,7 @@ impl Client {
     pub(crate) fn new(
         sender: mpsc::UnboundedSender<Request>,
         ssl_mode: SslMode,
+        ssl_negotiation: SslNegotiation,
         process_id: i32,
         secret_key: i32,
     ) -> Client {
@@ -200,6 +202,7 @@ impl Client {
             #[cfg(feature = "runtime")]
             socket_config: None,
             ssl_mode,
+            ssl_negotiation,
             process_id,
             secret_key,
         }
@@ -550,6 +553,7 @@ impl Client {
             #[cfg(feature = "runtime")]
             socket_config: self.socket_config.clone(),
             ssl_mode: self.ssl_mode,
+            ssl_negotiation: self.ssl_negotiation,
             process_id: self.process_id,
             secret_key: self.secret_key,
         }

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -117,6 +117,7 @@ pub enum Host {
 ///     can be specified, separated by commas. Each host will be tried in turn when connecting. Required if connecting
 ///     with the `connect` method.
 /// * `sslnegotiation` - TLS negotiation method. If set to `direct`, the client will perform direct TLS handshake, this only works for PostgreSQL 17 and newer.
+///     Note that you will need to setup ALPN of TLS client configuration to `postgresql` when using direct TLS.
 ///     If set to `postgres`, the default value, it follows original postgres wire protocol to perform the negotiation.
 /// * `hostaddr` - Numeric IP address of host to connect to. This should be in the standard IPv4 address format,
 ///     e.g., 172.28.40.9. If your machine supports IPv6, you can also use those addresses.

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -50,6 +50,16 @@ pub enum SslMode {
     Require,
 }
 
+/// TLS negotiation configuration
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SslNegotiation {
+    /// Use PostgreSQL SslRequest for Ssl negotiation
+    Postgres,
+    /// Start Ssl handshake without negotiation, only works for PostgreSQL 17+
+    Direct,
+}
+
 /// Channel binding configuration.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -106,6 +116,8 @@ pub enum Host {
 ///     path to the directory containing Unix domain sockets. Otherwise, it is treated as a hostname. Multiple hosts
 ///     can be specified, separated by commas. Each host will be tried in turn when connecting. Required if connecting
 ///     with the `connect` method.
+/// * `sslnegotiation` - TLS negotiation method. If set to `direct`, the client will perform direct TLS handshake, this only works for PostgreSQL 17 and newer.
+///     If set to `postgres`, the default value, it follows original postgres wire protocol to perform the negotiation.
 /// * `hostaddr` - Numeric IP address of host to connect to. This should be in the standard IPv4 address format,
 ///     e.g., 172.28.40.9. If your machine supports IPv6, you can also use those addresses.
 ///     If this parameter is not specified, the value of `host` will be looked up to find the corresponding IP address,
@@ -198,6 +210,7 @@ pub struct Config {
     pub(crate) options: Option<String>,
     pub(crate) application_name: Option<String>,
     pub(crate) ssl_mode: SslMode,
+    pub(crate) ssl_negotiation: SslNegotiation,
     pub(crate) host: Vec<Host>,
     pub(crate) hostaddr: Vec<IpAddr>,
     pub(crate) port: Vec<u16>,
@@ -227,6 +240,7 @@ impl Config {
             options: None,
             application_name: None,
             ssl_mode: SslMode::Prefer,
+            ssl_negotiation: SslNegotiation::Postgres,
             host: vec![],
             hostaddr: vec![],
             port: vec![],
@@ -323,6 +337,19 @@ impl Config {
     /// Gets the SSL configuration.
     pub fn get_ssl_mode(&self) -> SslMode {
         self.ssl_mode
+    }
+
+    /// Sets the SSL negotiation method.
+    ///
+    /// Defaults to `postgres`.
+    pub fn ssl_negotiation(&mut self, ssl_negotiation: SslNegotiation) -> &mut Config {
+        self.ssl_negotiation = ssl_negotiation;
+        self
+    }
+
+    /// Gets the SSL negotiation method.
+    pub fn get_ssl_negotiation(&self) -> SslNegotiation {
+        self.ssl_negotiation
     }
 
     /// Adds a host to the configuration.
@@ -549,6 +576,18 @@ impl Config {
                     _ => return Err(Error::config_parse(Box::new(InvalidValue("sslmode")))),
                 };
                 self.ssl_mode(mode);
+            }
+            "sslnegotiation" => {
+                let mode = match value {
+                    "postgres" => SslNegotiation::Postgres,
+                    "direct" => SslNegotiation::Direct,
+                    _ => {
+                        return Err(Error::config_parse(Box::new(InvalidValue(
+                            "sslnegotiation",
+                        ))))
+                    }
+                };
+                self.ssl_negotiation(mode);
             }
             "host" => {
                 for host in value.split(',') {

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -51,10 +51,14 @@ pub enum SslMode {
 }
 
 /// TLS negotiation configuration
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+///
+/// See more information at
+/// https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLNEGOTIATION
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum SslNegotiation {
     /// Use PostgreSQL SslRequest for Ssl negotiation
+    #[default]
     Postgres,
     /// Start Ssl handshake without negotiation, only works for PostgreSQL 17+
     Direct,
@@ -116,9 +120,15 @@ pub enum Host {
 ///     path to the directory containing Unix domain sockets. Otherwise, it is treated as a hostname. Multiple hosts
 ///     can be specified, separated by commas. Each host will be tried in turn when connecting. Required if connecting
 ///     with the `connect` method.
-/// * `sslnegotiation` - TLS negotiation method. If set to `direct`, the client will perform direct TLS handshake, this only works for PostgreSQL 17 and newer.
-///     Note that you will need to setup ALPN of TLS client configuration to `postgresql` when using direct TLS.
-///     If set to `postgres`, the default value, it follows original postgres wire protocol to perform the negotiation.
+/// * `sslnegotiation` - TLS negotiation method. If set to `direct`, the client
+///     will perform direct TLS handshake, this only works for PostgreSQL 17 and
+///     newer.
+///     Note that you will need to setup ALPN of TLS client configuration to
+///     `postgresql` when using direct TLS. If you are using postgres_openssl
+///     as TLS backend, a `postgres_openssl::set_postgresql_alpn` helper is
+///     provided for that.
+///     If set to `postgres`, the default value, it follows original postgres
+///     wire protocol to perform the negotiation.
 /// * `hostaddr` - Numeric IP address of host to connect to. This should be in the standard IPv4 address format,
 ///     e.g., 172.28.40.9. If your machine supports IPv6, you can also use those addresses.
 ///     If this parameter is not specified, the value of `host` will be looked up to find the corresponding IP address,

--- a/tokio-postgres/src/connect_raw.rs
+++ b/tokio-postgres/src/connect_raw.rs
@@ -89,7 +89,14 @@ where
     S: AsyncRead + AsyncWrite + Unpin,
     T: TlsConnect<S>,
 {
-    let stream = connect_tls(stream, config.ssl_mode, tls, has_hostname).await?;
+    let stream = connect_tls(
+        stream,
+        config.ssl_mode,
+        config.ssl_negotiation,
+        tls,
+        has_hostname,
+    )
+    .await?;
 
     let mut stream = StartupStream {
         inner: Framed::new(stream, PostgresCodec),
@@ -107,7 +114,13 @@ where
     let (process_id, secret_key, parameters) = read_info(&mut stream).await?;
 
     let (sender, receiver) = mpsc::unbounded();
-    let client = Client::new(sender, config.ssl_mode, process_id, secret_key);
+    let client = Client::new(
+        sender,
+        config.ssl_mode,
+        config.ssl_negotiation,
+        process_id,
+        secret_key,
+    );
     let connection = Connection::new(stream.inner, stream.delayed, parameters, receiver);
 
     Ok((client, connection))

--- a/tokio-postgres/src/connect_tls.rs
+++ b/tokio-postgres/src/connect_tls.rs
@@ -23,6 +23,9 @@ where
         SslMode::Prefer if !tls.can_connect(ForcePrivateApi) => {
             return Ok(MaybeTlsStream::Raw(stream))
         }
+        SslMode::Prefer if negotiation == SslNegotiation::Direct => {
+            return Err(Error::tls("weak sslmode \"prefer\" may not be used with sslnegotiation=direct (use \"require\", \"verify-ca\", or \"verify-full\")".into()))
+        }
         SslMode::Prefer | SslMode::Require => {}
     }
 

--- a/tokio-postgres/src/connect_tls.rs
+++ b/tokio-postgres/src/connect_tls.rs
@@ -1,4 +1,4 @@
-use crate::config::SslMode;
+use crate::config::{SslMode, SslNegotiation};
 use crate::maybe_tls_stream::MaybeTlsStream;
 use crate::tls::private::ForcePrivateApi;
 use crate::tls::TlsConnect;
@@ -10,6 +10,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 pub async fn connect_tls<S, T>(
     mut stream: S,
     mode: SslMode,
+    negotiation: SslNegotiation,
     tls: T,
     has_hostname: bool,
 ) -> Result<MaybeTlsStream<S, T::Stream>, Error>
@@ -25,18 +26,20 @@ where
         SslMode::Prefer | SslMode::Require => {}
     }
 
-    let mut buf = BytesMut::new();
-    frontend::ssl_request(&mut buf);
-    stream.write_all(&buf).await.map_err(Error::io)?;
+    if negotiation == SslNegotiation::Postgres {
+        let mut buf = BytesMut::new();
+        frontend::ssl_request(&mut buf);
+        stream.write_all(&buf).await.map_err(Error::io)?;
 
-    let mut buf = [0];
-    stream.read_exact(&mut buf).await.map_err(Error::io)?;
+        let mut buf = [0];
+        stream.read_exact(&mut buf).await.map_err(Error::io)?;
 
-    if buf[0] != b'S' {
-        if SslMode::Require == mode {
-            return Err(Error::tls("server does not support TLS".into()));
-        } else {
-            return Ok(MaybeTlsStream::Raw(stream));
+        if buf[0] != b'S' {
+            if SslMode::Require == mode {
+                return Err(Error::tls("server does not support TLS".into()));
+            } else {
+                return Ok(MaybeTlsStream::Raw(stream));
+            }
         }
     }
 

--- a/tokio-postgres/src/generic_client.rs
+++ b/tokio-postgres/src/generic_client.rs
@@ -80,7 +80,7 @@ pub trait GenericClient: private::Sealed {
     ) -> Result<Statement, Error>;
 
     /// Like [`Client::transaction`].
-    async fn transaction(&mut self) -> Result<Transaction<'_>, Error>;
+    async fn transaction<'a>(&'a mut self) -> Result<Transaction<'a>, Error>;
 
     /// Like [`Client::batch_execute`].
     async fn batch_execute(&self, query: &str) -> Result<(), Error>;
@@ -180,7 +180,7 @@ impl GenericClient for Client {
         self.prepare_typed(query, parameter_types).await
     }
 
-    async fn transaction(&mut self) -> Result<Transaction<'_>, Error> {
+    async fn transaction<'a>(&'a mut self) -> Result<Transaction<'a>, Error> {
         self.transaction().await
     }
 

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -20,7 +20,7 @@ use std::task::{Context, Poll};
 
 struct BorrowToSqlParamsDebug<'a, T>(&'a [T]);
 
-impl<'a, T> fmt::Debug for BorrowToSqlParamsDebug<'a, T>
+impl<T> fmt::Debug for BorrowToSqlParamsDebug<'_, T>
 where
     T: BorrowToSql,
 {
@@ -61,7 +61,7 @@ where
     })
 }
 
-pub async fn query_typed<'a, P, I>(
+pub async fn query_typed<P, I>(
     client: &Arc<InnerClient>,
     query: &str,
     params: I,

--- a/tokio-postgres/src/row.rs
+++ b/tokio-postgres/src/row.rs
@@ -79,9 +79,9 @@ impl RowIndex for str {
     }
 }
 
-impl<'a, T> Sealed for &'a T where T: ?Sized + Sealed {}
+impl<T> Sealed for &T where T: ?Sized + Sealed {}
 
-impl<'a, T> RowIndex for &'a T
+impl<T> RowIndex for &T
 where
     T: ?Sized + RowIndex,
 {

--- a/tokio-postgres/src/to_statement.rs
+++ b/tokio-postgres/src/to_statement.rs
@@ -11,7 +11,7 @@ mod private {
         Query(&'a str),
     }
 
-    impl<'a> ToStatementType<'a> {
+    impl ToStatementType<'_> {
         pub async fn into_statement(self, client: &Client) -> Result<Statement, Error> {
             match self {
                 ToStatementType::Statement(s) => Ok(s.clone()),

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -33,7 +33,7 @@ struct Savepoint {
     depth: u32,
 }
 
-impl<'a> Drop for Transaction<'a> {
+impl Drop for Transaction<'_> {
     fn drop(&mut self) {
         if self.done {
             return;

--- a/tokio-postgres/src/transaction_builder.rs
+++ b/tokio-postgres/src/transaction_builder.rs
@@ -113,7 +113,7 @@ impl<'a> TransactionBuilder<'a> {
             done: bool,
         }
 
-        impl<'a> Drop for RollbackIfNotDone<'a> {
+        impl Drop for RollbackIfNotDone<'_> {
             fn drop(&mut self) {
                 if self.done {
                     return;

--- a/tokio-postgres/tests/test/parse.rs
+++ b/tokio-postgres/tests/test/parse.rs
@@ -1,5 +1,5 @@
 use std::time::Duration;
-use tokio_postgres::config::{Config, TargetSessionAttrs};
+use tokio_postgres::config::{Config, SslNegotiation, TargetSessionAttrs};
 
 fn check(s: &str, config: &Config) {
     assert_eq!(s.parse::<Config>().expect(s), *config, "`{}`", s);
@@ -41,6 +41,10 @@ fn settings() {
             .keepalives(false)
             .keepalives_idle(Duration::from_secs(30))
             .target_session_attrs(TargetSessionAttrs::ReadOnly),
+    );
+    check(
+        "sslnegotiation=direct",
+        Config::new().ssl_negotiation(SslNegotiation::Direct),
     );
 }
 

--- a/tokio-postgres/tests/test/types/mod.rs
+++ b/tokio-postgres/tests/test/types/mod.rs
@@ -509,7 +509,7 @@ async fn domain() {
         to_sql_checked!();
     }
 
-    impl<'a> FromSql<'a> for SessionId {
+    impl FromSql<'_> for SessionId {
         fn from_sql(ty: &Type, raw: &[u8]) -> result::Result<Self, Box<dyn Error + Sync + Send>> {
             Vec::<u8>::from_sql(ty, raw).map(SessionId)
         }


### PR DESCRIPTION
This patch adds Direct SSL support which is a new feature coming in PostgreSQL 17. With this option, we issue TLS handshake directly without `SslRequest`. This will save a roundtrip on connection opening.

I just follow how libpq is designed, to offer an option `sslnegotiation` to control this behaviour (because it won't work on Postgres 16 or earlier).

