### PR TITLE
fix(tokio-postgres): support wasm32-wasip2 compilation

### DIFF
--- a/tokio-postgres/src/cancel_query.rs
+++ b/tokio-postgres/src/cancel_query.rs
@@ -35,6 +35,7 @@ where
         config.port,
         config.connect_timeout,
         config.tcp_user_timeout,
+        #[cfg(not(target_arch = "wasm32"))]
         config.keepalive.as_ref(),
     )
     .await?;

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -4,7 +4,7 @@ use crate::codec::{BackendMessages, FrontendMessage};
 use crate::config::{SslMode, SslNegotiation};
 use crate::connection::{Request, RequestMessages};
 use crate::copy_out::CopyOutStream;
-#[cfg(feature = "runtime")]
+#[cfg(all(feature = "runtime", not(target_arch = "wasm32")))]
 use crate::keepalive::KeepaliveConfig;
 use crate::query::RowStream;
 use crate::simple_query::SimpleQueryStream;
@@ -163,6 +163,7 @@ pub(crate) struct SocketConfig {
     pub port: u16,
     pub connect_timeout: Option<Duration>,
     pub tcp_user_timeout: Option<Duration>,
+    #[cfg(not(target_arch = "wasm32"))]
     pub keepalive: Option<KeepaliveConfig>,
 }
 

--- a/tokio-postgres/src/connect.rs
+++ b/tokio-postgres/src/connect.rs
@@ -148,6 +148,7 @@ where
         port,
         config.connect_timeout,
         config.tcp_user_timeout,
+        #[cfg(not(target_arch = "wasm32"))]
         if config.keepalives {
             Some(&config.keepalive_config)
         } else {
@@ -218,6 +219,7 @@ where
         port,
         connect_timeout: config.connect_timeout,
         tcp_user_timeout: config.tcp_user_timeout,
+        #[cfg(not(target_arch = "wasm32"))]
         keepalive: if config.keepalives {
             Some(config.keepalive_config.clone())
         } else {

--- a/tokio-postgres/src/connect_socket.rs
+++ b/tokio-postgres/src/connect_socket.rs
@@ -1,6 +1,8 @@
 use crate::client::Addr;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::keepalive::KeepaliveConfig;
 use crate::{Error, Socket};
+#[cfg(not(target_arch = "wasm32"))]
 use socket2::{SockRef, TcpKeepalive};
 use std::future::Future;
 use std::io;
@@ -17,7 +19,7 @@ pub(crate) async fn connect_socket(
     #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] tcp_user_timeout: Option<
         Duration,
     >,
-    keepalive_config: Option<&KeepaliveConfig>,
+    #[cfg(not(target_arch = "wasm32"))] keepalive_config: Option<&KeepaliveConfig>,
 ) -> Result<Socket, Error> {
     match addr {
         Addr::Tcp(ip) => {
@@ -26,19 +28,22 @@ pub(crate) async fn connect_socket(
 
             stream.set_nodelay(true).map_err(Error::connect)?;
 
-            let sock_ref = SockRef::from(&stream);
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let sock_ref = SockRef::from(&stream);
 
-            #[cfg(target_os = "linux")]
-            if let Some(tcp_user_timeout) = tcp_user_timeout {
-                sock_ref
-                    .set_tcp_user_timeout(Some(tcp_user_timeout))
-                    .map_err(Error::connect)?;
-            }
+                #[cfg(target_os = "linux")]
+                if let Some(tcp_user_timeout) = tcp_user_timeout {
+                    sock_ref
+                        .set_tcp_user_timeout(Some(tcp_user_timeout))
+                        .map_err(Error::connect)?;
+                }
 
-            if let Some(keepalive_config) = keepalive_config {
-                sock_ref
-                    .set_tcp_keepalive(&TcpKeepalive::from(keepalive_config))
-                    .map_err(Error::connect)?;
+                if let Some(keepalive_config) = keepalive_config {
+                    sock_ref
+                        .set_tcp_keepalive(&TcpKeepalive::from(keepalive_config))
+                        .map_err(Error::connect)?;
+                }
             }
 
             Ok(Socket::new_tcp(stream))


### PR DESCRIPTION
With tokio 1.51 shipping wasm32-wasip2 networking ([tokio-rs/tokio#7933](https://github.com/tokio-rs/tokio/pull/7933)), tokio-postgres is close to compiling on that target.

The `keepalive` module and `socket2` dependency are already gated:

```rust
// lib.rs
#[cfg(not(target_arch = "wasm32"))]
mod keepalive;
```

```toml
[target.'cfg(not(target_arch = "wasm32"))'..dependencies]
socket2 = { version = "0.6", features = ["all"] }
```

But `connect_socket.rs`, `connect.rs`, and `cancel_query.rs` still import them unconditionally, causing compile errors on wasm32. This PR extends the existing `cfg(not(target_arch = "wasm32"))` gating to those three files. On WASM targets, connections proceed without keepalive — correct since WASI sockets don't expose socket options.

Also requires a fix in the `whoami` dependency ([ardaku/whoami#233](https://github.com/ardaku/whoami/pull/233)) for a separate `std::os::wasi` stability issue on wasip2. With both patches, tokio-postgres compiles on `wasm32-wasip2`.