### PR TITLE
fix(postgres-protocol): increase bind parameter limit from i16::MAX to u16::MAX

### DIFF
--- a/postgres-protocol/src/lib.rs
+++ b/postgres-protocol/src/lib.rs
@@ -74,4 +74,5 @@ macro_rules! from_usize {
 }
 
 from_usize!(i16);
+from_usize!(u16);
 from_usize!(i32);

--- a/postgres-protocol/src/message/frontend.rs
+++ b/postgres-protocol/src/message/frontend.rs
@@ -105,8 +105,8 @@ where
         serializer(item, buf)?;
         count += 1;
     }
-    let count = i16::from_usize(count)?;
-    BigEndian::write_i16(&mut buf[base..], count);
+    let count = u16::from_usize(count)?;
+    BigEndian::write_u16(&mut buf[base..], count);
 
     Ok(())
 }


### PR DESCRIPTION
PostgreSQL's wire protocol documentation describes the parameter count field as "Int16", which led to us using a signed 16-bit integer. However, PostgreSQL actually interprets this field as unsigned, allowing up to 65,535 bind parameters per query rather than 32,767.

Fixes #1302