### PR TITLE
Fix clippy lifetimes

### DIFF
--- a/postgres-protocol/src/message/backend.rs
+++ b/postgres-protocol/src/message/backend.rs
@@ -475,7 +475,7 @@ pub struct ColumnFormats<'a> {
     remaining: u16,
 }
 
-impl<'a> FallibleIterator for ColumnFormats<'a> {
+impl FallibleIterator for ColumnFormats<'_> {
     type Item = u16;
     type Error = io::Error;
 
@@ -557,7 +557,7 @@ pub struct DataRowRanges<'a> {
     remaining: u16,
 }
 
-impl<'a> FallibleIterator for DataRowRanges<'a> {
+impl FallibleIterator for DataRowRanges<'_> {
     type Item = Option<Range<usize>>;
     type Error = io::Error;
 
@@ -645,7 +645,7 @@ pub struct ErrorField<'a> {
     value: &'a [u8],
 }
 
-impl<'a> ErrorField<'a> {
+impl ErrorField<'_> {
     #[inline]
     pub fn type_(&self) -> u8 {
         self.type_
@@ -717,7 +717,7 @@ pub struct Parameters<'a> {
     remaining: u16,
 }
 
-impl<'a> FallibleIterator for Parameters<'a> {
+impl FallibleIterator for Parameters<'_> {
     type Item = Oid;
     type Error = io::Error;
 

--- a/postgres-protocol/src/types/mod.rs
+++ b/postgres-protocol/src/types/mod.rs
@@ -582,7 +582,7 @@ impl<'a> Array<'a> {
 /// An iterator over the dimensions of an array.
 pub struct ArrayDimensions<'a>(&'a [u8]);
 
-impl<'a> FallibleIterator for ArrayDimensions<'a> {
+impl FallibleIterator for ArrayDimensions<'_> {
     type Item = ArrayDimension;
     type Error = StdBox<dyn Error + Sync + Send>;
 
@@ -950,7 +950,7 @@ pub struct PathPoints<'a> {
     buf: &'a [u8],
 }
 
-impl<'a> FallibleIterator for PathPoints<'a> {
+impl FallibleIterator for PathPoints<'_> {
     type Item = Point;
     type Error = StdBox<dyn Error + Sync + Send>;
 

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -955,7 +955,7 @@ impl<T: ToSql> ToSql for Option<T> {
 
     fn encode_format(&self, ty: &Type) -> Format {
         match self {
-            Some(ref val) => val.encode_format(ty),
+            &Some(ref val) => val.encode_format(ty),
             None => Format::Binary,
         }
     }

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -955,7 +955,7 @@ impl<T: ToSql> ToSql for Option<T> {
 
     fn encode_format(&self, ty: &Type) -> Format {
         match self {
-            &Some(ref val) => val.encode_format(ty),
+            Some(val) => val.encode_format(ty),
             None => Format::Binary,
         }
     }

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -914,7 +914,7 @@ pub enum Format {
     Binary,
 }
 
-impl<'a, T> ToSql for &'a T
+impl<T> ToSql for &T
 where
     T: ToSql,
 {
@@ -963,7 +963,7 @@ impl<T: ToSql> ToSql for Option<T> {
     to_sql_checked!();
 }
 
-impl<'a, T: ToSql> ToSql for &'a [T] {
+impl<T: ToSql> ToSql for &[T] {
     fn to_sql(&self, ty: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         let member_type = match *ty.kind() {
             Kind::Array(ref member) => member,
@@ -1004,7 +1004,7 @@ impl<'a, T: ToSql> ToSql for &'a [T] {
     to_sql_checked!();
 }
 
-impl<'a> ToSql for &'a [u8] {
+impl ToSql for &[u8] {
     fn to_sql(&self, _: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         types::bytea_to_sql(self, w);
         Ok(IsNull::No)
@@ -1064,7 +1064,7 @@ impl<T: ToSql> ToSql for Box<[T]> {
     to_sql_checked!();
 }
 
-impl<'a> ToSql for Cow<'a, [u8]> {
+impl ToSql for Cow<'_, [u8]> {
     fn to_sql(&self, ty: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         <&[u8] as ToSql>::to_sql(&self.as_ref(), ty, w)
     }
@@ -1088,7 +1088,7 @@ impl ToSql for Vec<u8> {
     to_sql_checked!();
 }
 
-impl<'a> ToSql for &'a str {
+impl ToSql for &str {
     fn to_sql(&self, ty: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         match ty.name() {
             "ltree" => types::ltree_to_sql(self, w),
@@ -1109,7 +1109,7 @@ impl<'a> ToSql for &'a str {
     to_sql_checked!();
 }
 
-impl<'a> ToSql for Cow<'a, str> {
+impl ToSql for Cow<'_, str> {
     fn to_sql(&self, ty: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         <&str as ToSql>::to_sql(&self.as_ref(), ty, w)
     }
@@ -1256,17 +1256,17 @@ impl BorrowToSql for &dyn ToSql {
     }
 }
 
-impl<'a> sealed::Sealed for Box<dyn ToSql + Sync + 'a> {}
+impl sealed::Sealed for Box<dyn ToSql + Sync + '_> {}
 
-impl<'a> BorrowToSql for Box<dyn ToSql + Sync + 'a> {
+impl BorrowToSql for Box<dyn ToSql + Sync + '_> {
     #[inline]
     fn borrow_to_sql(&self) -> &dyn ToSql {
         self.as_ref()
     }
 }
 
-impl<'a> sealed::Sealed for Box<dyn ToSql + Sync + Send + 'a> {}
-impl<'a> BorrowToSql for Box<dyn ToSql + Sync + Send + 'a> {
+impl sealed::Sealed for Box<dyn ToSql + Sync + Send + '_> {}
+impl BorrowToSql for Box<dyn ToSql + Sync + Send + '_> {
     #[inline]
     fn borrow_to_sql(&self) -> &dyn ToSql {
         self.as_ref()

--- a/postgres/src/notifications.rs
+++ b/postgres/src/notifications.rs
@@ -77,7 +77,7 @@ pub struct Iter<'a> {
     connection: ConnectionRef<'a>,
 }
 
-impl<'a> FallibleIterator for Iter<'a> {
+impl FallibleIterator for Iter<'_> {
     type Item = Notification;
     type Error = Error;
 
@@ -100,7 +100,7 @@ pub struct BlockingIter<'a> {
     connection: ConnectionRef<'a>,
 }
 
-impl<'a> FallibleIterator for BlockingIter<'a> {
+impl FallibleIterator for BlockingIter<'_> {
     type Item = Notification;
     type Error = Error;
 
@@ -129,7 +129,7 @@ pub struct TimeoutIter<'a> {
     timeout: Duration,
 }
 
-impl<'a> FallibleIterator for TimeoutIter<'a> {
+impl FallibleIterator for TimeoutIter<'_> {
     type Item = Notification;
     type Error = Error;
 

--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -12,7 +12,7 @@ pub struct Transaction<'a> {
     transaction: Option<tokio_postgres::Transaction<'a>>,
 }
 
-impl<'a> Drop for Transaction<'a> {
+impl Drop for Transaction<'_> {
     fn drop(&mut self) {
         if let Some(transaction) = self.transaction.take() {
             let _ = self.connection.block_on(transaction.rollback());

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -61,7 +61,7 @@ where
     })
 }
 
-pub async fn query_typed<'a, P, I>(
+pub async fn query_typed<P, I>(
     client: &Arc<InnerClient>,
     query: &str,
     params: I,

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -20,7 +20,7 @@ use std::task::{Context, Poll};
 
 struct BorrowToSqlParamsDebug<'a, T>(&'a [T]);
 
-impl<'a, T> fmt::Debug for BorrowToSqlParamsDebug<'a, T>
+impl<T> fmt::Debug for BorrowToSqlParamsDebug<'_, T>
 where
     T: BorrowToSql,
 {

--- a/tokio-postgres/src/row.rs
+++ b/tokio-postgres/src/row.rs
@@ -79,9 +79,9 @@ impl RowIndex for str {
     }
 }
 
-impl<'a, T> Sealed for &'a T where T: ?Sized + Sealed {}
+impl<T> Sealed for &T where T: ?Sized + Sealed {}
 
-impl<'a, T> RowIndex for &'a T
+impl<T> RowIndex for &T
 where
     T: ?Sized + RowIndex,
 {

--- a/tokio-postgres/src/to_statement.rs
+++ b/tokio-postgres/src/to_statement.rs
@@ -11,7 +11,7 @@ mod private {
         Query(&'a str),
     }
 
-    impl<'a> ToStatementType<'a> {
+    impl ToStatementType<'_> {
         pub async fn into_statement(self, client: &Client) -> Result<Statement, Error> {
             match self {
                 ToStatementType::Statement(s) => Ok(s.clone()),

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -33,7 +33,7 @@ struct Savepoint {
     depth: u32,
 }
 
-impl<'a> Drop for Transaction<'a> {
+impl Drop for Transaction<'_> {
     fn drop(&mut self) {
         if self.done {
             return;

--- a/tokio-postgres/src/transaction_builder.rs
+++ b/tokio-postgres/src/transaction_builder.rs
@@ -113,7 +113,7 @@ impl<'a> TransactionBuilder<'a> {
             done: bool,
         }
 
-        impl<'a> Drop for RollbackIfNotDone<'a> {
+        impl Drop for RollbackIfNotDone<'_> {
             fn drop(&mut self) {
                 if self.done {
                     return;

--- a/tokio-postgres/tests/test/types/mod.rs
+++ b/tokio-postgres/tests/test/types/mod.rs
@@ -509,7 +509,7 @@ async fn domain() {
         to_sql_checked!();
     }
 
-    impl<'a> FromSql<'a> for SessionId {
+    impl FromSql<'_> for SessionId {
         fn from_sql(ty: &Type, raw: &[u8]) -> result::Result<Self, Box<dyn Error + Sync + Send>> {
             Vec::<u8>::from_sql(ty, raw).map(SessionId)
         }


### PR DESCRIPTION
This fixes two lints:
 - [needless_lifetimes](https://rust-lang.github.io/rust-clippy/master/index.html#/needless_lifetimes)
 - [extra_unused_lifetimes](https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes)
 
 Clippy should have no errors or warnings after this.
 
 #1197  related, [CI failing](https://github.com/sfackler/rust-postgres/actions/runs/12862110375/job/35856532074) due to pre-existing clippy warnings