### PR TITLE
Fix time 0.3 infinity panics

### DIFF
--- a/postgres-types/src/time_02.rs
+++ b/postgres-types/src/time_02.rs
@@ -14,9 +14,7 @@ const fn base() -> PrimitiveDateTime {
 impl<'a> FromSql<'a> for PrimitiveDateTime {
     fn from_sql(_: &Type, raw: &[u8]) -> Result<PrimitiveDateTime, Box<dyn Error + Sync + Send>> {
         let t = types::timestamp_from_sql(raw)?;
-        Ok(base()
-            .checked_add(Duration::microseconds(t))
-            .ok_or("value too large to decode")?)
+        Ok(base() + Duration::microseconds(t))
     }
 
     accepts!(TIMESTAMP);

--- a/postgres-types/src/time_02.rs
+++ b/postgres-types/src/time_02.rs
@@ -14,7 +14,9 @@ const fn base() -> PrimitiveDateTime {
 impl<'a> FromSql<'a> for PrimitiveDateTime {
     fn from_sql(_: &Type, raw: &[u8]) -> Result<PrimitiveDateTime, Box<dyn Error + Sync + Send>> {
         let t = types::timestamp_from_sql(raw)?;
-        Ok(base() + Duration::microseconds(t))
+        Ok(base()
+            .checked_add(Duration::microseconds(t))
+            .ok_or("value too large to decode")?)
     }
 
     accepts!(TIMESTAMP);

--- a/postgres-types/src/time_03.rs
+++ b/postgres-types/src/time_03.rs
@@ -13,7 +13,9 @@ fn base() -> PrimitiveDateTime {
 impl<'a> FromSql<'a> for PrimitiveDateTime {
     fn from_sql(_: &Type, raw: &[u8]) -> Result<PrimitiveDateTime, Box<dyn Error + Sync + Send>> {
         let t = types::timestamp_from_sql(raw)?;
-        Ok(base() + Duration::microseconds(t))
+        Ok(base()
+            .checked_add(Duration::microseconds(t))
+            .ok_or("value too large to decode")?)
     }
 
     accepts!(TIMESTAMP);
@@ -62,7 +64,10 @@ impl ToSql for OffsetDateTime {
 impl<'a> FromSql<'a> for Date {
     fn from_sql(_: &Type, raw: &[u8]) -> Result<Date, Box<dyn Error + Sync + Send>> {
         let jd = types::date_from_sql(raw)?;
-        Ok(base().date() + Duration::days(i64::from(jd)))
+        Ok(base()
+            .date()
+            .checked_add(Duration::days(i64::from(jd)))
+            .ok_or("value too large to decode")?)
     }
 
     accepts!(DATE);


### PR DESCRIPTION
Trying to get a `PrimitiveDateTime` panics if the value was infinity. This commit fixes the panic.

An infinity test is added, mirroring the existing one for chrono. The test is passing.

I also have an example repo here --> https://github.com/allan2/postgres-time-overflow

This PR is for Issue #1171, but for time 0.3 only.

