### PR TITLE
Add a function to read the inner value of sql types.

### DIFF
--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -368,6 +368,11 @@ impl Type {
     pub fn name(&self) -> &str {
         self.0.name()
     }
+
+    /// Returns the inner value of this type.
+    pub fn inner(&self) -> &Inner {
+        &self.0
+    }
 }
 
 /// Represents the kind of a Postgres type.


### PR DESCRIPTION
Currently, there is no way to know the actual type of a sql value because inner is private. This pr adds a .inner() function to expose the read value of inner to fix this.

