### PR TITLE
override FallibleIterator::size_hint for Fields

### DIFF
--- a/postgres-protocol/src/message/backend.rs
+++ b/postgres-protocol/src/message/backend.rs
@@ -831,6 +831,12 @@ impl<'a> FallibleIterator for Fields<'a> {
             format,
         }))
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.remaining as usize;
+        (len, Some(len))
+    }
 }
 
 pub struct Field<'a> {


### PR DESCRIPTION
The size hint could be useful when collecting column info from field