### PR TITLE
Return an error on `CommandComplete("ROLLBACK")` when executing commit in a transaction

### DIFF
--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -695,6 +695,12 @@ impl Client {
         simple_query::batch_execute(self.inner(), query).await
     }
 
+    /// Executes `COMMIT`, treating PostgreSQL completing it as `ROLLBACK` as an
+    /// error.
+    pub(crate) async fn execute_commit(&self) -> Result<(), Error> {
+        simple_query::execute_commit(self.inner()).await
+    }
+
     /// Check that the connection is alive and wait for the confirmation.
     pub async fn check_connection(&self) -> Result<(), Error> {
         // sync is a very quick message to test the connection health.

--- a/tokio-postgres/src/error/mod.rs
+++ b/tokio-postgres/src/error/mod.rs
@@ -355,6 +355,7 @@ enum Kind {
     ConfigParse,
     Config,
     RowCount,
+    CommitRolledBack,
     #[cfg(feature = "runtime")]
     Connect,
     Timeout,
@@ -398,6 +399,7 @@ impl fmt::Display for Error {
             Kind::ConfigParse => fmt.write_str("invalid connection string"),
             Kind::Config => fmt.write_str("invalid configuration"),
             Kind::RowCount => fmt.write_str("query returned an unexpected number of rows"),
+            Kind::CommitRolledBack => fmt.write_str("transaction commit completed as ROLLBACK"),
             #[cfg(feature = "runtime")]
             Kind::Connect => fmt.write_str("error connecting to server"),
             Kind::Timeout => fmt.write_str("timeout waiting for server"),
@@ -427,6 +429,11 @@ impl Error {
     /// Determines if the error was associated with closed connection.
     pub fn is_closed(&self) -> bool {
         self.0.kind == Kind::Closed
+    }
+
+    /// Determines if the transaction commit completed as `ROLLBACK`.
+    pub fn is_commit_rolled_back(&self) -> bool {
+        self.0.kind == Kind::CommitRolledBack
     }
 
     /// Returns the SQLSTATE error code associated with the error.
@@ -507,6 +514,10 @@ impl Error {
 
     pub(crate) fn row_count() -> Error {
         Error::new(Kind::RowCount, None)
+    }
+
+    pub(crate) fn commit_rolled_back() -> Error {
+        Error::new(Kind::CommitRolledBack, None)
     }
 
     #[cfg(feature = "runtime")]

--- a/tokio-postgres/src/simple_query.rs
+++ b/tokio-postgres/src/simple_query.rs
@@ -61,6 +61,27 @@ pub async fn batch_execute(client: &InnerClient, query: &str) -> Result<(), Erro
     }
 }
 
+pub async fn execute_commit(client: &InnerClient) -> Result<(), Error> {
+    debug!("executing transaction commit");
+
+    let buf = encode(client, "COMMIT")?;
+    let mut responses = client.send(RequestMessages::Single(FrontendMessage::Raw(buf)))?;
+
+    loop {
+        match responses.next().await? {
+            Message::CommandComplete(body) => {
+                return match body.tag().map_err(Error::parse)? {
+                    "COMMIT" => Ok(()),
+                    "ROLLBACK" => Err(Error::commit_rolled_back()),
+                    _ => Err(Error::unexpected_message()),
+                };
+            }
+            Message::EmptyQueryResponse | Message::RowDescription(_) | Message::DataRow(_) => {}
+            _ => return Err(Error::unexpected_message()),
+        }
+    }
+}
+
 fn encode(client: &InnerClient, query: &str) -> Result<Bytes, Error> {
     client.with_buf(|buf| {
         frontend::query(query, buf).map_err(Error::encode)?;

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -53,12 +53,13 @@ impl<'a> Transaction<'a> {
     /// Consumes the transaction, committing all changes made within it.
     pub async fn commit(mut self) -> Result<(), Error> {
         self.done = true;
-        let query = if let Some(sp) = self.savepoint.as_ref() {
-            format!("RELEASE {}", sp.name)
+        if let Some(sp) = self.savepoint.as_ref() {
+            let query = format!("RELEASE {}", sp.name);
+
+            self.client.batch_execute(&query).await
         } else {
-            "COMMIT".to_string()
-        };
-        self.client.batch_execute(&query).await
+            self.client.execute_commit().await
+        }
     }
 
     /// Rolls the transaction back, discarding all changes made within it.

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -80,6 +80,28 @@ async fn in_transaction(client: &Client) -> bool {
     current_transaction_id(client).await == current_transaction_id(client).await
 }
 
+/// Returns SQL for a helper function that succeeds for the first row and then
+/// raises a deferred error for later rows.
+///
+/// This lets a query yield one row before the backend reports an error, which
+/// is the shape needed to reproduce dropped-stream transaction issues.
+fn late_fail_function_sql() -> &'static str {
+    "
+    CREATE OR REPLACE FUNCTION pg_temp.late_fail(i BIGINT)
+    RETURNS BOOLEAN
+    LANGUAGE plpgsql
+    VOLATILE
+    AS $$
+    BEGIN
+        IF i = 1 THEN
+            RETURN TRUE;
+        END IF;
+        RAISE EXCEPTION 'late_fail boom on row %', i USING ERRCODE = '22012';
+    END;
+    $$;
+    "
+}
+
 #[tokio::test]
 async fn plain_password_missing() {
     connect_raw("user=pass_user dbname=postgres")
@@ -1290,6 +1312,95 @@ async fn query_typed_with_transaction() {
         .await
         .unwrap();
     assert_eq!(updated_rows.len(), 0);
+}
+
+#[tokio::test]
+async fn dropped_row_stream_error_causes_commit_to_fail() {
+    let mut client = connect("user=postgres").await;
+    let setup_sql = format!(
+        "
+            CREATE TEMPORARY TABLE foo (
+                id BIGINT PRIMARY KEY,
+                note TEXT NOT NULL
+            );
+            {}
+        ",
+        late_fail_function_sql()
+    );
+
+    client.batch_execute(&setup_sql).await.unwrap();
+
+    let transaction = client.transaction().await.unwrap();
+    transaction
+        .execute(
+            "INSERT INTO foo (id, note) VALUES ($1, $2), ($3, $4)",
+            &[&1_i64, &"first-row", &2_i64, &"second-row"],
+        )
+        .await
+        .unwrap();
+
+    let stream = transaction
+        .query_typed_raw(
+            "SELECT pg_temp.late_fail(x) FROM generate_series(1, 2) AS t(x)",
+            std::iter::empty::<(&str, Type)>(),
+        )
+        .await
+        .unwrap();
+    let mut stream = pin!(stream);
+    let first = stream.try_next().await.unwrap();
+    assert!(first.is_some());
+
+    transaction.commit().await.expect_err("commit should fail");
+
+    let rows = client
+        .query("SELECT id, note FROM foo ORDER BY id", &[])
+        .await
+        .unwrap();
+    assert!(rows.is_empty());
+}
+
+#[tokio::test]
+async fn dropped_row_stream_error_causes_savepoint_release_to_fail() {
+    let mut client = connect("user=postgres").await;
+    let setup_sql = format!(
+        "
+            CREATE TEMPORARY TABLE foo (
+                id BIGINT PRIMARY KEY,
+                note TEXT NOT NULL
+            );
+            {}
+        ",
+        late_fail_function_sql()
+    );
+
+    client.batch_execute(&setup_sql).await.unwrap();
+
+    let mut transaction = client.transaction().await.unwrap();
+    let savepoint = transaction.transaction().await.unwrap();
+    savepoint
+        .execute(
+            "INSERT INTO foo (id, note) VALUES ($1, $2), ($3, $4)",
+            &[&1_i64, &"first-row", &2_i64, &"second-row"],
+        )
+        .await
+        .unwrap();
+
+    let stream = savepoint
+        .query_typed_raw(
+            "SELECT pg_temp.late_fail(x) FROM generate_series(1, 2) AS t(x)",
+            std::iter::empty::<(&str, Type)>(),
+        )
+        .await
+        .unwrap();
+    let mut stream = pin!(stream);
+    let first = stream.try_next().await.unwrap();
+    assert!(first.is_some());
+
+    savepoint
+        .commit()
+        .await
+        .expect_err("savepoint release should fail");
+    transaction.rollback().await.unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
In PostgreSQL, a transaction that has already been rolled back on the server can still complete a later `COMMIT` as `CommandComplete("ROLLBACK")` rather than as an `ErrorResponse`. In that case, `tokio-postgres` currently reports success, because the existing simple-query commit path does not inspect the command tag.

The main goal here is to avoid reporting a successful commit after the server has already decided that the transaction was rolled back, even if we did not see the error that caused the rollback. (For an example of this happening see #1334)