### PR TITLE
Derive Clone for Row

### DIFF
--- a/postgres-protocol/src/message/backend.rs
+++ b/postgres-protocol/src/message/backend.rs
@@ -524,7 +524,7 @@ impl CopyOutResponseBody {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DataRowBody {
     storage: Bytes,
     len: u16,

--- a/tokio-postgres/src/row.rs
+++ b/tokio-postgres/src/row.rs
@@ -95,6 +95,7 @@ where
 }
 
 /// A row of data returned from the database by a query.
+#[derive(Clone)]
 pub struct Row {
     statement: Statement,
     body: DataRowBody,


### PR DESCRIPTION
### Feature

Derive a `Clone` implementation for `tokio_postgres::Row`.

### Use case

I want to clone the row. I can't see why I shouldn't be able to, the actual data is stored in `bytes::Bytes`, which is made to be cloned, and the `Statement` (including columns, etc) is behind an `Arc`, which is exactly the same as `bytes::Bytes`.

### Workarounds

I could place the row in an `Arc`, but that would be pretty silly since underneath it would be two `Arc`s stored inside another `Arc`.