### PR TITLE
tokio-postgres: fix deadlock in query_typed/prepare on unknown OIDs (per-response parking variant — alternative to #1348)

### DIFF
--- a/tokio-postgres/src/connection.rs
+++ b/tokio-postgres/src/connection.rs
@@ -29,6 +29,19 @@ pub struct Request {
 
 pub struct Response {
     sender: mpsc::Sender<BackendMessages>,
+    /// Frames the consumer's sender wasn't ready to accept when they
+    /// arrived from the wire. Kept per-response so an in-flight typeinfo
+    /// sub-query (whose response is queued behind the original query's
+    /// DataRows on the same socket) can be routed to a *different*
+    /// response while this one is congested. The `bool` tracks whether the
+    /// frame carries `ReadyForQuery` — once that has been *delivered* (not
+    /// just observed) the response is removed from the queue.
+    parked: VecDeque<(BackendMessages, bool)>,
+    /// Set true once a `ReadyForQuery` frame for this response has been
+    /// seen on the wire (whether or not it's been pushed to `sender` yet).
+    /// New wire frames after this point are routed to the *next*
+    /// in-flight response, not this one.
+    completion_seen: bool,
 }
 
 #[derive(PartialEq, Debug)]
@@ -92,6 +105,69 @@ where
             .map(|o| o.map(|r| r.map_err(Error::io)))
     }
 
+    /// Walk every in-flight response and try to flush its parked frames
+    /// into its sender. We poll each sender independently so a congested
+    /// response (e.g. a streaming query whose consumer is paused waiting
+    /// on a typeinfo lookup) doesn't block delivery to other responses
+    /// (e.g. that very typeinfo sub-query) — that's the whole point of
+    /// per-response parking. The waker registered by each `poll_ready`
+    /// will wake us back up when the corresponding consumer pulls.
+    fn drain_all_parked(&mut self, cx: &mut Context<'_>) {
+        // Track responses whose parked queue we exhausted *and* whose
+        // completion frame is among the delivered. They can be removed.
+        let mut idx = 0;
+        while idx < self.responses.len() {
+            let response = &mut self.responses[idx];
+            let mut remove = false;
+            while let Some((_, _)) = response.parked.front() {
+                match response.sender.poll_ready(cx) {
+                    Poll::Ready(Ok(())) => {
+                        let (messages, frame_complete) = response.parked.pop_front().unwrap();
+                        let _ = response.sender.start_send(messages);
+                        if frame_complete {
+                            // The completion frame just left for the
+                            // consumer — this response is finished from
+                            // the Connection's POV.
+                            remove = true;
+                            break;
+                        }
+                    }
+                    Poll::Ready(Err(_)) => {
+                        // Receiver hung up. Drain the rest of the parked
+                        // queue silently so the wire stays in sync, then
+                        // remove the response once we hit its completion
+                        // frame (or, if it's not yet seen, leave it as a
+                        // marker so subsequent wire frames are routed
+                        // correctly).
+                        let (_, frame_complete) = response.parked.pop_front().unwrap();
+                        if frame_complete {
+                            remove = true;
+                            break;
+                        }
+                    }
+                    Poll::Pending => break, // sender still backed up; try next response
+                }
+            }
+            if remove {
+                self.responses.remove(idx);
+            } else {
+                idx += 1;
+            }
+        }
+    }
+
+    /// Index of the response that the next wire frame belongs to. Frames
+    /// arrive in strict FIFO order per request, so the target is the first
+    /// response whose `ReadyForQuery` has *not* been observed yet. If a
+    /// response's completion frame is parked (sent but not yet delivered to
+    /// the consumer), it's still "done" from the wire's POV — the next
+    /// frame is for a later response.
+    fn target_response_idx(&self) -> Option<usize> {
+        self.responses
+            .iter()
+            .position(|r| !r.completion_seen)
+    }
+
     fn poll_read(&mut self, cx: &mut Context<'_>) -> Result<Option<AsyncMessage>, Error> {
         if self.state != State::Active {
             trace!("poll_read: done");
@@ -99,6 +175,10 @@ where
         }
 
         loop {
+            // Try to flush any backlog from a previous iteration before
+            // pulling new bytes off the wire.
+            self.drain_all_parked(cx);
+
             let message = match self.poll_response(cx)? {
                 Poll::Ready(Some(message)) => message,
                 Poll::Ready(None) => return Err(Error::closed()),
@@ -135,35 +215,51 @@ where
                 } => (messages, request_complete),
             };
 
-            let mut response = match self.responses.pop_front() {
-                Some(response) => response,
-                None => match messages.next().map_err(Error::parse)? {
-                    Some(Message::ErrorResponse(error)) => return Err(Error::db(error)),
-                    _ => return Err(Error::unexpected_message()),
-                },
+            let Some(target_idx) = self.target_response_idx() else {
+                // No in-flight request — only acceptable if the wire sent
+                // us an `ErrorResponse` to surface as a connection error.
+                return match messages.next().map_err(Error::parse)? {
+                    Some(Message::ErrorResponse(error)) => Err(Error::db(error)),
+                    _ => Err(Error::unexpected_message()),
+                };
             };
+
+            let response = &mut self.responses[target_idx];
+
+            if !response.parked.is_empty() {
+                // Must preserve protocol order: a later wire frame for the
+                // same response can't be sent before an earlier parked one.
+                if request_complete {
+                    response.completion_seen = true;
+                }
+                response.parked.push_back((messages, request_complete));
+                continue;
+            }
 
             match response.sender.poll_ready(cx) {
                 Poll::Ready(Ok(())) => {
                     let _ = response.sender.start_send(messages);
-                    if !request_complete {
-                        self.responses.push_front(response);
+                    if request_complete {
+                        // Completion frame delivered straight through to
+                        // the consumer — drop the response.
+                        self.responses.remove(target_idx);
                     }
                 }
                 Poll::Ready(Err(_)) => {
-                    // we need to keep paging through the rest of the messages even if the receiver's hung up
-                    if !request_complete {
-                        self.responses.push_front(response);
+                    if request_complete {
+                        self.responses.remove(target_idx);
                     }
                 }
                 Poll::Pending => {
-                    self.responses.push_front(response);
-                    self.pending_responses.push_back(BackendMessage::Normal {
-                        messages,
-                        request_complete,
-                    });
-                    trace!("poll_read: waiting on sender");
-                    return Ok(None);
+                    // Park this frame. New wire frames for *this* response
+                    // will continue to be parked (preserving order), while
+                    // frames for *later* responses can still be delivered
+                    // directly via `target_response_idx()`.
+                    if request_complete {
+                        response.completion_seen = true;
+                    }
+                    response.parked.push_back((messages, request_complete));
+                    trace!("poll_read: parking frame for congested response");
                 }
             }
         }
@@ -184,6 +280,8 @@ where
                 trace!("polled new request");
                 self.responses.push_back(Response {
                     sender: request.sender,
+                    parked: VecDeque::new(),
+                    completion_seen: false,
                 });
                 Poll::Ready(Some(request.messages))
             }


### PR DESCRIPTION
## Summary

**This is an alternative to #1348** for the same deadlock. Same root
cause, different remediation. The two PRs are mutually exclusive — pick
whichever you prefer; closing the other.

The deadlock is described in detail in #1348 and reproduced minimally
here: https://github.com/rubenfiszel/tokio-postgres-deadlock-repro
TL;DR: `query::query_typed` calls `get_type(client, oid).await`
synchronously while still holding the streaming `Responses`; on a
result schema with unknown OIDs (citext, custom enums / domains,
postgis geometry, …) the original query's `DataRow`s back up in the
per-`Responses` `mpsc::channel(1)`, `Connection::poll_read` stops
draining the wire, and the typeinfo sub-query response (queued behind
those `DataRow`s on the same socket) never arrives.

## Approach (vs. #1348)

| | #1348 | this PR |
|---|---|---|
| Per-`Responses` channel | `unbounded` | `channel(1)` (unchanged) |
| Per-response parked queue | n/a | `VecDeque<(BackendMessages, bool)>` on `Response` |
| Lines changed | ~25 | ~120 |
| Memory profile in deadlock case | identical (one result set's worth) | identical |
| Public API impact (`Responses` receiver type) | bounded → unbounded | unchanged |

This PR keeps the `mpsc::channel(1)` per `Responses` and instead changes
`Connection::poll_read` to keep draining the wire when a sender backs up
— parking the unsent frame on a per-response queue inside `Response`
itself. New wire frames are routed to `target_response_idx()` — the
first in-flight response whose `ReadyForQuery` hasn't been observed yet
— so a congested streaming query no longer blocks delivery to a
concurrent typeinfo sub-query whose response is queued behind it on the
same socket.

### Why per-response (and not a single global parked queue)

A single global queue still deadlocks: once `response[0]`'s sender is
full, the global queue accumulates frames for `response[1]` that we
have no way to deliver without first delivering `response[0]`'s
frames. Per-response queues let us poll each sender independently in
`drain_all_parked`.

### The `completion_seen` flag

`Response::completion_seen` tracks whether the `ReadyForQuery` frame
for that response has been **observed on the wire** — independent of
whether it's been **delivered** to the consumer's channel yet.
`target_response_idx()` uses this to route subsequent wire frames to
the next response while the completion frame for the previous one is
still flushed in-order to its own consumer when its sender unblocks.

## Reproduction

```sh
git clone https://github.com/rubenfiszel/tokio-postgres-deadlock-repro
cd tokio-postgres-deadlock-repro
./setup.sh
# Test against master (deadlocks at limit ~100+):
cargo run --release
# Test against this PR (passes at all limits):
# edit Cargo.toml [patch.crates-io] to point at this branch
cargo run --release
```

`master`:
```
[limit 100]  ok (100 rows) in 663µs
[limit 200]  TIMEOUT after 10s
[limit 500]  TIMEOUT after 10s
```

with this PR:
```
[limit 100]  ok (100 rows) in 761µs
[limit 200]  ok (200 rows) in 1.5ms
[limit 500]  ok (500 rows) in 898µs
```

## Test plan

- [x] `cargo build -p tokio-postgres` clean
- [x] `cargo test -p tokio-postgres --lib` passes
- [x] Standalone repro: passes at all LIMITs (deadlocks at 100+ on
      master)
- [x] End-to-end against a real workload (the same `query_typed_raw`
      call against a partitioned table with a `citext` column on Neon)
      that this PR's author originally hit — hangs indefinitely on
      master, completes in ~420ms with this patch

## Why two PRs

#1348 is the minimal fix (one type swap). This PR preserves the
bounded-channel API at the cost of ~100 lines of routing bookkeeping.
Functionally and memory-wise they're equivalent. I have a slight
preference for #1348 for the obvious reason (smaller surface), but
opened both so you can pick based on whether the bounded-vs-unbounded
distinction matters to you for some reason I might not be aware of.