### PR TITLE
Getrandom 0.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
   check-wasm32:
     name: check-wasm32
     runs-on: ubuntu-latest
+    env:
+        RUSTFLAGS: ${env.RUSTFLAGS} --cfg getrandom_backend="wasm_js"
     steps:
       - uses: actions/checkout@v3
       - uses: sfackler/actions/rustup@master

--- a/postgres-protocol/Cargo.toml
+++ b/postgres-protocol/Cargo.toml
@@ -20,7 +20,7 @@ fallible-iterator = "0.2"
 hmac = "0.12"
 md-5 = "0.10"
 memchr = "2.0"
-rand = "0.8"
+rand = "0.9"
 sha2 = "0.10"
 stringprep = "0.1"
 getrandom = { version = "0.2", optional = true }

--- a/postgres-protocol/Cargo.toml
+++ b/postgres-protocol/Cargo.toml
@@ -10,7 +10,7 @@ readme = "../README.md"
 
 [features]
 default = []
-js = ["getrandom/js"]
+js = ["getrandom/wasm_js"]
 
 [dependencies]
 base64 = "0.22"
@@ -23,4 +23,4 @@ memchr = "2.0"
 rand = "0.9"
 sha2 = "0.10"
 stringprep = "0.1"
-getrandom = { version = "0.2", optional = true }
+getrandom = { version = "0.3.1", optional = true }

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -59,7 +59,7 @@ postgres-protocol = { version = "0.6.7", path = "../postgres-protocol" }
 postgres-types = { version = "0.2.8", path = "../postgres-types" }
 tokio = { version = "1.27", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["codec"] }
-rand = "0.8.5"
+rand = "0.9.0"
 whoami = "1.4.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]


### PR DESCRIPTION
#1205 should go first, because `rand@0.9` needs `getrandom@0.3.1`, and doing `getrandom` only makes `rand` being included twice.

Notice I've had to update the `RUSTFLAGS` for the wasm build. This means that customers of this crate who use wasm must do the same. It might warrant an update in the docs. 

If you don't, fails like this:

```
error: The wasm32-unknown-unknown targets are not supported by default; you may need to enable the "wasm_js" configuration flag. Note that enabling the `wasm_js` feature flag alone is insufficient. For more information see: https://docs.rs/getrandom/#webassembly-support
   --> /home/kristof/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.3.1/src/backends.rs:159:9
    |
159 | /         compile_error!(
160 | |             "The wasm32-unknown-unknown targets are not supported by default; \
161 | |             you may need to enable the \"wasm_js\" configuration flag. Note \
162 | |             that enabling the `wasm_js` feature flag alone is insufficient. \
163 | |             For more information see: \
164 | |             https://docs.rs/getrandom/#webassembly-support"
165 | |         );
    | |_________^
```