### PR TITLE
Use #[project(!Unpin)] instead of PhantomPinned

### DIFF
--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -56,7 +56,7 @@ futures-util = { version = "0.3", features = ["sink"] }
 log = "0.4"
 parking_lot = "0.12"
 percent-encoding = "2.0"
-pin-project-lite = "0.2"
+pin-project-lite = "0.2.11"
 phf = "0.11"
 postgres-protocol = { version = "0.6.8", path = "../postgres-protocol" }
 postgres-types = { version = "0.2.9", path = "../postgres-types" }

--- a/tokio-postgres/src/copy_in.rs
+++ b/tokio-postgres/src/copy_in.rs
@@ -11,7 +11,7 @@ use pin_project_lite::pin_project;
 use postgres_protocol::message::backend::Message;
 use postgres_protocol::message::frontend;
 use postgres_protocol::message::frontend::CopyData;
-use std::marker::{PhantomData, PhantomPinned};
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -73,14 +73,13 @@ pin_project! {
     ///
     /// The copy *must* be explicitly completed via the `Sink::close` or `finish` methods. If it is
     /// not, the copy will be aborted.
+    #[project(!Unpin)]
     pub struct CopyInSink<T> {
         #[pin]
         sender: mpsc::Sender<CopyInMessage>,
         responses: Responses,
         buf: BytesMut,
         state: SinkState,
-        #[pin]
-        _p: PhantomPinned,
         _p2: PhantomData<T>,
     }
 }
@@ -220,7 +219,6 @@ where
         responses,
         buf: BytesMut::new(),
         state: SinkState::Active,
-        _p: PhantomPinned,
         _p2: PhantomData,
     })
 }

--- a/tokio-postgres/src/copy_out.rs
+++ b/tokio-postgres/src/copy_out.rs
@@ -7,7 +7,6 @@ use futures_util::{ready, Stream};
 use log::debug;
 use pin_project_lite::pin_project;
 use postgres_protocol::message::backend::Message;
-use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -16,10 +15,7 @@ pub async fn copy_out(client: &InnerClient, statement: Statement) -> Result<Copy
 
     let buf = query::encode(client, &statement, slice_iter(&[]))?;
     let responses = start(client, buf).await?;
-    Ok(CopyOutStream {
-        responses,
-        _p: PhantomPinned,
-    })
+    Ok(CopyOutStream { responses })
 }
 
 async fn start(client: &InnerClient, buf: Bytes) -> Result<Responses, Error> {
@@ -40,10 +36,9 @@ async fn start(client: &InnerClient, buf: Bytes) -> Result<Responses, Error> {
 
 pin_project! {
     /// A stream of `COPY ... TO STDOUT` query data.
+    #[project(!Unpin)]
     pub struct CopyOutStream {
         responses: Responses,
-        #[pin]
-        _p: PhantomPinned,
     }
 }
 

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -13,7 +13,6 @@ use postgres_protocol::message::backend::{CommandCompleteBody, Message};
 use postgres_protocol::message::frontend;
 use postgres_types::Type;
 use std::fmt;
-use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -57,7 +56,6 @@ where
         statement,
         responses,
         rows_affected: None,
-        _p: PhantomPinned,
     })
 }
 
@@ -95,7 +93,6 @@ where
                     statement: Statement::unnamed(vec![], vec![]),
                     responses,
                     rows_affected: None,
-                    _p: PhantomPinned,
                 });
             }
             Message::RowDescription(row_description) => {
@@ -115,7 +112,6 @@ where
                     statement: Statement::unnamed(vec![], columns),
                     responses,
                     rows_affected: None,
-                    _p: PhantomPinned,
                 });
             }
             _ => return Err(Error::unexpected_message()),
@@ -140,7 +136,6 @@ pub async fn query_portal(
         statement: portal.statement().clone(),
         responses,
         rows_affected: None,
-        _p: PhantomPinned,
     })
 }
 
@@ -285,12 +280,11 @@ where
 
 pin_project! {
     /// A stream of table rows.
+    #[project(!Unpin)]
     pub struct RowStream {
         statement: Statement,
         responses: Responses,
         rows_affected: Option<u64>,
-        #[pin]
-        _p: PhantomPinned,
     }
 }
 

--- a/tokio-postgres/src/simple_query.rs
+++ b/tokio-postgres/src/simple_query.rs
@@ -10,7 +10,6 @@ use log::debug;
 use pin_project_lite::pin_project;
 use postgres_protocol::message::backend::Message;
 use postgres_protocol::message::frontend;
-use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -41,7 +40,6 @@ pub async fn simple_query(client: &InnerClient, query: &str) -> Result<SimpleQue
     Ok(SimpleQueryStream {
         responses,
         columns: None,
-        _p: PhantomPinned,
     })
 }
 
@@ -72,11 +70,10 @@ fn encode(client: &InnerClient, query: &str) -> Result<Bytes, Error> {
 
 pin_project! {
     /// A stream of simple query results.
+    #[project(!Unpin)]
     pub struct SimpleQueryStream {
         responses: Responses,
         columns: Option<Arc<[SimpleColumn]>>,
-        #[pin]
-        _p: PhantomPinned,
     }
 }
 


### PR DESCRIPTION
`pin-project-lite` supports this since 0.2.11. The main advantage is that it gets rid of this confusing clause from the docs:

```rust
impl<'__pin, T> Unpin for CopyInSink<T>
where
    PinnedFieldsOf<__Origin<'__pin, T>>: Unpin,
```