### PR TITLE
add `load_balance_hosts` to `Debug` impl for `Config`

### DIFF
--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -744,6 +744,7 @@ impl fmt::Debug for Config {
         config_dbg
             .field("target_session_attrs", &self.target_session_attrs)
             .field("channel_binding", &self.channel_binding)
+            .field("load_balance_hosts", &self.load_balance_hosts)
             .finish()
     }
 }


### PR DESCRIPTION
Seems to have been an oversight when adding that member to the `Config` type