### PR TITLE
Derive `Serialize` and `Deserialize` for `JSON`

### DIFF
--- a/postgres-types/src/serde_json_1.rs
+++ b/postgres-types/src/serde_json_1.rs
@@ -7,7 +7,8 @@ use std::fmt::Debug;
 use std::io::Read;
 
 /// A wrapper type to allow arbitrary `Serialize`/`Deserialize` types to convert to Postgres JSON values.
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(crate = "serde_1", transparent)]
 pub struct Json<T>(pub T);
 
 impl<'a, T> FromSql<'a> for Json<T>


### PR DESCRIPTION
This allows one to use the same struct with serde (`Serialize`/`Deserialize`) and postgres (`FromSql`/`ToSql`) instead of needing to decide between these options and implement manual conversions between two structs.