### PR TITLE
Add support for scalar queries.

### DIFF
--- a/tokio-postgres/src/error/mod.rs
+++ b/tokio-postgres/src/error/mod.rs
@@ -345,6 +345,7 @@ enum Kind {
     ToSql(usize),
     FromSql(usize),
     Column(String),
+    ColumnCount,
     Parameters(usize, usize),
     Closed,
     Db,
@@ -385,6 +386,7 @@ impl fmt::Display for Error {
             Kind::ToSql(idx) => write!(fmt, "error serializing parameter {idx}"),
             Kind::FromSql(idx) => write!(fmt, "error deserializing column {idx}"),
             Kind::Column(column) => write!(fmt, "invalid column `{column}`"),
+            Kind::ColumnCount => write!(fmt, "query returned an unexpected number of columns"),
             Kind::Parameters(real, expected) => {
                 write!(fmt, "expected {expected} parameters but got {real}")
             }
@@ -473,6 +475,10 @@ impl Error {
 
     pub(crate) fn column(column: String) -> Error {
         Error::new(Kind::Column(column), None)
+    }
+
+    pub(crate) fn column_count() -> Error {
+        Error::new(Kind::ColumnCount, None)
     }
 
     pub(crate) fn parameters(real: usize, expected: usize) -> Error {

--- a/tokio-postgres/src/to_statement.rs
+++ b/tokio-postgres/src/to_statement.rs
@@ -2,7 +2,9 @@ use crate::to_statement::private::{Sealed, ToStatementType};
 use crate::Statement;
 
 mod private {
-    use crate::{Client, Error, Statement};
+    use std::sync::Arc;
+
+    use crate::{client::InnerClient, prepare, Error, Statement};
 
     pub trait Sealed {}
 
@@ -12,10 +14,10 @@ mod private {
     }
 
     impl ToStatementType<'_> {
-        pub async fn into_statement(self, client: &Client) -> Result<Statement, Error> {
+        pub async fn into_statement(self, client: &Arc<InnerClient>) -> Result<Statement, Error> {
             match self {
                 ToStatementType::Statement(s) => Ok(s.clone()),
-                ToStatementType::Query(s) => client.prepare(s).await,
+                ToStatementType::Query(s) => prepare::prepare(client, s, &[]).await,
             }
         }
     }

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -205,7 +205,10 @@ impl<'a> Transaction<'a> {
         I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
-        let statement = statement.__convert().into_statement(self.client).await?;
+        let statement = statement
+            .__convert()
+            .into_statement(self.client.inner())
+            .await?;
         bind::bind(self.client.inner(), statement, params).await
     }
 


### PR DESCRIPTION
This PR adds support for querying scalars with the following functions:

- query_scalar returns a vector of scalars
- query_one_scalar returns one scalar
- query_opt_scalar returns optional scalar

The PR also contains a change so `Arc<InnerClient>` is passed to `prepare::prepare` without indirections via `ToStatementType::into_statement`.

Supersedes https://github.com/rust-postgres/rust-postgres/pull/1126

And as @paolobarbolini questioned, if the row does not contain exactly one column, an error is raised.