### PR TITLE
Add rkyv 0.8 and rend 0.5 support

### DIFF
--- a/postgres-types/Cargo.toml
+++ b/postgres-types/Cargo.toml
@@ -28,6 +28,9 @@ with-uuid-0_8 = ["uuid-08"]
 with-uuid-1 = ["uuid-1"]
 with-time-0_2 = ["time-02"]
 with-time-0_3 = ["time-03"]
+with-rkyv-0_8 = ["rkyv-08"]
+with-rend-0_5 = ["rend-05"]
+
 
 [dependencies]
 bytes = "1.0"
@@ -55,3 +58,5 @@ uuid-1 = { version = "1.0", package = "uuid", optional = true }
 time-02 = { version = "0.2", package = "time", optional = true }
 time-03 = { version = "0.3", package = "time", default-features = false, optional = true }
 smol_str-01 = { version = "0.1.23", package = "smol_str", default-features = false, optional = true }
+rkyv-08 = { version = "0.8.0-rc.1", package = "rkyv", optional = true, default-features = false }
+rend-05 = { version = "0.5.0-rc.1", package = "rend", optional = true, default-features = false }

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -278,6 +278,10 @@ mod geo_types_06;
 mod geo_types_07;
 #[cfg(feature = "with-jiff-0_1")]
 mod jiff_01;
+#[cfg(feature = "with-rend-0_5")]
+mod rend_05;
+#[cfg(feature = "with-rkyv-0_8")]
+mod rkyv_08;
 #[cfg(feature = "with-serde_json-1")]
 mod serde_json_1;
 #[cfg(feature = "with-smol_str-01")]

--- a/postgres-types/src/rend_05.rs
+++ b/postgres-types/src/rend_05.rs
@@ -1,0 +1,41 @@
+use crate::{IsNull, ToSql, Type};
+use bytes::BytesMut;
+
+macro_rules! impl_rend {
+    ($($ty:ty => $orig:ty,)*) => {$(
+        impl ToSql for $ty {
+            #[inline]
+            fn to_sql(
+                &self,
+                ty: &Type,
+                out: &mut BytesMut,
+            ) -> Result<IsNull, Box<dyn std::error::Error + Sync + Send>> {
+                self.to_native().to_sql(ty, out)
+            }
+
+            #[inline]
+            fn accepts(ty: &Type) -> bool {
+                <$orig as ToSql>::accepts(ty)
+            }
+
+            to_sql_checked!();
+        }
+    )*};
+}
+
+impl_rend! {
+    rend_05::f32_le => f32,
+    rend_05::f32_be => f32,
+    rend_05::f64_le => f64,
+    rend_05::f64_be => f64,
+
+    rend_05::i16_le => i16,
+    rend_05::i16_be => i16,
+    rend_05::i32_le => i32,
+    rend_05::i32_be => i32,
+    rend_05::i64_le => i64,
+    rend_05::i64_be => i64,
+
+    rend_05::u32_le => u32,
+    rend_05::u32_be => u32,
+}

--- a/postgres-types/src/rkyv_08.rs
+++ b/postgres-types/src/rkyv_08.rs
@@ -1,0 +1,136 @@
+use std::{collections::HashMap, error::Error, hash::Hasher, net::IpAddr};
+
+use crate::{Format, IsNull, ToSql, Type};
+use bytes::BytesMut;
+use postgres_protocol::types;
+
+use rkyv_08::{
+    collections::swiss_table::ArchivedHashMap, net::ArchivedIpAddr,
+    niche::option_box::ArchivedOptionBox, option::ArchivedOption, string::ArchivedString,
+    vec::ArchivedVec,
+};
+
+macro_rules! fwd_accepts {
+    ($ty:ty) => {
+        #[inline]
+        fn accepts(ty: &Type) -> bool {
+            <$ty as ToSql>::accepts(ty)
+        }
+    };
+}
+
+impl ToSql for ArchivedString {
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        self.as_str().to_sql(ty, out)
+    }
+
+    fwd_accepts!(&str);
+    to_sql_checked!();
+}
+
+impl<T> ToSql for ArchivedVec<T>
+where
+    T: ToSql,
+{
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        self.as_slice().to_sql(ty, out)
+    }
+
+    fwd_accepts!(&[T]);
+    to_sql_checked!();
+}
+
+impl<T> ToSql for ArchivedOption<T>
+where
+    T: ToSql,
+{
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        match self {
+            ArchivedOption::Some(value) => value.to_sql(ty, out),
+            ArchivedOption::None => Ok(IsNull::Yes),
+        }
+    }
+
+    fn encode_format(&self, ty: &Type) -> Format {
+        match self {
+            ArchivedOption::Some(ref val) => val.encode_format(ty),
+            ArchivedOption::None => Format::Binary,
+        }
+    }
+
+    fwd_accepts!(Option<T>);
+    to_sql_checked!();
+}
+
+impl<T> ToSql for ArchivedOptionBox<T>
+where
+    T: ToSql,
+{
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        match self.as_ref() {
+            Some(value) => value.to_sql(ty, out),
+            None => Ok(IsNull::Yes),
+        }
+    }
+
+    fn encode_format(&self, ty: &Type) -> Format {
+        match self.as_ref() {
+            Some(val) => val.encode_format(ty),
+            None => Format::Binary,
+        }
+    }
+
+    fwd_accepts!(Option<T>);
+    to_sql_checked!();
+}
+
+impl ToSql for ArchivedIpAddr {
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        self.as_ipaddr().to_sql(ty, out)
+    }
+
+    fwd_accepts!(IpAddr);
+    to_sql_checked!();
+}
+
+impl<H> ToSql for ArchivedHashMap<ArchivedString, ArchivedOption<ArchivedString>, H>
+where
+    H: Hasher,
+{
+    fn to_sql(
+        &self,
+        _ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        types::hstore_to_sql(
+            self.iter()
+                .map(|(k, v)| (k.as_ref(), v.as_ref().map(|v| v.as_ref()))),
+            out,
+        )?;
+
+        Ok(IsNull::No)
+    }
+
+    fwd_accepts!(HashMap<String, Option<String>>);
+    to_sql_checked!();
+}


### PR DESCRIPTION
Creating this as a draft since the crates are currently release candidates, but the full releases should be published within a week or two according to rkyv's creator. 

If you could decide if these should be accepted into postgres-types before rkyv 0.8 officially releases, that would be amazing, as we could remove these impls from rkyv itself, simplifying things. 