### PR TITLE
Fix latest clippy warnings

### DIFF
--- a/postgres-protocol/src/authentication/sasl.rs
+++ b/postgres-protocol/src/authentication/sasl.rs
@@ -180,7 +180,7 @@ impl ScramSha256 {
                     password,
                     channel_binding,
                 } => (nonce, password, channel_binding),
-                _ => return Err(io::Error::new(io::ErrorKind::Other, "invalid SCRAM state")),
+                _ => return Err(io::Error::other("invalid SCRAM state")),
             };
 
         let message =
@@ -252,7 +252,7 @@ impl ScramSha256 {
                 salted_password,
                 auth_message,
             } => (salted_password, auth_message),
-            _ => return Err(io::Error::new(io::ErrorKind::Other, "invalid SCRAM state")),
+            _ => return Err(io::Error::other("invalid SCRAM state")),
         };
 
         let message =
@@ -262,10 +262,7 @@ impl ScramSha256 {
 
         let verifier = match parsed {
             ServerFinalMessage::Error(e) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("SCRAM error: {}", e),
-                ));
+                return Err(io::Error::other(format!("SCRAM error: {}", e)));
             }
             ServerFinalMessage::Verifier(verifier) => verifier,
         };

--- a/postgres-protocol/src/types/mod.rs
+++ b/postgres-protocol/src/types/mod.rs
@@ -324,7 +324,7 @@ pub fn varbit_from_sql(mut buf: &[u8]) -> Result<Varbit<'_>, StdBox<dyn Error + 
     if len < 0 {
         return Err("invalid varbit length: varbit < 0".into());
     }
-    let bytes = (len as usize + 7) / 8;
+    let bytes = (len as usize).div_ceil(8);
     if buf.len() != bytes {
         return Err("invalid message length: varbit mismatch".into());
     }

--- a/postgres/src/config.rs
+++ b/postgres/src/config.rs
@@ -1,5 +1,7 @@
 //! Connection configuration.
 
+#![allow(clippy::doc_overindented_list_items)]
+
 use crate::connection::Connection;
 use crate::Client;
 use log::info;

--- a/postgres/src/copy_in_writer.rs
+++ b/postgres/src/copy_in_writer.rs
@@ -53,7 +53,6 @@ impl Write for CopyInWriter<'_> {
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.flush_inner()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+        self.flush_inner().map_err(io::Error::other)
     }
 }

--- a/postgres/src/copy_out_reader.rs
+++ b/postgres/src/copy_out_reader.rs
@@ -41,7 +41,7 @@ impl BufRead for CopyOutReader<'_> {
                 .block_on(async { stream.next().await.transpose() })
             {
                 Ok(Some(cur)) => self.cur = cur,
-                Err(e) => return Err(io::Error::new(io::ErrorKind::Other, e)),
+                Err(e) => return Err(io::Error::other(e)),
                 Ok(None) => break,
             };
         }

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -1,5 +1,7 @@
 //! Connection configuration.
 
+#![allow(clippy::doc_overindented_list_items)]
+
 #[cfg(feature = "runtime")]
 use crate::connect::connect;
 use crate::connect_raw::connect_raw;


### PR DESCRIPTION
`div_ceil` is from Rust v1.73, `io::Error::other` from Rust v1.74.

I've allowed `clippy::doc_overindented_list_items` for now because it made the markdown more readable.