### PR TITLE
Add cause error information on alternate display

### DIFF
--- a/tokio-postgres/src/error/mod.rs
+++ b/tokio-postgres/src/error/mod.rs
@@ -379,27 +379,33 @@ impl fmt::Debug for Error {
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0.kind {
-            Kind::Io => fmt.write_str("error communicating with the server"),
-            Kind::UnexpectedMessage => fmt.write_str("unexpected message from server"),
-            Kind::Tls => fmt.write_str("error performing TLS handshake"),
-            Kind::ToSql(idx) => write!(fmt, "error serializing parameter {idx}"),
-            Kind::FromSql(idx) => write!(fmt, "error deserializing column {idx}"),
-            Kind::Column(column) => write!(fmt, "invalid column `{column}`"),
+            Kind::Io => fmt.write_str("error communicating with the server")?,
+            Kind::UnexpectedMessage => fmt.write_str("unexpected message from server")?,
+            Kind::Tls => fmt.write_str("error performing TLS handshake")?,
+            Kind::ToSql(idx) => write!(fmt, "error serializing parameter {idx}")?,
+            Kind::FromSql(idx) => write!(fmt, "error deserializing column {idx}")?,
+            Kind::Column(column) => write!(fmt, "invalid column `{column}`")?,
             Kind::Parameters(real, expected) => {
-                write!(fmt, "expected {expected} parameters but got {real}")
+                write!(fmt, "expected {expected} parameters but got {real}")?;
             }
-            Kind::Closed => fmt.write_str("connection closed"),
-            Kind::Db => fmt.write_str("db error"),
-            Kind::Parse => fmt.write_str("error parsing response from server"),
-            Kind::Encode => fmt.write_str("error encoding message to server"),
-            Kind::Authentication => fmt.write_str("authentication error"),
-            Kind::ConfigParse => fmt.write_str("invalid connection string"),
-            Kind::Config => fmt.write_str("invalid configuration"),
-            Kind::RowCount => fmt.write_str("query returned an unexpected number of rows"),
+            Kind::Closed => fmt.write_str("connection closed")?,
+            Kind::Db => fmt.write_str("db error")?,
+            Kind::Parse => fmt.write_str("error parsing response from server")?,
+            Kind::Encode => fmt.write_str("error encoding message to server")?,
+            Kind::Authentication => fmt.write_str("authentication error")?,
+            Kind::ConfigParse => fmt.write_str("invalid connection string")?,
+            Kind::Config => fmt.write_str("invalid configuration")?,
+            Kind::RowCount => fmt.write_str("query returned an unexpected number of rows")?,
             #[cfg(feature = "runtime")]
-            Kind::Connect => fmt.write_str("error connecting to server"),
-            Kind::Timeout => fmt.write_str("timeout waiting for server"),
+            Kind::Connect => fmt.write_str("error connecting to server")?,
+            Kind::Timeout => fmt.write_str("timeout waiting for server")?,
         }
+        if fmt.alternate() {
+            if let Some(ref cause) = self.0.cause {
+                write!(fmt, ": {cause}")?;
+            }
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
I saw that the cause error was recently removed in https://github.com/rust-postgres/rust-postgres/commit/c5d3442ed8507453b1f83be34ac9ecbb97070e9e.

Especially for db errors, which are quite common, this is quite annoying. Getting a "db error" is really hard to debug :)

The anyhow crate exposes the full error path as their alternate Display format. This PR does the same here. It means that the full error will be printed for `println!("err: {:#}", err)`