### PR TITLE
fix(tokio-postgres): guard PathBuf import with #[cfg(unix)] to match its only usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,33 @@ jobs:
           key: clippy-target-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}
       - run: cargo clippy --all --all-targets
 
+  check-windows-cross:
+    name: check-windows-cross
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+      - run: echo "version=$(rustc --version)" >> $GITHUB_OUTPUT
+        id: rust-version
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry/index
+          key: index-${{ runner.os }}-${{ github.run_number }}
+          restore-keys: |
+            index-${{ runner.os }}-
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry/cache
+          key: registry-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}
+      - run: cargo fetch
+      - uses: actions/cache@v4
+        with:
+          path: target
+          key: check-windows-target-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}
+      - run: cargo check --target x86_64-pc-windows-msvc -p tokio-postgres --features runtime
+
   check-wasm32:
     name: check-wasm32
     runs-on: ubuntu-latest

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -29,7 +29,7 @@ use std::fmt;
 use std::future;
 #[cfg(feature = "runtime")]
 use std::net::IpAddr;
-#[cfg(feature = "runtime")]
+#[cfg(all(unix, feature = "runtime"))]
 use std::path::PathBuf;
 use std::pin::pin;
 use std::sync::Arc;


### PR DESCRIPTION
(encountered this while working on https://github.com/NikolayS/rpg)

## Problem

In `tokio-postgres/src/client.rs`, `use std::path::PathBuf` was guarded with `#[cfg(feature = "runtime")]`. But `PathBuf` is only used in the `Unix(PathBuf)` variant of the `Addr` enum, which requires **both** `#[cfg(unix)]` (on the variant) and `#[cfg(feature = "runtime")]` (on the enum).

This caused an unused-import error (`-D warnings`) on any non-Unix platform with `runtime` enabled. CI never caught it because it only runs on Linux.

## Fix

- Change the guard to `#[cfg(all(unix, feature = "runtime"))]` — matching both conditions required for `PathBuf` to actually be used.
- Add a `check-windows-cross` CI job that cross-compiles for `x86_64-pc-windows-msvc` via `cargo check` on Ubuntu (cfg/type checking only, no linking) to prevent regressions.

## Red/Green TDD

This PR uses two commits to demonstrate the fix:

1. **RED** — adds the `check-windows-cross` CI job only, no code change. This job fails with `error: unused import: std::path::PathBuf`.
2. **GREEN** — changes the guard to `#[cfg(all(unix, feature = "runtime"))]`. The CI job now passes.

## Test plan

- [x] `cargo check --target x86_64-pc-windows-msvc -p tokio-postgres --features runtime` — passes
- [x] `cargo check -p tokio-postgres --features runtime` (Linux) — passes
- [x] `cargo check --manifest-path tokio-postgres/Cargo.toml --no-default-features` (Linux) — passes