### PR TITLE
Bump CI Rust version to 1.75.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: docker compose up -d
       - uses: sfackler/actions/rustup@master
         with:


### PR DESCRIPTION
cargo tests in CI are [failing](https://github.com/sfackler/rust-postgres/actions/runs/12862700447/job/35858038081?pr=1198) because of a dependency requirement:

```
Run cargo test --all
error: package `geo-types v0.7.15` cannot be built because it requires rustc 1.75 or newer, while the currently active rustc version is 1.74.0
Either upgrade to rustc 1.75 or newer, or use
cargo update geo-types@0.7.15 --precise ver
where `ver` is the latest version of `geo-types` supporting rustc 1.74.0
```

This bumps the Rust version so tests will run. actions/checkout is also bumped because it was right there.