### PR TITLE
Make error::Kind public

### DIFF
--- a/tokio-postgres/src/error/mod.rs
+++ b/tokio-postgres/src/error/mod.rs
@@ -337,14 +337,20 @@ pub enum ErrorPosition {
     },
 }
 
-#[derive(Debug, PartialEq)]
-enum Kind {
+/// Error kind returned by the database.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Clone)]
+pub enum Kind {
     Io,
     UnexpectedMessage,
     Tls,
     ToSql(usize),
     FromSql(usize),
+    /// A column was fetched from the row which wasn't returned by the database.
+    /// This usually indicates the column wasn't included in the query.
     Column(String),
+    /// The number of parameters expected by the query doesn't match the number
+    /// of parameters passed when executing the prepared statement.
     Parameters(usize, usize),
     Closed,
     Db,
@@ -436,6 +442,11 @@ impl Error {
     /// This is a convenience method that downcasts the cause to a `DbError` and returns its code.
     pub fn code(&self) -> Option<&SqlState> {
         self.as_db_error().map(DbError::code)
+    }
+
+    /// Returns the kind of error.
+    pub fn kind(&self) -> &Kind {
+        &self.0.kind
     }
 
     fn new(kind: Kind, cause: Option<Box<dyn error::Error + Sync + Send>>) -> Error {


### PR DESCRIPTION
Make `error::Kind` public and provide a getter. This allows lib/app code to handle different kind of errors, e.g.

```rust
match err.kind() {
  Kind::Column(name) => panic!("You forgot to include column {} into the query", name),
  Kind::Parameter(_, _) => panic!("You forgot to pass a parameter to the prepared statement"),
  _kind=> panic!("{:?}", kind),
}
```

I documented errors I know about, but the ones I don't know what they do I left undocumented, hiding the doc warning.