### PR TITLE
Fix `chrono::DateTime<Utc>` tests

### DIFF
--- a/tokio-postgres/tests/test/types/chrono_04.rs
+++ b/tokio-postgres/tests/test/types/chrono_04.rs
@@ -1,4 +1,4 @@
-use chrono_04::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
+use chrono_04::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use std::fmt;
 use tokio_postgres::types::{Date, FromSqlOwned, Timestamp};
 use tokio_postgres::Client;
@@ -53,18 +53,20 @@ async fn test_with_special_naive_date_time_params() {
 async fn test_date_time_params() {
     fn make_check(time: &str) -> (Option<DateTime<Utc>>, &str) {
         (
-            Some(Utc.from_utc_datetime(
-                &NaiveDateTime::parse_from_str(time, "'%Y-%m-%d %H:%M:%S.%f'").unwrap(),
-            )),
+            Some(
+                DateTime::parse_from_str(time, "'%Y-%m-%d %H:%M:%S.%f%#z'")
+                    .unwrap()
+                    .to_utc(),
+            ),
             time,
         )
     }
     test_type(
         "TIMESTAMP WITH TIME ZONE",
         &[
-            make_check("'1970-01-01 00:00:00.010000000'"),
-            make_check("'1965-09-25 11:19:33.100314000'"),
-            make_check("'2010-02-09 23:11:45.120200000'"),
+            make_check("'1970-01-01 00:00:00.010000000Z'"),
+            make_check("'1965-09-25 11:19:33.100314000Z'"),
+            make_check("'2010-02-09 23:11:45.120200000Z'"),
             (None, "NULL"),
         ],
     )
@@ -75,18 +77,20 @@ async fn test_date_time_params() {
 async fn test_with_special_date_time_params() {
     fn make_check(time: &str) -> (Timestamp<DateTime<Utc>>, &str) {
         (
-            Timestamp::Value(Utc.from_utc_datetime(
-                &NaiveDateTime::parse_from_str(time, "'%Y-%m-%d %H:%M:%S.%f'").unwrap(),
-            )),
+            Timestamp::Value(
+                DateTime::parse_from_str(time, "'%Y-%m-%d %H:%M:%S.%f%#z'")
+                    .unwrap()
+                    .to_utc(),
+            ),
             time,
         )
     }
     test_type(
         "TIMESTAMP WITH TIME ZONE",
         &[
-            make_check("'1970-01-01 00:00:00.010000000'"),
-            make_check("'1965-09-25 11:19:33.100314000'"),
-            make_check("'2010-02-09 23:11:45.120200000'"),
+            make_check("'1970-01-01 00:00:00.010000000Z'"),
+            make_check("'1965-09-25 11:19:33.100314000Z'"),
+            make_check("'2010-02-09 23:11:45.120200000Z'"),
             (Timestamp::PosInfinity, "'infinity'"),
             (Timestamp::NegInfinity, "'-infinity'"),
         ],


### PR DESCRIPTION
`test_date_time_params` and `test_with_special_date_time_params` could fail when run with a non-UTC system time zone.
I encountered these failing tests when writing the tests for jiff.

In Postgres, if no time zone is stated in the input string, then it is assumed to be in system time.<sup>[1]</sup> This means that in these tests, a correctly parsed `DateTime<Utc>` could be compared to an incorrectly offset time.

The offset component is now included in the test strings of these tests. This component is already present in the test strings for `time::OffsetDateTime`.


<sup>[1]</sup> [Postgres docs](https://www.postgresql.org/docs/current/datatype-datetime.html):

>For timestamp with time zone, the internally stored value is always in UTC (Universal Coordinated Time, traditionally known as Greenwich Mean Time, GMT). An input value that has an explicit time zone specified is converted to UTC using the appropriate offset for that time zone. If no time zone is stated in the input string, then it is assumed to be in the time zone indicated by the system's [TimeZone](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-TIMEZONE) parameter, and is converted to UTC using the offset for the timezone zone.
