### PR TITLE
impl Debug for Statement

### DIFF
--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -61,6 +61,16 @@ impl Statement {
     }
 }
 
+impl std::fmt::Debug for Statement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        f.debug_struct("Statement")
+            .field("name", &self.0.name)
+            .field("params", &self.0.params)
+            .field("columns", &self.0.columns)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Information about a column of a query.
 #[derive(Debug)]
 pub struct Column {


### PR DESCRIPTION
The lack of this common trait bound caused some unpleasantness. For example, the following didn't compile:

let x = OnceLock::new();
let stmt = db.prepare(...)?;
x.set(stmt).expect(...); // returns Result<(), T=Statement> where T: Debug