### PR TITLE
Fix a few nits pointed out by clippy

### DIFF
--- a/postgres-protocol/src/lib.rs
+++ b/postgres-protocol/src/lib.rs
@@ -60,7 +60,7 @@ macro_rules! from_usize {
         impl FromUsize for $t {
             #[inline]
             fn from_usize(x: usize) -> io::Result<$t> {
-                if x > <$t>::max_value() as usize {
+                if x > <$t>::MAX as usize {
                     Err(io::Error::new(
                         io::ErrorKind::InvalidInput,
                         "value too large to transmit",

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -1222,7 +1222,7 @@ impl ToSql for IpAddr {
 }
 
 fn downcast(len: usize) -> Result<i32, Box<dyn Error + Sync + Send>> {
-    if len > i32::max_value() as usize {
+    if len > i32::MAX as usize {
         Err("value too large to transmit".into())
     } else {
         Ok(len as i32)

--- a/postgres-types/src/special.rs
+++ b/postgres-types/src/special.rs
@@ -1,7 +1,6 @@
 use bytes::BytesMut;
 use postgres_protocol::types;
 use std::error::Error;
-use std::{i32, i64};
 
 use crate::{FromSql, IsNull, ToSql, Type};
 


### PR DESCRIPTION
- ...::max_value() -> ..::MAX
- delete explicit import of signed integer types