### PR TITLE
fix(tokio-postgres,copy): fix copy_in double-Sync protocol crash

### DIFF
--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -93,6 +93,16 @@ pub struct InnerClient {
 }
 
 impl InnerClient {
+    #[cfg(test)]
+    pub(crate) fn new_for_test() -> InnerClient {
+        let (tx, _rx) = mpsc::unbounded();
+        InnerClient {
+            sender: tx,
+            cached_typeinfo: Default::default(),
+            buffer: Mutex::new(BytesMut::new()),
+        }
+    }
+
     pub fn send(&self, messages: RequestMessages) -> Result<Responses, Error> {
         let (sender, receiver) = mpsc::channel(1);
         let request = Request { messages, sender };

--- a/tokio-postgres/src/copy_in.rs
+++ b/tokio-postgres/src/copy_in.rs
@@ -188,13 +188,25 @@ where
     }
 }
 
+/// Encode the initial Bind+Execute for a COPY IN statement.
+///
+/// Must not include a Sync — CopyInReceiver sends the sole Sync with
+/// CopyDone/CopyFail.  A trailing Flush forces the server to deliver
+/// its response even if COPY mode is never entered (error path).
+pub(crate) fn encode_copy_in(
+    client: &InnerClient,
+    statement: &Statement,
+) -> Result<bytes::Bytes, Error> {
+    query::encode(client, statement, slice_iter(&[]))
+}
+
 pub async fn copy_in<T>(client: &InnerClient, statement: Statement) -> Result<CopyInSink<T>, Error>
 where
     T: Buf + 'static + Send,
 {
     debug!("executing copy in statement {}", statement.name());
 
-    let buf = query::encode(client, &statement, slice_iter(&[]))?;
+    let buf = encode_copy_in(client, &statement)?;
 
     let (mut sender, receiver) = mpsc::channel(1);
     let receiver = CopyInReceiver::new(receiver);
@@ -222,4 +234,35 @@ where
         state: SinkState::Active,
         _p2: PhantomData,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::encode_copy_in;
+    use crate::client::InnerClient;
+    use crate::Statement;
+
+    /// Wire bytes for Sync ('S', length 4) and Flush ('H', length 4).
+    const SYNC_BYTES: [u8; 5] = [b'S', 0, 0, 0, 4];
+    const FLUSH_BYTES: [u8; 5] = [b'H', 0, 0, 0, 4];
+
+    /// The initial Bind+Execute that `copy_in` sends must NOT contain a
+    /// Sync message.  CopyInReceiver sends the sole Sync with CopyDone or
+    /// CopyFail; a second Sync here would produce two ReadyForQuery
+    /// responses, crashing the connection driver.
+    ///
+    /// It SHOULD contain a Flush so the server delivers its response even
+    /// when COPY mode is never entered (error path).
+    #[test]
+    fn copy_in_initial_message_has_no_sync() {
+        let client = InnerClient::new_for_test();
+        let statement = Statement::unnamed(vec![], vec![]);
+        let buf = encode_copy_in(&client, &statement).unwrap();
+
+        let syncs = buf.windows(5).filter(|w| *w == SYNC_BYTES).count();
+        assert_eq!(syncs, 0, "must not contain Sync");
+
+        let flushes = buf.windows(5).filter(|w| *w == FLUSH_BYTES).count();
+        assert_eq!(flushes, 1, "must contain Flush");
+    }
 }

--- a/tokio-postgres/src/copy_in.rs
+++ b/tokio-postgres/src/copy_in.rs
@@ -197,7 +197,7 @@ pub(crate) fn encode_copy_in(
     client: &InnerClient,
     statement: &Statement,
 ) -> Result<bytes::Bytes, Error> {
-    query::encode(client, statement, slice_iter(&[]))
+    query::encode_no_sync(client, statement, slice_iter(&[]))
 }
 
 pub async fn copy_in<T>(client: &InnerClient, statement: Statement) -> Result<CopyInSink<T>, Error>

--- a/tokio-postgres/src/copy_in.rs
+++ b/tokio-postgres/src/copy_in.rs
@@ -239,8 +239,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::encode_copy_in;
-    use crate::client::InnerClient;
     use crate::Statement;
+    use crate::client::InnerClient;
 
     /// Wire bytes for Sync ('S', length 4) and Flush ('H', length 4).
     const SYNC_BYTES: [u8; 5] = [b'S', 0, 0, 0, 4];

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -267,6 +267,34 @@ where
     })
 }
 
+/// Like [`encode`] but replaces the trailing Sync with a Flush message.
+///
+/// Used by `copy_in` where the Sync must be deferred: CopyInReceiver sends
+/// the sole Sync together with CopyDone (success) or CopyFail (abort).
+/// Sending two Syncs would produce two ReadyForQuery messages from the
+/// server, crashing the connection driver.
+///
+/// The Flush forces the server to deliver buffered output (BindComplete,
+/// CopyInResponse, or ErrorResponse) without producing a ReadyForQuery,
+/// preventing a hang when the server never enters COPY mode.
+pub fn encode_no_sync<P, I>(
+    client: &InnerClient,
+    statement: &Statement,
+    params: I,
+) -> Result<Bytes, Error>
+where
+    P: BorrowToSql,
+    I: IntoIterator<Item = P>,
+    I::IntoIter: ExactSizeIterator,
+{
+    client.with_buf(|buf| {
+        encode_bind(statement, params, "", buf)?;
+        frontend::execute("", 0, buf).map_err(Error::encode)?;
+        frontend::flush(buf);
+        Ok(buf.split().freeze())
+    })
+}
+
 pub fn encode_bind<P, I>(
     statement: &Statement,
     params: I,


### PR DESCRIPTION
(another problem I encountered with while working on https://github.com/NikolayS/rpg)

## Bug

`copy_in()` calls `query::encode()` which sends **Bind+Execute+Sync**. Then `CopyInReceiver` sends another **Sync** with CopyDone/CopyFail. Two Syncs produce two `ReadyForQuery` messages. The second arrives when the connection driver's response queue is empty, crashing with "unexpected message from server".

We encountered this in [rpg](https://github.com/NikolayS/rpg/) when running PostgreSQL's `copy2` regression test — multi-statement COPY sequences would crash the connection.

**Why PostgreSQL masks this in the success path:** PG explicitly ignores Sync during COPY-IN mode ([protocol spec §55.2.6](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-COPY)). So for successful COPYs the extra Sync is silently dropped. But if the server rejects the COPY *before* entering COPY mode (e.g. table dropped between prepare and execute), the Sync is processed normally → double ReadyForQuery → crash. Non-PG wire-compatible servers may not ignore Sync during COPY mode at all, making the success path crash too.

## Fix

Replace Sync with **Flush** (`'H'`) in the initial Bind+Execute message:

- **No Sync** → no double ReadyForQuery → no crash
- **Flush** → server delivers buffered output (BindComplete, CopyInResponse, or ErrorResponse) without producing ReadyForQuery → no hang when COPY mode is never entered

## Red/green TDD

Commit history demonstrates the fix:

1. **RED** ([`5e003fe`](https://github.com/NikolayS/rust-postgres/commit/5e003fe)): adds `copy_in_initial_message_has_no_sync` test — fails because `encode_copy_in` delegates to `query::encode` (includes Sync, no Flush)
2. **GREEN** ([`c1055b4`](https://github.com/NikolayS/rust-postgres/commit/c1055b4)): adds `encode_no_sync` (Bind+Execute+Flush), wires `encode_copy_in` to use it — test passes