### PR TITLE
[doc] Encourage the user to handle connection properly

### DIFF
--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //!     // The connection object performs the actual communication with the database,
 //!     // so spawn it off to run on its own.
-//!     tokio::spawn(async move {
+//!     let connection_handle = tokio::spawn(async move {
 //!         if let Err(e) = connection.await {
 //!             eprintln!("connection error: {}", e);
 //!         }
@@ -29,6 +29,9 @@
 //!     // And then check that we got back the same string we sent over.
 //!     let value: &str = rows[0].get(0);
 //!     assert_eq!(value, "hello world");
+//!
+//!     // Handle the connection or panic to avoid irrecoverable state
+//!     connection_handle.await.expect("tokio join");
 //!
 //!     Ok(())
 //! }


### PR DESCRIPTION
The current version on the main page of the documentation doesn't encourage users to handle the connection coroutine. One may (and I already have multiple pieces of evidence) use this example in the real app with a long-running server where connection panic doesn't affect the other part of the app leading to the inconsistent state.

Even simple panic would be better in this case since you explicitly rely on the outside mechanisms to deal with it (e.g. docker or any other runtime/supervisor). 