### PR TITLE
Improve feature flag compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,11 @@ jobs:
         with:
           path: target
           key: test-target-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}
+      - run: cargo check --all-targets
+      - run: cargo check --all-targets --all-features
+      - run: cargo check --manifest-path tokio-postgres/Cargo.toml --all-targets --no-default-features
+      - run: cargo check --manifest-path postgres/Cargo.toml --all-targets --no-default-features
       - run: cargo test --all
+      - run: cargo test --all --all-features
       - run: cargo test --manifest-path tokio-postgres/Cargo.toml --no-default-features
-      - run: cargo test --manifest-path tokio-postgres/Cargo.toml --all-features
+      - run: cargo test --manifest-path postgres/Cargo.toml --no-default-features

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,8 @@ services:
       - ./docker/sql_setup.sh:/docker-entrypoint-initdb.d/sql_setup.sh
     environment:
       POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U postgres -p 5433"]
+      interval: 1s
+      timeout: 5s
+      retries: 30

--- a/postgres-derive-test/src/domains.rs
+++ b/postgres-derive-test/src/domains.rs
@@ -139,7 +139,14 @@ fn composite_in_domain_in_composite() {
     }
 
     let mut conn = Client::connect("user=postgres host=localhost port=5433", NoTls).unwrap();
-    conn.batch_execute("CREATE TYPE leaf_composite AS (prim integer); CREATE DOMAIN domain AS leaf_composite; CREATE TYPE root_composite AS (domain domain);").unwrap();
+    conn.batch_execute(
+        "
+            CREATE TYPE pg_temp.leaf_composite AS (prim integer);
+            CREATE DOMAIN pg_temp.domain AS pg_temp.leaf_composite;
+            CREATE TYPE pg_temp.root_composite AS (domain pg_temp.domain);
+        ",
+    )
+    .unwrap();
 
     test_type(
         &mut conn,

--- a/postgres-openssl/src/lib.rs
+++ b/postgres-openssl/src/lib.rs
@@ -47,7 +47,6 @@
 //! ```
 #![warn(rust_2018_idioms, clippy::all, missing_docs)]
 
-#[cfg(feature = "runtime")]
 use openssl::error::ErrorStack;
 use openssl::hash::MessageDigest;
 use openssl::nid::Nid;
@@ -73,6 +72,7 @@ use tokio_postgres::tls::{ChannelBinding, TlsConnect};
 #[cfg(test)]
 mod test;
 
+#[cfg(feature = "runtime")]
 type ConfigCallback =
     dyn Fn(&mut ConnectConfiguration, &str) -> Result<(), ErrorStack> + Sync + Send;
 

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -47,7 +47,9 @@ futures-util = { version = "0.3.14", default-features = false, features = [
   "sink",
 ] }
 log = "0.4"
-tokio-postgres = { version = "0.7.18", path = "../tokio-postgres" }
+tokio-postgres = { version = "0.7.18", path = "../tokio-postgres", default-features = false, features = [
+  "runtime",
+] }
 tokio = { version = "1.0", features = ["rt", "time"] }
 
 [dev-dependencies]

--- a/postgres/src/test.rs
+++ b/postgres/src/test.rs
@@ -526,6 +526,11 @@ fn is_closed() {
     }
 
     assert!(!client.is_closed());
-    client.check_connection().unwrap_err();
+    for _ in 0..3 {
+        client.check_connection().unwrap_err();
+        if client.is_closed() {
+            break;
+        }
+    }
     assert!(client.is_closed());
 }

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -17,6 +17,7 @@ test = false
 [[bench]]
 name = "bench"
 harness = false
+required-features = ["runtime"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Split-of from: https://github.com/rust-postgres/rust-postgres/pull/1359

The feature flag conditional compilation fails if one excludes the `runtime` feature flag.

This is fixed by:

* Retaining the `ErrorStack` import for `set_postgresql_alpn` function
* Excluding `ConfigCallback` type which is only used by `MakeTlsConnector` when the feature flag is provided

---

I have stabilized two tests:

* `is_closed`: performing only one `check_connection` turned out to be flaky
  * Resolved by performing a few `check_connection` rounds
* `composite_in_domain_in_composite` was not idempotent, if execute multiple times against the same database it fails
  * Resolved by using PostgreSQL session temporary namespace `pg_temp`

I have added a health-check to the database startup, I hit the case starting the fresh database and quickly running the testsuite failed because the database wasn't yet listening/responding to connection requests. With the added health-check you can do `docker compose up -d wait` to await the database becoming healthy before starting the test suite.

Testing with `--all-features` works but testing with `--no-default-features` only limits to the feature set that is specified in all manifests. Therefore the `--no-default-features` test runs for the `postgres` and `tokio-postgres` are separated.